### PR TITLE
fix(tag)!: use tag name instead of 'value' for field name

### DIFF
--- a/src/datasources/tag/TagDataSource.test.ts
+++ b/src/datasources/tag/TagDataSource.test.ts
@@ -38,8 +38,7 @@ describe('queries', () => {
 
     expect(result.data).toEqual([
       {
-        fields: [{ name: 'value', values: ['3.14'] }],
-        name: 'my.tag',
+        fields: [{ name: 'my.tag', values: ['3.14'] }],
         refId: 'A',
       },
     ]);
@@ -50,7 +49,7 @@ describe('queries', () => {
 
     const result = await ds.query({ ...defaultQueryOptions, targets: [{ path: 'my.tag'} as TagQuery]});
 
-    expect(result.data[0]).toHaveProperty('fields', [{ name: 'value', values: ['3.14'] }]);
+    expect(result.data[0]).toHaveProperty('fields', [{ name: 'my.tag', values: ['3.14'] }]);
   });
 
   test('uses displayName property', async () => {
@@ -58,7 +57,7 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ path: 'my.tag' }));
 
-    expect(result.data[0]).toEqual(expect.objectContaining({ name: 'My cool tag' }));
+    expect(result.data[0].fields[0]).toHaveProperty('name', 'My cool tag');
   });
 
   test('handles null tag properties', async () => {
@@ -68,7 +67,7 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ path: 'my.tag' }));
 
-    expect(result.data[0]).toEqual(expect.objectContaining({ name: 'my.tag' }));
+    expect(result.data[0]).toHaveProperty('fields', [{ name: 'my.tag', values: ['3.14'] }]);
   });
 
   test('multiple targets - skips invalid queries', async () => {
@@ -82,13 +81,11 @@ describe('queries', () => {
     expect(backendSrv.post.mock.calls[1][1]).toHaveProperty('filter', 'path = "my.tag2"');
     expect(result.data).toEqual([
       {
-        fields: [{ name: 'value', values: ['3.14'] }],
-        name: 'my.tag1',
+        fields: [{ name: 'my.tag1', values: ['3.14'] }],
         refId: 'A',
       },
       {
-        fields: [{ name: 'value', values: ['foo'] }],
-        name: 'my.tag2',
+        fields: [{ name: 'my.tag2', values: ['foo'] }],
         refId: 'C',
       },
     ]);
@@ -133,9 +130,8 @@ describe('queries', () => {
       {
         fields: [
           { name: 'time', values: [1672531200000, 1672531260000] },
-          { name: 'value', values: [1, 2] },
+          { name: 'my.tag', values: [1, 2] },
         ],
-        name: 'my.tag',
         refId: 'A',
       },
     ]);
@@ -156,9 +152,8 @@ describe('queries', () => {
       {
         fields: [
           { name: 'time', values: [1672531200000, 1672531260000] },
-          { name: 'value', values: ['3.14', 'foo'] },
+          { name: 'my.tag', values: ['3.14', 'foo'] },
         ],
-        name: 'my.tag',
         refId: 'A',
       },
     ]);
@@ -190,7 +185,7 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ type: TagQueryType.Current, path: '$my_variable' }));
 
-    expect(result.data[0]).toHaveProperty('name', 'my.tag');
+    expect(result.data[0].fields[0]).toHaveProperty('name', 'my.tag');
   });
 
   test('filters by workspace if provided', async () => {

--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -33,18 +33,16 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
     if (query.type === TagQueryType.Current) {
       return {
         refId: query.refId,
-        name,
-        fields: [{ name: 'value', values: [current.value.value] }],
+        fields: [{ name, values: [current.value.value] }],
       };
     }
 
     const history = await this.getTagHistoryValues(tag.path, tag.workspace_id, range, maxDataPoints);
     return {
       refId: query.refId,
-      name,
       fields: [
         { name: 'time', values: history.datetimes },
-        { name: 'value', values: history.values },
+        { name, values: history.values },
       ],
     };
   }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Before this change, the data source would return a data frame with a name property set to the tag's name. The historical/current field was always named 'value':

**name: my.tag**
| time                | value |
|---------------------|-------|
| 2020-01-02 03:04:00 | 45.0  |
| 2020-01-02 03:05:00 | 47.0  |
| 2020-01-02 03:06:00 | 48.0  |

With this change, the 'value' field will take on the tag's name instead:

| time                | my.tag |
|---------------------|-------|
| 2020-01-02 03:04:00 | 45.0  |
| 2020-01-02 03:05:00 | 47.0  |
| 2020-01-02 03:06:00 | 48.0  |

Grafana's documentation doesn't provide any recommendations on which format is preferable, but the new approach makes the explore mode more usable for visualizing multiple tags.

Fixes [this bug](https://dev.azure.com/ni/DevCentral/_workitems/edit/2504138).

## 👩‍💻 Implementation

- Use the tag's name as the field name instead of the frame name

## 🧪 Testing

- Manually tested explore mode and dashboard mode to make sure that any core workflows haven't broken

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).


**Unfortunately, I think we need to consider this a breaking change. It's possible for a dashboard to be configured in a way that relies on the fields being named 'value'. I know [this dashboard](https://dev.lifecyclesolutions.ni.com/dashboards/d/b73d4191-1060-4648-8649-8ad48142a855/canvas-demo?orgId=1) that I helped Josh set up will be broken.**