### PR TITLE
fix(tag): set max width for tag path input

### DIFF
--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -34,7 +34,7 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
         <RadioButtonGroup options={enumToOptions(TagQueryType)} value={query.type} onChange={onTypeChange} />
       </InlineField>
       <InlineField label="Tag path" labelWidth={14} tooltip={tooltips.tagPath}>
-        <AutoSizeInput minWidth={20} maxWidth={100} defaultValue={query.path} onCommitChange={onPathChange} />
+        <AutoSizeInput minWidth={20} maxWidth={80} defaultValue={query.path} onCommitChange={onPathChange} />
       </InlineField>
       <InlineField label="Workspace" labelWidth={14} tooltip={tooltips.workspace}>
         <Select

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -34,7 +34,7 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
         <RadioButtonGroup options={enumToOptions(TagQueryType)} value={query.type} onChange={onTypeChange} />
       </InlineField>
       <InlineField label="Tag path" labelWidth={14} tooltip={tooltips.tagPath}>
-        <AutoSizeInput minWidth={20} defaultValue={query.path} onCommitChange={onPathChange} />
+        <AutoSizeInput minWidth={20} maxWidth={100} defaultValue={query.path} onCommitChange={onPathChange} />
       </InlineField>
       <InlineField label="Workspace" labelWidth={14} tooltip={tooltips.workspace}>
         <Select


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2508339

The tag path field shouldn't be able to extend to infinity and beyond 🚀

## 👩‍💻 Implementation

- Set max width manually to a reasonable length
- I played around with having the input be dynamic (i.e. extend until it hits the end of its container), but there isn't a straightforward way with the current implementation of the AutoSizeInput component

## 🧪 Testing

- Manual testing

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).