### PR TITLE
feat(tag): include properties in query result

### DIFF
--- a/src/datasources/tag/TagDataSource.test.ts
+++ b/src/datasources/tag/TagDataSource.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
   [ds, backendSrv, templateSrv] = setupDataSource(TagDataSource);
 });
 
-const buildQuery = getQueryBuilder<TagQuery>()({ type: TagQueryType.Current, workspace: '' });
+const buildQuery = getQueryBuilder<TagQuery>()({ type: TagQueryType.Current, workspace: '', properties: false });
 mockTimers();
 
 describe('testDatasource', () => {
@@ -51,20 +51,15 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ path: 'my.tag' }));
 
-    expect(result.data).toEqual([
-      {
-        fields: [{ name: 'my.tag', values: [3.14] }],
-        refId: 'A',
-      },
-    ]);
+    expect(result.data).toMatchSnapshot();
   });
 
   test('applies query defaults when missing fields', async () => {
     backendSrv.fetch.mockReturnValue(createQueryTagsResponse());
 
-    const result = await ds.query({ ...defaultQueryOptions, targets: [{ path: 'my.tag' } as TagQuery] });
+    const result = await ds.query({ ...defaultQueryOptions, targets: [{ path: 'my.tag', refId: 'A' } as TagQuery] });
 
-    expect(result.data[0]).toHaveProperty('fields', [{ name: 'my.tag', values: [3.14] }]);
+    expect(result.data).toMatchSnapshot();
   });
 
   test('uses displayName property', async () => {
@@ -72,7 +67,7 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ path: 'my.tag' }));
 
-    expect(result.data[0].fields[0]).toHaveProperty('name', 'My cool tag');
+    expect(result.data).toMatchSnapshot();
   });
 
   test('handles null tag properties', async () => {
@@ -80,7 +75,7 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ path: 'my.tag' }));
 
-    expect(result.data[0]).toHaveProperty('fields', [{ name: 'my.tag', values: [3.14] }]);
+    expect(result.data).toMatchSnapshot();
   });
 
   test('handles tag with no current value', async () => {
@@ -88,7 +83,7 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ path: 'my.tag' }));
 
-    expect(result.data[0]).toHaveProperty('fields', [{ name: 'my.tag', values: [] }]);
+    expect(result.data).toMatchSnapshot();
   });
 
   test('multiple targets - skips invalid queries', async () => {
@@ -101,16 +96,7 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ path: 'my.tag1' }, { path: '' }, { path: 'my.tag2' }));
 
-    expect(result.data).toEqual([
-      {
-        fields: [{ name: 'my.tag1', values: [3.14] }],
-        refId: 'A',
-      },
-      {
-        fields: [{ name: 'my.tag2', values: [41.3] }],
-        refId: 'C',
-      },
-    ]);
+    expect(result.data).toMatchSnapshot();
   });
 
   test('current value for all data types', async () => {
@@ -127,13 +113,7 @@ describe('queries', () => {
       buildQuery({ path: 'tag1' }, { path: 'tag2' }, { path: 'tag3' }, { path: 'tag4' }, { path: 'tag5' })
     );
 
-    expect(result.data.map(frames => frames.fields[0])).toEqual([
-      { name: 'tag1', values: [3] },
-      { name: 'tag2', values: [3.3] },
-      { name: 'tag3', values: ['foo'] },
-      { name: 'tag4', values: ['True'] },
-      { name: 'tag5', values: [2147483648] },
-    ]);
+    expect(result.data).toMatchSnapshot();
   });
 
   test('throw when no tags matched', async () => {
@@ -171,15 +151,7 @@ describe('queries', () => {
 
     const result = await ds.query(queryRequest);
 
-    expect(result.data).toEqual([
-      {
-        fields: [
-          { name: 'time', values: [1672531200000, 1672531260000] },
-          { name: 'my.tag', values: [1, 2] },
-        ],
-        refId: 'A',
-      },
-    ]);
+    expect(result.data).toMatchSnapshot();
   });
 
   test('string tag history', async () => {
@@ -193,15 +165,7 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ type: TagQueryType.History, path: 'my.tag' }));
 
-    expect(result.data).toEqual([
-      {
-        fields: [
-          { name: 'time', values: [1672531200000, 1672531260000] },
-          { name: 'my.tag', values: ['3.14', 'foo'] },
-        ],
-        refId: 'A',
-      },
-    ]);
+    expect(result.data).toMatchSnapshot();
   });
 
   test('decimation parameter does not go above 1000', async () => {
@@ -230,7 +194,7 @@ describe('queries', () => {
 
     const result = await ds.query(buildQuery({ type: TagQueryType.Current, path: '$my_variable' }));
 
-    expect(result.data[0].fields[0]).toHaveProperty('name', 'my.tag');
+    expect(result.data).toMatchSnapshot();
   });
 
   test('filters by workspace if provided', async () => {
@@ -275,7 +239,7 @@ function createQueryTagsResponse(
       _.defaultsDeep(
         { tag, current },
         {
-          current: { value: { value: '3.14' } },
+          current: { value: { value: '3.14' }, timestamp: '2023-10-04T00:00:00.000000Z' },
           tag: { datatype: 'DOUBLE', path: 'my.tag', properties: {}, workspace_id: '1' },
         }
       ),

--- a/src/datasources/tag/TagDataSource.test.ts
+++ b/src/datasources/tag/TagDataSource.test.ts
@@ -228,6 +228,14 @@ describe('queries', () => {
 
     expect(backendSrv.fetch).toHaveBeenCalledTimes(5);
   });
+
+  test('appends tag properties to query result', async () => {
+    backendSrv.fetch.mockReturnValue(createQueryTagsResponse({ properties: { nitagHistoryTTLDays: '7', foo: 'bar' } }));
+
+    const result = await ds.query(buildQuery({ path: 'my.tag', properties: true }));
+
+    expect(result.data).toMatchSnapshot();
+  });
 });
 
 function createQueryTagsResponse(

--- a/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
+++ b/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`queries appends tag properties to query result 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "my.tag",
+        "values": [
+          3.14,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+      {
+        "name": "foo",
+        "values": [
+          "bar",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
 exports[`queries applies query defaults when missing fields 1`] = `
 [
   {

--- a/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
+++ b/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
@@ -1,0 +1,362 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`queries applies query defaults when missing fields 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "my.tag",
+        "values": [
+          3.14,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries current value for all data types 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "tag1",
+        "values": [
+          3,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+  {
+    "fields": [
+      {
+        "name": "tag2",
+        "values": [
+          3.3,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "B",
+  },
+  {
+    "fields": [
+      {
+        "name": "tag3",
+        "values": [
+          "foo",
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "C",
+  },
+  {
+    "fields": [
+      {
+        "name": "tag4",
+        "values": [
+          "True",
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "D",
+  },
+  {
+    "fields": [
+      {
+        "name": "tag5",
+        "values": [
+          2147483648,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "E",
+  },
+]
+`;
+
+exports[`queries handles null tag properties 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "my.tag",
+        "values": [
+          3.14,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries handles tag with no current value 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "my.tag",
+        "values": [
+          undefined,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          undefined,
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries multiple targets - skips invalid queries 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "my.tag1",
+        "values": [
+          3.14,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+  {
+    "fields": [
+      {
+        "name": "my.tag2",
+        "values": [
+          41.3,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "C",
+  },
+]
+`;
+
+exports[`queries numeric tag history 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "time",
+        "values": [
+          1672531200000,
+          1672531260000,
+        ],
+      },
+      {
+        "name": "my.tag",
+        "values": [
+          1,
+          2,
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries replaces tag path with variable 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "my.tag",
+        "values": [
+          3.14,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries string tag history 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "time",
+        "values": [
+          1672531200000,
+          1672531260000,
+        ],
+      },
+      {
+        "name": "my.tag",
+        "values": [
+          "3.14",
+          "foo",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries tag current value 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "my.tag",
+        "values": [
+          3.14,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries uses displayName property 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "My cool tag",
+        "values": [
+          3.14,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;

--- a/src/datasources/tag/components/TagQueryEditor.test.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.test.tsx
@@ -16,10 +16,11 @@ it('renders with query defaults', async () => {
   expect(screen.getByRole('radio', { name: 'Current' })).toBeChecked();
   expect(screen.getByLabelText('Tag path')).not.toHaveValue();
   expect(screen.getByRole('combobox')).toHaveAccessibleDescription('Any workspace');
+  expect(screen.getByRole('checkbox')).not.toBeChecked();
 });
 
 it('renders with initial query and updates when user makes changes', async () => {
-  const [onChange] = render({ type: TagQueryType.History, path: 'my.tag', workspace: '1' });
+  const [onChange] = render({ type: TagQueryType.History, path: 'my.tag', workspace: '1', properties: true });
   await workspacesLoaded();
 
   // Renders saved query
@@ -38,4 +39,8 @@ it('renders with initial query and updates when user makes changes', async () =>
   // User selects different workspace
   await select(screen.getByRole('combobox'), 'Other workspace', { container: document.body });
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ workspace: '2' }));
+
+  // User toggles properties
+  await userEvent.click(screen.getByRole('checkbox'));
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ properties: false }));
 });

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -68,5 +68,5 @@ const tooltips = {
   workspace: `The workspace to search for the given tag path. If left blank, the plugin
               finds the most recently updated tag in any workspace.`,
 
-  properties: `If toggled, include the tag's properties in the query result.`,
+  properties: `If enabled, include the tag properties in the query result.`,
 };

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -1,5 +1,5 @@
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { AutoSizeInput, RadioButtonGroup, Select } from '@grafana/ui';
+import { AutoSizeInput, InlineSwitch, RadioButtonGroup, Select } from '@grafana/ui';
 import { InlineField } from 'core/components/InlineField';
 import { enumToOptions, useWorkspaceOptions } from 'core/utils';
 import React, { FormEvent } from 'react';
@@ -28,6 +28,11 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
     onRunQuery();
   };
 
+  const onPropertiesChange = () => {
+    onChange({ ...query, properties: !query.properties });
+    onRunQuery();
+  };
+
   return (
     <>
       <InlineField label="Query type" labelWidth={14} tooltip={tooltips.queryType}>
@@ -46,6 +51,9 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
           value={query.workspace}
         />
       </InlineField>
+      <InlineField label="Properties" labelWidth={14} tooltip={tooltips.properties}>
+        <InlineSwitch onChange={onPropertiesChange} value={query.properties} />
+      </InlineField>
     </>
   );
 }
@@ -59,4 +67,6 @@ const tooltips = {
 
   workspace: `The workspace to search for the given tag path. If left blank, the plugin
               finds the most recently updated tag in any workspace.`,
+
+  properties: `If toggled, include the tag's properties in the query result.`,
 };

--- a/src/datasources/tag/types.ts
+++ b/src/datasources/tag/types.ts
@@ -13,7 +13,10 @@ export interface TagQuery extends DataQuery {
 }
 
 export interface TagWithValue {
-  current: { value: { value: string }; timestamp: string } | null;
+  current: {
+    value: { value: string };
+    timestamp: string;
+  } | null;
   tag: {
     datatype: string;
     path: string;

--- a/src/datasources/tag/types.ts
+++ b/src/datasources/tag/types.ts
@@ -9,14 +9,15 @@ export interface TagQuery extends DataQuery {
   type: TagQueryType;
   path: string;
   workspace: string;
+  properties: boolean;
 }
 
 export interface TagWithValue {
-  current: { value: { value: string } } | null;
+  current: { value: { value: string }; timestamp: string } | null;
   tag: {
     datatype: string;
     path: string;
-    properties: { displayName?: string } | null;
+    properties: Record<string, string> | null;
     workspace_id: string;
   };
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2504597

## 👩‍💻 Implementation

Pretty straightforward - `TagQueryEditor` now has an `InlineSwitch` component that lets users toggle whether or not to show properties. In `TagDataSource`, we map the tag's properties to DataFrame fields and conditionally append them to the result. We ignore properties that start with "nitag" because they're used by the historian service and not useful to users. We also now return the tag's last updated timestamp for the "Current" query mode.

## 🧪 Testing

I decided to make the leap to using [snapshot testing](https://jestjs.io/docs/snapshot-testing) for some of the tag data source tests. I've been thinking about it for a while, but this change made updating the test assertions tedious enough that I tried it out. It's _really_ nice for testing the data source `query` method. Instead of manually typing out the expected result, Jest generates a snapshot file for us that stores the results. Then in the future if the snapshot changes, the test will fail.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).