### PR TITLE
feat(tag): add user-friendly workspace dropdown

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,7 +1,14 @@
 // Jest setup provided by Grafana scaffolding
 import './.config/jest-setup';
+import { DataSourceBase } from './src/core/DataSourceBase';
 
 // Called by @grafana/ui AutoSizeInput
 HTMLCanvasElement.prototype.getContext = () => ({
-  measureText: (text) => ({ width: text.length * 8 }),
+  measureText: text => ({ width: text.length * 8 }),
 });
+
+// Default workspaces for tests
+DataSourceBase.Workspaces = [
+  { id: '1', name: 'Default workspace' },
+  { id: '2', name: 'Other workspace' },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "jest-mock-extended": "^3.0.4",
         "plop": "^3.1.2",
         "prettier": "^2.8.7",
+        "react-select-event": "^5.5.1",
         "replace-in-file-webpack-plugin": "^1.0.6",
         "sass": "1.63.2",
         "sass-loader": "13.3.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "jest-mock-extended": "^3.0.4",
     "plop": "^3.1.2",
     "prettier": "^2.8.7",
+    "react-select-event": "^5.5.1",
     "replace-in-file-webpack-plugin": "^1.0.6",
     "sass": "1.63.2",
     "sass-loader": "13.3.1",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,4 @@
+export interface Workspace {
+  name: string;
+  id: string;
+}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,4 +1,6 @@
 import { SelectableValue } from '@grafana/data';
+import { useAsync } from 'react-use';
+import { DataSourceBase } from './DataSourceBase';
 
 export function enumToOptions<T>(stringEnum: { [name: string]: T }): Array<SelectableValue<T>> {
   const RESULT = [];
@@ -19,7 +21,7 @@ export function Throw(error: string | Error): never {
     throw new Error(error);
   }
   throw error;
-};
+}
 
 /**
  * Throw exception if value is null or undefined
@@ -28,4 +30,12 @@ export function Throw(error: string | Error): never {
  */
 export function throwIfNullish<T>(value: T, error: string | Error): NonNullable<T> {
   return value === undefined || value === null ? Throw(error) : value!;
+}
+
+/** Gets available workspaces as an array of {@link SelectableValue}. */
+export function useWorkspaceOptions<DSType extends DataSourceBase<any>>(datasource: DSType) {
+  return useAsync(async () => {
+    const workspaces = await datasource.getWorkspaces();
+    return workspaces.map(w => ({ label: w.name, value: w.id }));
+  });
 }

--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -10,7 +10,7 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
     readonly backendSrv: BackendSrv = getBackendSrv(),
     readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
-    super(instanceSettings);
+    super(instanceSettings, backendSrv);
   }
 
   tagUrl = this.instanceSettings.url + '/nitag/v2';

--- a/src/datasources/tag/components/TagQueryEditor.test.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.test.tsx
@@ -1,48 +1,41 @@
-import { screen } from '@testing-library/react';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { TagQueryEditor } from './TagQueryEditor';
+import { select } from 'react-select-event';
 import { setupRenderer } from 'test/fixtures';
-import { TagQuery, TagQueryType } from '../types';
 import { TagDataSource } from '../TagDataSource';
+import { TagQuery, TagQueryType } from '../types';
+import { TagQueryEditor } from './TagQueryEditor';
 
 const render = setupRenderer(TagQueryEditor, TagDataSource);
+const workspacesLoaded = () => waitForElementToBeRemoved(screen.getByTestId('Spinner'));
 
 it('renders with query defaults', async () => {
   render({} as TagQuery);
+  await workspacesLoaded();
 
   expect(screen.getByRole('radio', { name: 'Current' })).toBeChecked();
   expect(screen.getByLabelText('Tag path')).not.toHaveValue();
-  expect(screen.getByLabelText('Workspace')).not.toHaveValue();
+  expect(screen.getByRole('combobox')).toHaveAccessibleDescription('Any workspace');
 });
 
-it('renders with saved query values', async () => {
-  render({ type: TagQueryType.History, path: 'my.tag', workspace: '1' });
+it('renders with initial query and updates when user makes changes', async () => {
+  const [onChange] = render({ type: TagQueryType.History, path: 'my.tag', workspace: '1' });
+  await workspacesLoaded();
 
+  // Renders saved query
   expect(screen.getByRole('radio', { name: 'History' })).toBeChecked();
   expect(screen.getByLabelText('Tag path')).toHaveValue('my.tag');
-  expect(screen.getByLabelText('Workspace')).toHaveValue('1');
-});
+  expect(screen.getByText('Default workspace')).toBeInTheDocument();
 
-it('updates query when user types new path', async () => {
-  const [onChange] = render({ type: TagQueryType.Current, path: '', workspace: '' });
+  // Users changes query type
+  await userEvent.click(screen.getByRole('radio', { name: 'Current' }));
+  expect(onChange).toBeCalledWith(expect.objectContaining({ type: TagQueryType.Current }));
 
-  await userEvent.type(screen.getByLabelText('Tag path'), 'my.tag{enter}');
+  // User types in new tag path
+  await userEvent.type(screen.getByLabelText('Tag path'), '.test{enter}');
+  expect(onChange).toBeCalledWith(expect.objectContaining({ path: 'my.tag.test' }));
 
-  expect(onChange).toBeCalledWith(expect.objectContaining({ path: 'my.tag' }));
-});
-
-it('updates query when user selects new type', async () => {
-  const [onChange] = render({ type: TagQueryType.Current, path: '', workspace: '' });
-
-  await userEvent.click(screen.getByRole('radio', { name: 'History' }));
-
-  expect(onChange).toBeCalledWith(expect.objectContaining({ type: TagQueryType.History }));
-});
-
-it('updates query when user types new workspace', async () => {
-  const [onChange] = render({ type: TagQueryType.Current, path: '', workspace: '' });
-
-  await userEvent.type(screen.getByLabelText('Workspace'), '1234{enter}');
-
-  expect(onChange).toBeCalledWith(expect.objectContaining({ workspace: '1234' }));
+  // User selects different workspace
+  await select(screen.getByRole('combobox'), 'Other workspace', { container: document.body });
+  expect(onChange).toBeCalledWith(expect.objectContaining({ workspace: '2' }));
 });

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -1,15 +1,17 @@
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { AutoSizeInput, RadioButtonGroup, Select } from '@grafana/ui';
+import { InlineField } from 'core/components/InlineField';
+import { enumToOptions, useWorkspaceOptions } from 'core/utils';
 import React, { FormEvent } from 'react';
-import { AutoSizeInput, RadioButtonGroup } from '@grafana/ui';
-import { QueryEditorProps } from '@grafana/data';
 import { TagDataSource } from '../TagDataSource';
 import { TagQuery, TagQueryType } from '../types';
-import { InlineField } from 'core/components/InlineField';
-import { enumToOptions } from 'core/utils';
 
 type Props = QueryEditorProps<TagDataSource, TagQuery>;
 
 export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   query = datasource.prepareQuery(query);
+
+  const workspaces = useWorkspaceOptions(datasource);
 
   const onTypeChange = (value: TagQueryType) => {
     onChange({ ...query, type: value });
@@ -21,8 +23,8 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
     onRunQuery();
   };
 
-  const onWorkspaceChange = (event: FormEvent<HTMLInputElement>) => {
-    onChange({ ...query, workspace: event.currentTarget.value });
+  const onWorkspaceChange = (option?: SelectableValue<string>) => {
+    onChange({ ...query, workspace: option?.value ?? '' });
     onRunQuery();
   };
 
@@ -35,11 +37,13 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
         <AutoSizeInput minWidth={20} defaultValue={query.path} onCommitChange={onPathChange} />
       </InlineField>
       <InlineField label="Workspace" labelWidth={14} tooltip={tooltips.workspace}>
-        <AutoSizeInput
-          minWidth={20}
+        <Select
+          isClearable
+          isLoading={workspaces.loading}
+          onChange={onWorkspaceChange}
+          options={workspaces.value}
           placeholder="Any workspace"
-          defaultValue={query.workspace}
-          onCommitChange={onWorkspaceChange}
+          value={query.workspace}
         />
       </InlineField>
     </>
@@ -53,6 +57,6 @@ const tooltips = {
 
   tagPath: `The full path of the tag to visualize. You can enter a variable into this field.`,
 
-  workspace: `The ID of the workspace to search for the given tag path. If left blank, the plugin
+  workspace: `The workspace to search for the given tag path. If left blank, the plugin
               finds the most recently updated tag in any workspace.`,
 };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2502935

Users can select a workspace by name instead of id.

## 👩‍💻 Implementation

- Added a method to `DataSourceBase` to fetch and cache workspaces
- Wrote a custom hook to get workspaces as Select options

## 🧪 Testing

Now that the TagQueryEditor component has side effects, I had to slightly refactor the tests to wait for the workspaces to populate. I combined some of the tests into one in the spirit of https://kentcdodds.com/blog/write-fewer-longer-tests.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).