### PR TITLE
refactor(system): clean up systems data source

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,6 +1,7 @@
 import { SelectableValue } from '@grafana/data';
 import { useAsync } from 'react-use';
 import { DataSourceBase } from './DataSourceBase';
+import { Workspace } from './types';
 
 export function enumToOptions<T>(stringEnum: { [name: string]: T }): Array<SelectableValue<T>> {
   const RESULT = [];
@@ -38,6 +39,10 @@ export function useWorkspaceOptions<DSType extends DataSourceBase<any>>(datasour
     const workspaces = await datasource.getWorkspaces();
     return workspaces.map(w => ({ label: w.name, value: w.id }));
   });
+}
+
+export function getWorkspaceName(workspaces: Workspace[], id: string) {
+  return workspaces.find(w => w.id === id)?.name ?? id;
 }
 
 /**

--- a/src/datasources/system/components/SystemQueryEditor.tsx
+++ b/src/datasources/system/components/SystemQueryEditor.tsx
@@ -1,38 +1,44 @@
-import React from 'react';
-import { InlineField, InlineFieldRow, Input, RadioButtonGroup } from '@grafana/ui';
+import React, { FormEvent } from 'react';
+import { AutoSizeInput, InlineField, RadioButtonGroup } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { SystemDataSource } from '../SystemDataSource';
-import { QueryType, SystemQuery } from '../types';
+import { SystemQueryType, SystemQuery } from '../types';
 import { enumToOptions } from 'core/utils';
 
 type Props = QueryEditorProps<SystemDataSource, SystemQuery>;
 
-export function SystemQueryEditor({ query, onChange, onRunQuery }: Props) {
-  const onQueryTypeChange = (value: QueryType) => {
-    onChange({ ...query, queryKind: value })
+export function SystemQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+  query = datasource.prepareQuery(query);
+  const onQueryTypeChange = (value: SystemQueryType) => {
+    onChange({ ...query, queryKind: value });
     onRunQuery();
-  }
+  };
 
-  const onIdBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    const id = e.currentTarget.value;
-    if (query.systemName !== id) {
-      onChange({ ...query, systemName: id })
-      onRunQuery(); 
-    }
-  }
+  const onSystemChange = (event: FormEvent<HTMLInputElement>) => {
+    onChange({ ...query, systemName: event.currentTarget.value });
+    onRunQuery();
+  };
 
   return (
-    <div>
-      <InlineFieldRow >
-        <InlineField label="Query type">
-          <RadioButtonGroup options={enumToOptions(QueryType)} onChange={onQueryTypeChange} value={query.queryKind} />
+    <>
+      <InlineField label="Query type">
+        <RadioButtonGroup
+          options={enumToOptions(SystemQueryType)}
+          onChange={onQueryTypeChange}
+          value={query.queryKind}
+        />
+      </InlineField>
+      {query.queryKind === SystemQueryType.Metadata && (
+        <InlineField label="System" tooltip="Enter system ID or alias">
+          <AutoSizeInput
+            defaultValue={query.systemName}
+            maxWidth={80}
+            minWidth={20}
+            onCommitChange={onSystemChange}
+            placeholder="All systems"
+          />
         </InlineField>
-      </InlineFieldRow>
-      <InlineFieldRow>
-        <InlineField label="System" tooltip="Enter system ID or alias" >
-          <Input placeholder="All systems" onBlur={onIdBlur} defaultValue={query.systemName} />
-        </InlineField>
-      </InlineFieldRow>
-    </div>
+      )}
+    </>
   );
 }

--- a/src/datasources/system/constants.ts
+++ b/src/datasources/system/constants.ts
@@ -1,14 +1,15 @@
-// constants.ts
 export const defaultProjection = [
-    'id',
-    'alias',
-    'connected.data.state',
-    'grains.data.minion_blackout as locked',
-    'grains.data.boottime as systemStartTime',
-    'grains.data.productname as model',
-    'grains.data.manufacturer as vendor',
-    'grains.data.osfullname as osFullName',
-    'grains.data.ip4_interfaces as ip4Interfaces',
-    'grains.data.ip6_interfaces as ip6Interfaces',
-    'workspace'
-  ]
+  'id',
+  'alias',
+  'connected.data.state',
+  'grains.data.minion_blackout as locked',
+  'grains.data.boottime as systemStartTime',
+  'grains.data.productname as model',
+  'grains.data.manufacturer as vendor',
+  'grains.data.osfullname as osFullName',
+  'grains.data.ip4_interfaces as ip4Interfaces',
+  'grains.data.ip6_interfaces as ip6Interfaces',
+  'workspace',
+];
+
+export const defaultOrderBy = 'createdTimeStamp DESC';

--- a/src/datasources/system/network-utils.ts
+++ b/src/datasources/system/network-utils.ts
@@ -1,67 +1,54 @@
 /**
- * Utility functions for parsing IP, MAC addresses, identify IP and hostname
+ * Utility functions for parsing IP addresses
  */
 export class NetworkUtils {
-    static getIpAddressFromInterfaces(ipInterfaces: { [key: string]: string[] }): string | null {
-        if (ipInterfaces) {
-            const firstConnectedInterface = NetworkUtils.getFirstConnectedInterface(ipInterfaces);
-            if (firstConnectedInterface) {
-                return firstConnectedInterface.address;
-            }
+  static getIpAddressFromInterfaces(...protocols: Array<{ [key: string]: string[] }>): string | null {
+    for (const ipInterfaces of protocols) {
+      if (ipInterfaces) {
+        const firstConnectedInterface = NetworkUtils.getFirstConnectedInterface(ipInterfaces);
+        if (firstConnectedInterface) {
+          return firstConnectedInterface.address;
         }
-
-        return null;
+      }
     }
 
-    static getFirstConnectedInterface(ipInterfaces: { [key: string]: string[] }): { name: string, address: string } | null {
-        for (const ipInterfaceName in ipInterfaces) {
-            if (!ipInterfaceName) {
-                continue;
-            }
-            const ipInterfaceAddresses = ipInterfaces[ipInterfaceName];
-            if (ipInterfaceName !== 'lo' && this.isInterfaceConnected(ipInterfaceAddresses)) {
-                return {
-                    name: ipInterfaceName,
-                    address: ipInterfaceAddresses[0]
-                };
-            }
-        }
+    return null;
+  }
 
-        return null;
+  static getFirstConnectedInterface(ipInterfaces: {
+    [key: string]: string[];
+  }): { name: string; address: string } | null {
+    for (const ipInterfaceName in ipInterfaces) {
+      if (!ipInterfaceName) {
+        continue;
+      }
+      const ipInterfaceAddresses = ipInterfaces[ipInterfaceName];
+      if (ipInterfaceName !== 'lo' && this.isInterfaceConnected(ipInterfaceAddresses)) {
+        return {
+          name: ipInterfaceName,
+          address: ipInterfaceAddresses[0],
+        };
+      }
     }
 
-    static getMacAddressFromInterfaceName(ipInterfaceName: string, hwaddrInterfaces: { [key: string]: string }): string | null {
-        if (!hwaddrInterfaces) {
-            return null;
-        }
-        return hwaddrInterfaces[ipInterfaceName] || null;
+    return null;
+  }
+
+  private static isInterfaceConnected(ipInterfaceAddresses: string[]): boolean {
+    if (!ipInterfaceAddresses || ipInterfaceAddresses.length === 0) {
+      return false;
+    }
+    if (ipInterfaceAddresses.length > 1) {
+      return true;
     }
 
-    static isValidIp(hostnameOrIpAddress: string): boolean {
-        const validIpAddressRegex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/;
-        return validIpAddressRegex.test(hostnameOrIpAddress);
+    const ipInterfaceAddress = ipInterfaceAddresses[0];
+    if (ipInterfaceAddress === '0.0.0.0' || ipInterfaceAddress === '::') {
+      // https://tools.ietf.org/html/rfc3513#section-2.5.2
+      // These addresses are used as non-routable meta-addresses
+      // to designate an invalid, unknown, or non-applicable address.
+      return false;
     }
-
-    static isValidHostname(hostnameOrIpAddress: string): boolean {
-        const validHostnameRegex = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/;
-        return validHostnameRegex.test(hostnameOrIpAddress);
-    }
-
-    private static isInterfaceConnected(ipInterfaceAddresses: string[]): boolean {
-        if (!ipInterfaceAddresses || ipInterfaceAddresses.length === 0) {
-            return false;
-        }
-        if (ipInterfaceAddresses.length > 1) {
-            return true;
-        }
-
-        const ipInterfaceAddress = ipInterfaceAddresses[0];
-        if (ipInterfaceAddress === '0.0.0.0' || ipInterfaceAddress === '::') {
-            // https://tools.ietf.org/html/rfc3513#section-2.5.2
-            // These addresses are used as non-routable meta-addresses
-            // to designate an invalid, unknown, or non-applicable address.
-            return false;
-        }
-        return true;
-    }
+    return true;
+  }
 }

--- a/src/datasources/system/types.ts
+++ b/src/datasources/system/types.ts
@@ -1,12 +1,12 @@
 import { DataQuery } from '@grafana/schema'
 
-export enum QueryType {
+export enum SystemQueryType {
   Metadata = "Metadata",
   Summary = "Summary"
 }
 
 export interface SystemQuery extends DataQuery {
-  queryKind: QueryType,
+  queryKind: SystemQueryType,
   systemName: string
 }
 
@@ -27,18 +27,4 @@ export interface SystemMetadata {
   ip4Interfaces: Record<string, string[]>,
   ip6Interfaces: Record<string, string[]>,
   workspace: string
-}
-
-export interface VariableQuery {
-  id: string,
-  alias: string
-}
-
-export interface AuthResponse {
-  workspaces: Workspace[]
-}
-
-export interface Workspace {
-  id: string,
-  name: string
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- Refactor systems data source to use `DataSourceBase` class and other misc clean up.

## 👩‍💻 Implementation

- `SystemDataSource` now extends from `DataSourceBase` and uses its `getWorkspaces` implementation
- Moved `getWorkspaceName` to shared utility function
- Remove unneeded `InlineFieldRow` component and use `AutoSizeInput` for system name field
- Hide system name field in Summary mode
- Remove unused types and `NetworkUtils` methods

## 🧪 Testing

- Manual testing of plugin. Automated tests will be in the next PR.

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).