### PR TITLE
feat(workspace): Add skeleton workspace data source

### DIFF
--- a/provisioning/example.yaml
+++ b/provisioning/example.yaml
@@ -29,3 +29,7 @@ datasources:
     type: ni-slsystem-datasource
     uid: system
     <<: *config
+  - name: SystemLink Workspaces
+    type: ni-slworkspace-datasource
+    uid: workspace
+    <<: *config

--- a/src/datasources/workspace/README.md
+++ b/src/datasources/workspace/README.md
@@ -1,0 +1,3 @@
+# Systemlink Workspace data source
+
+This data source plugin is responsible for querying and displaying SystemLink workspaces, which are part of the SystemLink User Service.

--- a/src/datasources/workspace/WorkspaceDataSource.test.ts
+++ b/src/datasources/workspace/WorkspaceDataSource.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
   [ds, backendSrv] = setupDataSource(WorkspaceDataSource);
 });
 
-fdescribe('testDatasource', () => {
+describe('testDatasource', () => {
   test('returns success', async () => {
     backendSrv.fetch
       .calledWith(requestMatching({ url: '/niuser/v1/workspaces' }))

--- a/src/datasources/workspace/WorkspaceDataSource.test.ts
+++ b/src/datasources/workspace/WorkspaceDataSource.test.ts
@@ -1,0 +1,36 @@
+import { BackendSrv } from '@grafana/runtime';
+import { MockProxy } from 'jest-mock-extended';
+import _ from 'lodash';
+import {
+  createFetchError,
+  createFetchResponse,
+  requestMatching,
+  setupDataSource,
+} from 'test/fixtures';
+import { WorkspaceDataSource } from './WorkspaceDataSource';
+
+let ds: WorkspaceDataSource, backendSrv: MockProxy<BackendSrv>;
+
+beforeEach(() => {
+  [ds, backendSrv] = setupDataSource(WorkspaceDataSource);
+});
+
+fdescribe('testDatasource', () => {
+  test('returns success', async () => {
+    backendSrv.fetch
+      .calledWith(requestMatching({ url: '/niuser/v1/workspaces' }))
+      .mockReturnValue(createFetchResponse(25));
+
+    const result = await ds.testDatasource();
+
+    expect(result.status).toEqual('success');
+  });
+
+  test('bubbles up exception', async () => {
+    backendSrv.fetch
+      .calledWith(requestMatching({ url: '/niuser/v1/workspaces' }))
+      .mockReturnValue(createFetchError(400));
+
+    await expect(ds.testDatasource()).rejects.toHaveProperty('status', 400);
+  });
+});

--- a/src/datasources/workspace/WorkspaceDataSource.ts
+++ b/src/datasources/workspace/WorkspaceDataSource.ts
@@ -1,0 +1,39 @@
+import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, FieldType } from '@grafana/data';
+import { BackendSrv, TemplateSrv, TestingStatus, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
+import { DataSourceBase } from 'core/DataSourceBase';
+import { WorkspaceQuery } from './types';
+
+export class WorkspaceDataSource extends DataSourceBase<WorkspaceQuery> {
+  constructor(
+    readonly instanceSettings: DataSourceInstanceSettings,
+    readonly backendSrv: BackendSrv = getBackendSrv(),
+    readonly templateSrv: TemplateSrv = getTemplateSrv()
+  ) {
+    super(instanceSettings, backendSrv);
+  }
+
+  baseUrl = this.instanceSettings.url + '/niuser/v1';
+
+  defaultQuery = {
+    constant: 3.14,
+  };
+
+  async runQuery(query: WorkspaceQuery, { range }: DataQueryRequest): Promise<DataFrameDTO> {
+    return {
+      refId: query.refId,
+      fields: [
+        { name: 'Time', values: [range.from.valueOf(), range.to.valueOf()], type: FieldType.time },
+        { name: 'Value', values: [query.constant, query.constant], type: FieldType.number },
+      ],
+    };
+  }
+
+  shouldRunQuery(query: WorkspaceQuery): boolean {
+    return true;
+  }
+
+  async testDatasource(): Promise<TestingStatus> {
+    await this.get(this.baseUrl + '/workspaces');
+    return { status: 'success', message: 'Data source connected and authentication successful!' };
+  }
+}

--- a/src/datasources/workspace/components/WorkspaceQueryEditor.tsx
+++ b/src/datasources/workspace/components/WorkspaceQueryEditor.tsx
@@ -1,0 +1,33 @@
+import React, { ChangeEvent } from 'react';
+import { Input } from '@grafana/ui';
+import { QueryEditorProps } from '@grafana/data';
+import { InlineField } from 'core/components/InlineField';
+import { WorkspaceDataSource } from '../WorkspaceDataSource';
+import { WorkspaceQuery } from '../types';
+
+type Props = QueryEditorProps<WorkspaceDataSource, WorkspaceQuery>;
+
+export function WorkspaceQueryEditor({ query, onChange, onRunQuery }: Props) {
+  const onQueryTextChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...query, queryText: event.target.value });
+  };
+
+  const onConstantChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...query, constant: parseFloat(event.target.value) });
+    // executes the query
+    onRunQuery();
+  };
+
+  const { queryText, constant } = query;
+
+  return (
+    <>
+      <InlineField label="Constant">
+        <Input onChange={onConstantChange} value={constant} width={8} type="number" step="0.1" />
+      </InlineField>
+      <InlineField label="Query Text" labelWidth={16} tooltip="Not used yet">
+        <Input onChange={onQueryTextChange} value={queryText || ''} />
+      </InlineField>
+    </>
+  );
+}

--- a/src/datasources/workspace/img/logo-ni.svg
+++ b/src/datasources/workspace/img/logo-ni.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="43px" height="29px" viewBox="0 0 43 29" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>9B441361-9BF9-4E57-A772-8A5F7846467E</title>
+    <g id="Login" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Logging-In-Loader" transform="translate(-864.000000, -139.000000)" fill="#00B383">
+            <g id="NI-logo" transform="translate(864.000000, 139.000000)">
+                <path d="M9.98214286,9.92105263 L9.98214286,29 L0,29 L0,9.92105263 L9.98214286,9.92105263 Z M43,0 L43,29 C37.4870147,29 33.0178571,24.5308424 33.0178571,19.0178571 L33.0178571,0 L43,0 Z M18.4107143,0 C23.9335618,-1.01453063e-15 28.4107143,4.4771525 28.4107143,10 L28.4107143,29 L18.4293773,29 L18.4293773,10.9210526 C18.4293439,10.3687809 17.981649,9.92107107 17.4293773,9.92101925 L9.98214286,9.92077061 L9.98214286,0 L18.4107143,0 Z"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/datasources/workspace/module.ts
+++ b/src/datasources/workspace/module.ts
@@ -1,0 +1,8 @@
+import { DataSourcePlugin } from '@grafana/data';
+import { WorkspaceDataSource } from './WorkspaceDataSource';
+import { WorkspaceQueryEditor } from './components/WorkspaceQueryEditor';
+import { HttpConfigEditor } from 'core/components/HttpConfigEditor';
+
+export const plugin = new DataSourcePlugin(WorkspaceDataSource)
+  .setConfigEditor(HttpConfigEditor)
+  .setQueryEditor(WorkspaceQueryEditor);

--- a/src/datasources/workspace/plugin.json
+++ b/src/datasources/workspace/plugin.json
@@ -1,0 +1,15 @@
+{
+  "type": "datasource",
+  "name": "SystemLink Workspaces",
+  "id": "ni-slworkspace-datasource",
+  "query": true,
+  "info": {
+    "author": {
+      "name": "NI"
+    },
+    "logos": {
+      "small": "img/logo-ni.svg",
+      "large": "img/logo-ni.svg"
+    }
+  }
+}

--- a/src/datasources/workspace/plugin.json
+++ b/src/datasources/workspace/plugin.json
@@ -2,7 +2,7 @@
   "type": "datasource",
   "name": "SystemLink Workspaces",
   "id": "ni-slworkspace-datasource",
-  "query": true,
+  "metrics": true,
   "info": {
     "author": {
       "name": "NI"

--- a/src/datasources/workspace/types.ts
+++ b/src/datasources/workspace/types.ts
@@ -1,0 +1,6 @@
+import { DataQuery } from '@grafana/schema'
+
+export interface WorkspaceQuery extends DataQuery {
+  queryText?: string;
+  constant: number;
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2527387

## 👩‍💻 Implementation

- `npm run generate`
- Add to provisioning example file
- Fill in README
- Update data source base and test routes

## 🧪 Testing

Validated the datasource is available locally

## ✅ Checklist

- [X] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).