### PR TITLE
fix(tag): crash when visualizing tag with no value

### DIFF
--- a/src/datasources/tag/TagDataSource.test.ts
+++ b/src/datasources/tag/TagDataSource.test.ts
@@ -70,6 +70,16 @@ describe('queries', () => {
     expect(result.data[0]).toHaveProperty('fields', [{ name: 'my.tag', values: ['3.14'] }]);
   });
 
+  test('handles tag with no current value', async () => {
+    const response = createQueryTagsResponse('my.tag', '');
+    response.tagsWithValues[0].current = null;
+    backendSrv.post.mockResolvedValue(response);
+
+    const result = await ds.query(buildQuery({ path: 'my.tag' }));
+
+    expect(result.data[0]).toHaveProperty('fields', [{ name: 'my.tag', values: [] }]);
+  });
+
   test('multiple targets - skips invalid queries', async () => {
     backendSrv.post
       .mockResolvedValueOnce(createQueryTagsResponse('my.tag1', '3.14'))

--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -33,7 +33,7 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
     if (query.type === TagQueryType.Current) {
       return {
         refId: query.refId,
-        fields: [{ name, values: [current.value.value] }],
+        fields: [{ name, values: [current?.value.value] }],
       };
     }
 

--- a/src/datasources/tag/types.ts
+++ b/src/datasources/tag/types.ts
@@ -12,7 +12,7 @@ export interface TagQuery extends DataQuery {
 }
 
 export interface TagWithValue {
-  current: { value: { value: string } };
+  current: { value: { value: string } } | null;
   tag: {
     path: string;
     properties: { displayName?: string } | null;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2508350

This fixes an edge case where someone tries to visualize the current value of a tag that exists but has never been written to.

## 👩‍💻 Implementation

There isn't a useful workflow in this case, so I just took the simplest possible approach - returning an empty field when there's no current value.

## 🧪 Testing

- Added auto test

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).