### PR TITLE
Add launch configuration for VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Grafana in Chrome",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/src",
+      "sourceMapPathOverrides": {
+        "webpack:///*": "${webRoot}/*"
+      },
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ],
+      "preLaunchTask": "npm: start"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+		{
+			"type": "npm",
+			"script": "start",
+			"problemMatcher": [],
+			"label": "npm: start",
+			"isBackground": true
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -36,15 +36,18 @@ requires [Node.js + npm](https://docs.npmjs.com/cli/v9/configuring-npm/install)
 [Docker](https://docs.docker.com/engine/install/) is used to run the Grafana
 server in a container for development.
 
-After cloning the repo:
+After cloning the repo, `npm install` to fetch dependencies and then `npm run start` to build in development mode. This command does two things:
 
-1. Run `npm install`
-1. Run `npm run dev` to build in development mode. This starts a process that
+1. Starts a process that
    watches for changes to the source code and automatically rebuilds.
-1. In a separate shell session (e.g. another terminal window), run `npm run
-   server`. This starts up Grafana in a container with the `./dist` directory
-   created by the previous step mounted. After a brief startup, you should now
-   be able to access the Grafana UI at http://localhost:3000 .
+1. Starts up Grafana in a container with the `./dist` directory
+   created by the build process mounted. After a brief startup, you should now
+   be able to access the Grafana UI at http://localhost:3000.
+
+Alternatively, if you use VS Code as your editor, this repo contains a launch
+configuration that runs the steps above and then attaches to an instance of
+Chrome for debugging. See [Debugging in Visual Studio
+Code](https://code.visualstudio.com/docs/editor/debugging) for more information.
 
 For panel plugins, there's no extra configuration needed - it will automatically
 show up in the list of available visualizations.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Plugins for visualizing data from SystemLink services",
   "private": true,
   "scripts": {
+    "start": "npm run server && npm run dev",
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
@@ -13,7 +14,7 @@
     "lint:fix": "npm run lint -- --fix",
     "e2e": "npm exec cypress install && npm exec grafana-e2e run",
     "e2e:update": "npm exec cypress install && npm exec grafana-e2e run --update-screenshots",
-    "server": "docker-compose up --build",
+    "server": "docker-compose up --build -d",
     "generate": "plop",
     "release": "semantic-release"
   },


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

VS Code can attach to an instance of Chrome, which allows you to set and debug breakpoints right in the editor. This is a better workflow then having to open the dev tools separately in Chrome.

## 👩‍💻 Implementation

- Added a "task" that starts up Docker compose and `npm run dev`.
- Added a launch configuration that runs the task and then attaches to a new Chrome window.

## 🧪 Testing

Tried a few scenarios:
- Running the debugger and hitting a breakpoint
- Launching when Docker engine isn't running - correctly throws an error
- Running when the Docker compose is already started - restarts if needed

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).