### PR TITLE
feat(tag): retry requests for 429 error

### DIFF
--- a/src/core/DataSourceBase.ts
+++ b/src/core/DataSourceBase.ts
@@ -5,14 +5,21 @@ import {
   DataSourceApi,
   DataSourceInstanceSettings,
 } from '@grafana/data';
-import { BackendSrv, TestingStatus } from '@grafana/runtime';
+import { BackendSrv, BackendSrvRequest, TestingStatus, isFetchError } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { Workspace } from './types';
+import { sleep } from './utils';
+import { lastValueFrom } from 'rxjs';
 
 export abstract class DataSourceBase<TQuery extends DataQuery> extends DataSourceApi<TQuery> {
   constructor(readonly instanceSettings: DataSourceInstanceSettings, readonly backendSrv: BackendSrv) {
     super(instanceSettings);
   }
+
+  abstract defaultQuery: Partial<TQuery> & Omit<TQuery, 'refId'>;
+  abstract runQuery(query: TQuery, options: DataQueryRequest): Promise<DataFrameDTO>;
+  abstract shouldRunQuery(query: TQuery): boolean;
+  abstract testDatasource(): Promise<TestingStatus>;
 
   query(request: DataQueryRequest<TQuery>): Promise<DataQueryResponse> {
     const promises = request.targets
@@ -25,6 +32,26 @@ export abstract class DataSourceBase<TQuery extends DataQuery> extends DataSourc
 
   prepareQuery(query: TQuery): TQuery {
     return { ...this.defaultQuery, ...query };
+  }
+
+  private async fetch<T>(options: BackendSrvRequest, retries = 0): Promise<T> {
+    try {
+      return (await lastValueFrom(this.backendSrv.fetch<T>(options))).data;
+    } catch (error) {
+      if (isFetchError(error) && error.status === 429 && retries < 3) {
+        await sleep(Math.random() * 1000 * 2 ** retries);
+        return this.fetch(options, retries + 1);
+      }
+      throw error;
+    }
+  }
+
+  get<T>(url: string) {
+    return this.fetch<T>({ method: 'GET', url });
+  }
+
+  post<T>(url: string, body: Record<string, any>) {
+    return this.fetch<T>({ method: 'POST', url, data: body });
   }
 
   static Workspaces: Workspace[];
@@ -40,9 +67,4 @@ export abstract class DataSourceBase<TQuery extends DataQuery> extends DataSourc
 
     return (DataSourceBase.Workspaces = response.workspaces);
   }
-
-  abstract defaultQuery: Partial<TQuery> & Omit<TQuery, 'refId'>;
-  abstract runQuery(query: TQuery, options: DataQueryRequest): Promise<DataFrameDTO>;
-  abstract shouldRunQuery(query: TQuery): boolean;
-  abstract testDatasource(): Promise<TestingStatus>;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,3 +2,7 @@ export interface Workspace {
   name: string;
   id: string;
 }
+
+export type DeepPartial<T> = {
+  [Key in keyof T]?: DeepPartial<T[Key]>;
+};

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -39,3 +39,11 @@ export function useWorkspaceOptions<DSType extends DataSourceBase<any>>(datasour
     return workspaces.map(w => ({ label: w.name, value: w.id }));
   });
 }
+
+/**
+ * Async wrapper for `window.setTimeout`
+ * @param timeout the time to sleep in milliseconds
+ */
+export function sleep(timeout: number) {
+  return new Promise(res => window.setTimeout(res, timeout));
+}

--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -53,7 +53,7 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
       filter += ` && workspace = "${workspace}"`;
     }
 
-    const response = await this.backendSrv.post<TagsWithValues>(this.tagUrl + '/query-tags-with-values', {
+    const response = await this.post<TagsWithValues>(this.tagUrl + '/query-tags-with-values', {
       filter,
       take: 1,
       orderBy: 'TIMESTAMP',
@@ -64,7 +64,7 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
   }
 
   private async getTagHistoryValues(path: string, workspace: string, range: TimeRange, intervals?: number) {
-    const response = await this.backendSrv.post<TagHistoryResponse>(this.tagHistoryUrl + '/query-decimated-history', {
+    const response = await this.post<TagHistoryResponse>(this.tagHistoryUrl + '/query-decimated-history', {
       paths: [path],
       workspace,
       startTime: range.from.toISOString(),
@@ -88,7 +88,7 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
   }
 
   async testDatasource(): Promise<TestingStatus> {
-    await this.backendSrv.get(this.tagUrl + '/tags-count');
+    await this.get(this.tagUrl + '/tags-count');
     return { status: 'success', message: 'Data source connected and authentication successful!' };
   }
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2523281

The tag plugin is likely to get throttled when making a lot of history requests.

## 👩‍💻 Implementation

There's a few ways to approach this, but retrying failed requests is the easiest to implement, works even if a user has multiple dashboards open, and can be reused across all our plugins.

The strategy I've applied is to retry a maximum of 3 times with an exponential backoff (1, 2, 4 seconds). The actual delay for each request will be randomized to introduce jitter.

## 🧪 Testing

Unfortunately, the mild amount of refactoring from this change did force us to have to rewrite all the tests a bit. I also added two new tests for the retry behavior.

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).