### PR TITLE
feat(tag): add query help documentation

### DIFF
--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -154,6 +154,7 @@ const config = async (env): Promise<Configuration> => {
           { from: 'img/**/*', to: '.', noErrorOnMissing: true }, // Optional
           { from: 'libs/**/*', to: '.', noErrorOnMissing: true }, // Optional
           { from: 'static/**/*', to: '.', noErrorOnMissing: true }, // Optional
+          { from: '**/query_help.md', to: '.', noErrorOnMissing: true }, // Optional
         ],
       }),
       // Replace certain template-variables in the README and plugin.json

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -28,13 +28,13 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
 
   return (
     <>
-      <InlineField label="Query type" labelWidth={11}>
+      <InlineField label="Query type" labelWidth={14} tooltip={tooltips.queryType}>
         <RadioButtonGroup options={enumToOptions(TagQueryType)} value={query.type} onChange={onTypeChange} />
       </InlineField>
-      <InlineField label="Tag path" labelWidth={11}>
+      <InlineField label="Tag path" labelWidth={14} tooltip={tooltips.tagPath}>
         <AutoSizeInput minWidth={20} defaultValue={query.path} onCommitChange={onPathChange} />
       </InlineField>
-      <InlineField label="Workspace" labelWidth={11}>
+      <InlineField label="Workspace" labelWidth={14} tooltip={tooltips.workspace}>
         <AutoSizeInput
           minWidth={20}
           placeholder="Any workspace"
@@ -45,3 +45,14 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
     </>
   );
 }
+
+const tooltips = {
+  queryType: `Current allows you to visualize the most recent tag value. History allows you to
+              visualize tag values over time. Historical values use the time range set on the
+              dashboard and are decimated according to the width of the panel.`,
+
+  tagPath: `The full path of the tag to visualize. You can enter a variable into this field.`,
+
+  workspace: `The ID of the workspace to search for the given tag path. If left blank, the plugin
+              finds the most recently updated tag in any workspace.`,
+};

--- a/src/datasources/tag/query_help.md
+++ b/src/datasources/tag/query_help.md
@@ -1,24 +1,5 @@
-### SystemLink Tags
-
-This data source allows you to visualize both the current and historical values
+The _SystemLink Tags_ data source allows you to visualize the current and historical values
 of tags.
 
-#### Query fields
-
-**Query type** - Choose **Current** to visualize the tag's most recent value, or
-**History** to visualize its values over time. Historical values will be
-retrieved within the time range set on the dashboard and decimated according to
-the width of the panel.
-
-**Tag path** - The full path of the tag you want to visualize. You can input a
-[variable](https://grafana.com/docs/grafana/latest/dashboards/variables/) into
-this field.
-
-**Workspace** - The id of the workspace in which to search for the given tag
-path. If left blank, the plugin finds the most recently updated tag in any
-workspace.
-
-#### Documentation links
-
-[Transferring Data Using Tags - SystemLink
-Enterprise](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/transferring-data-using-tags.html)
+For more information, refer to [Transferring Data Using Tags - SystemLink
+Enterprise](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/transferring-data-using-tags.html).

--- a/src/datasources/tag/query_help.md
+++ b/src/datasources/tag/query_help.md
@@ -1,0 +1,24 @@
+### SystemLink Tags
+
+This data source allows you to visualize both the current and historical values
+of tags.
+
+#### Query fields
+
+**Query type** - Choose **Current** to visualize the tag's most recent value, or
+**History** to visualize its values over time. Historical values will be
+retrieved within the time range set on the dashboard and decimated according to
+the width of the panel.
+
+**Tag path** - The full path of the tag you want to visualize. You can input a
+[variable](https://grafana.com/docs/grafana/latest/dashboards/variables/) into
+this field.
+
+**Workspace** - The id of the workspace in which to search for the given tag
+path. If left blank, the plugin finds the most recently updated tag in any
+workspace.
+
+#### Documentation links
+
+[Transferring Data Using Tags - SystemLink
+Enterprise](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/transferring-data-using-tags.html)


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2485887

## 👩‍💻 Implementation

Data sources can include a `query_help.md` markdown file to be displayed in the UI. Unfortunately, the webpack configuration extended from the [plugin tools](https://github.com/grafana/plugin-tools) doesn't copy that file in to the dist, so I had to manually change the config. I upstreamed a change here: https://github.com/grafana/plugin-tools/pull/374

## 🧪 Testing

- Built the plugins and viewed the rendered markdown

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).