### PR TITLE
ci: add lint step to pr workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build:
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,5 +23,8 @@ jobs:
       - name: Unit tests
         run: npm run test:ci
 
-      - name: Build and lint frontend
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
         run: npm run build


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The webpack build [runs eslint](https://github.com/ni/systemlink-grafana-plugins/blob/main/.config/webpack/webpack.config.ts#L186), but only for .ts and .tsx files. `npm run lint` also checks JS files, so we should add it to our CI workflow steps to have config files such like `release.config.js` also checked.

## 👩‍💻 Implementation

- Add lint step to worfklow

## 🧪 Testing

n/a

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).