### PR TITLE
feat(system): filter query variable by workspace

### DIFF
--- a/src/datasources/system/SystemDataSource.test.ts
+++ b/src/datasources/system/SystemDataSource.test.ts
@@ -95,20 +95,26 @@ test('query metadata with templated system name', async () => {
   await ds.query(buildQuery({ queryKind: SystemQueryType.Metadata, systemName: '$system_id' }));
 });
 
-test('queries for system variable values', async () => {
+test('queries for system variable values - all workspaces', async () => {
   backendSrv.fetch
-    .calledWith(
-      requestMatching({ url: '/nisysmgmt/v1/query-systems', data: { projection: 'new(id,alias)' } })
-    )
-    .mockReturnValue(createFetchResponse({ data: fakeSystems.map(({id, alias}) => ({id, alias})) }));
+    .calledWith(requestMatching({ url: '/nisysmgmt/v1/query-systems', data: { projection: 'new(id,alias)' } }))
+    .mockReturnValue(createFetchResponse({ data: fakeSystems.map(({ id, alias }) => ({ id, alias })) }));
 
-  const result = await ds.metricFindQuery();
+  const result = await ds.metricFindQuery({ workspace: '' });
 
   expect(result).toEqual([
     { text: 'my system', value: 'system-1' },
     { text: 'Cool system 😎', value: 'system-2' },
   ]);
-})
+});
+
+test('queries for system variable values - single workspace', async () => {
+  backendSrv.fetch
+    .calledWith(requestMatching({ url: '/nisysmgmt/v1/query-systems', data: { filter: 'workspace = "1"' } }))
+    .mockReturnValue(createFetchResponse({ data: fakeSystems.map(({ id, alias }) => ({ id, alias })) }));
+
+  await ds.metricFindQuery({ workspace: '1' });
+});
 
 const fakeSystems: SystemMetadata[] = [
   {

--- a/src/datasources/system/components/SystemVariableQueryEditor.test.tsx
+++ b/src/datasources/system/components/SystemVariableQueryEditor.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import React from 'react';
+import { select } from 'react-select-event';
+import { setupDataSource } from 'test/fixtures';
+import { SystemDataSource } from '../SystemDataSource';
+import { SystemVariableQueryEditor } from './SystemVariableQueryEditor';
+
+const onChange = jest.fn();
+const [datasource] = setupDataSource(SystemDataSource);
+const workspacesLoaded = () => waitForElementToBeRemoved(screen.getByTestId('Spinner'));
+
+test('renders with NO workspace selected', async () => {
+  render(<SystemVariableQueryEditor {...{ onChange, datasource, query: { workspace: '' } }} />);
+
+  await workspacesLoaded();
+
+  expect(screen.getByRole('combobox')).toHaveAccessibleDescription('Any workspace');
+});
+
+test('renders with workspace selected', async () => {
+  render(<SystemVariableQueryEditor {...{ onChange, datasource, query: { workspace: '1' } }} />);
+
+  await workspacesLoaded();
+
+  expect(screen.getByText('Default workspace')).toBeInTheDocument();
+});
+
+test('user selects new workspace', async () => {
+  render(<SystemVariableQueryEditor {...{ onChange, datasource, query: { workspace: '1' } }} />);
+
+  await workspacesLoaded();
+
+  await select(screen.getByRole('combobox'), 'Other workspace', { container: document.body });
+  expect(onChange).toBeCalledWith({ workspace: '2' });
+});

--- a/src/datasources/system/components/SystemVariableQueryEditor.tsx
+++ b/src/datasources/system/components/SystemVariableQueryEditor.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { SystemVariableQuery } from '../types';
+import { Select } from '@grafana/ui';
+import { useWorkspaceOptions } from 'core/utils';
+import { SystemDataSource } from '../SystemDataSource';
+import { InlineField } from 'core/components/InlineField';
+import { SelectableValue } from '@grafana/data';
+
+interface Props {
+  query: SystemVariableQuery;
+  onChange: (query: SystemVariableQuery) => void;
+  datasource: SystemDataSource;
+}
+
+export function SystemVariableQueryEditor({ onChange, query, datasource }: Props) {
+  const workspaces = useWorkspaceOptions(datasource);
+  return (
+    <InlineField label="Workspace">
+      <Select
+        isClearable
+        isLoading={workspaces.loading}
+        onChange={(option?: SelectableValue<string>) => onChange({ workspace: option?.value ?? '' })}
+        options={workspaces.value}
+        placeholder="Any workspace"
+        value={query.workspace}
+      />
+    </InlineField>
+  );
+}

--- a/src/datasources/system/module.ts
+++ b/src/datasources/system/module.ts
@@ -2,8 +2,9 @@ import { DataSourcePlugin } from '@grafana/data';
 import { SystemDataSource } from './SystemDataSource';
 import { SystemQueryEditor } from './components/SystemQueryEditor';
 import { HttpConfigEditor } from 'core/components/HttpConfigEditor';
+import { SystemVariableQueryEditor } from './components/SystemVariableQueryEditor';
 
 export const plugin = new DataSourcePlugin(SystemDataSource)
   .setConfigEditor(HttpConfigEditor)
   .setQueryEditor(SystemQueryEditor)
-  .setVariableQueryEditor(() => null);
+  .setVariableQueryEditor(SystemVariableQueryEditor);

--- a/src/datasources/system/types.ts
+++ b/src/datasources/system/types.ts
@@ -10,6 +10,10 @@ export interface SystemQuery extends DataQuery {
   systemName: string
 }
 
+export interface SystemVariableQuery {
+  workspace: string;
+}
+
 export interface SystemSummary {
   connectedCount: number,
   disconnectedCount: number


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2493969

![image](https://github.com/ni/systemlink-grafana-plugins/assets/9257800/70ab64ce-e9fc-43ae-b708-b8d78c737628)


## 👩‍💻 Implementation

- Added a workspace filter to `getSystemMetadata`
- New component `SystemVariableQueryEditor` that lets users select a workspace

## 🧪 Testing

- Added auto tests for the datasource and the new component

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).