### PR TITLE
fix: Rename Data Table data source

### DIFF
--- a/src/datasources/data-frame/DataFrameDataSource.test.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   const instanceSettings = {
     url: '_',
-    name: 'SystemLink Data Frames',
+    name: 'SystemLink Data Tables',
   };
   ds = new DataFrameDataSource(instanceSettings as DataSourceInstanceSettings);
   setupFetchMock();

--- a/src/datasources/data-frame/plugin.json
+++ b/src/datasources/data-frame/plugin.json
@@ -1,6 +1,6 @@
 {
   "type": "datasource",
-  "name": "SystemLink Data Frames",
+  "name": "SystemLink Data Tables",
   "id": "ni-sldataframe-datasource",
   "metrics": true,
   "info": {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We want to use the resource name "Data Table" instead of the service name "Data Frame".

## 👩‍💻 Implementation

Rename data source.

## 🧪 Testing

Trivial - PR build will validate.

## ✅ Checklist

- [X] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).