### PR TITLE
fix(tag): don't error on null properties

### DIFF
--- a/src/datasources/tag/TagDataSource.test.ts
+++ b/src/datasources/tag/TagDataSource.test.ts
@@ -61,6 +61,16 @@ describe('queries', () => {
     expect(result.data[0]).toEqual(expect.objectContaining({ name: 'My cool tag' }));
   });
 
+  test('handles null tag properties', async () => {
+    const response = createQueryTagsResponse('my.tag', '3.14');
+    response.tagsWithValues[0].tag.properties = null;
+    backendSrv.post.mockResolvedValue(response);
+
+    const result = await ds.query(buildQuery({ path: 'my.tag' }));
+
+    expect(result.data[0]).toEqual(expect.objectContaining({ name: 'my.tag' }));
+  });
+
   test('multiple targets - skips invalid queries', async () => {
     backendSrv.post
       .mockResolvedValueOnce(createQueryTagsResponse('my.tag1', '3.14'))

--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -28,7 +28,7 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
       query.workspace
     );
 
-    const name = tag.properties.displayName ?? tag.path;
+    const name = tag.properties?.displayName ?? tag.path;
 
     if (query.type === TagQueryType.Current) {
       return {

--- a/src/datasources/tag/types.ts
+++ b/src/datasources/tag/types.ts
@@ -15,7 +15,7 @@ export interface TagWithValue {
   current: { value: { value: string } };
   tag: {
     path: string;
-    properties: { displayName?: string };
+    properties: { displayName?: string } | null;
     workspace_id: string;
   };
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2504068

It turns out that the tag service can return `null` instead of an empty object for a tag's properties. The plugin was crashing in this case.

## 👩‍💻 Implementation

- Null check the `properties` property.

## 🧪 Testing

- Added a unit test for this case.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).