### PR TITLE
feat(tag): add support for tag path as variable

### DIFF
--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,12 +1,12 @@
 import { DataQueryRequest, DataSourceApi, DataSourceInstanceSettings, QueryEditorProps, dateTime } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
-import { BackendSrv, FetchError } from '@grafana/runtime';
-import { mock } from 'jest-mock-extended';
+import { BackendSrv, FetchError, TemplateSrv } from '@grafana/runtime';
+import { calledWithFn, mock } from 'jest-mock-extended';
 import React from 'react';
 import { render } from '@testing-library/react';
 
 export function setupDataSource<T>(
-  ctor: new (instanceSettings: DataSourceInstanceSettings, backendSrv: BackendSrv) => T
+  ctor: new (instanceSettings: DataSourceInstanceSettings, backendSrv: BackendSrv, templateSrv: TemplateSrv) => T
 ) {
   const mockBackendSrv = mock<BackendSrv>(
     {},
@@ -16,8 +16,11 @@ export function setupDataSource<T>(
       },
     }
   );
-  const ds = new ctor({ url: '' } as DataSourceInstanceSettings, mockBackendSrv);
-  return [ds, mockBackendSrv] as const;
+  const mockTemplateSrv = mock<TemplateSrv>({
+    replace: calledWithFn({ fallbackMockImplementation: target => target ?? '' }),
+  });
+  const ds = new ctor({ url: '' } as DataSourceInstanceSettings, mockBackendSrv, mockTemplateSrv);
+  return [ds, mockBackendSrv, mockTemplateSrv] as const;
 }
 
 export function setupRenderer<DSType extends DataSourceApi<TQuery>, TQuery extends DataQuery>(


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2387168

- Lets users control the tag path using a dashboard variable

## 👩‍💻 Implementation

- Call into the `TemplateSrv` to interpolate variables

## 🧪 Testing

- Updated `setupDataSource` fixture to include a mock `TemplateSrv` and wrote a new test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).