### PR TITLE
fix: Revert Data Frame data source rename

### DIFF
--- a/src/datasources/data-frame/DataFrameDataSource.test.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   const instanceSettings = {
     url: '_',
-    name: 'SystemLink Data Tables',
+    name: 'SystemLink Data Frames',
   };
   ds = new DataFrameDataSource(instanceSettings as DataSourceInstanceSettings);
   setupFetchMock();

--- a/src/datasources/data-frame/plugin.json
+++ b/src/datasources/data-frame/plugin.json
@@ -1,6 +1,6 @@
 {
   "type": "datasource",
-  "name": "SystemLink Data Tables",
+  "name": "SystemLink Data Frames",
   "id": "ni-sldataframe-datasource",
   "metrics": true,
   "info": {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Revert DFS data source rename. Grafana isn't very robust to these renames which resulted in two different breakages.

## 👩‍💻 Implementation

Revert rename.

## 🧪 Testing

Trivial change - PR build will validate.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [X] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).