### PR TITLE
fix(tag): support both `workspace` and `workspace_id` properties

### DIFF
--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -46,7 +46,7 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
         { name: 'updated', values: [current?.timestamp], type: FieldType.time, config: { unit: 'dateTimeFromNow' } },
       ];
     } else {
-      const history = await this.getTagHistoryValues(tag.path, tag.workspace, range, maxDataPoints);
+      const history = await this.getTagHistoryValues(tag.path, tag.workspace ?? tag.workspace_id, range, maxDataPoints);
       result.fields = [
         { name: 'time', values: history.datetimes },
         { name, values: history.values },

--- a/src/datasources/tag/types.ts
+++ b/src/datasources/tag/types.ts
@@ -22,6 +22,7 @@ export interface TagWithValue {
     path: string;
     properties: Record<string, string> | null;
     workspace: string;
+    workspace_id: string;
   };
 }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The tag service had a breaking change that we fixed in #45, but the service is in a mixed state of deployment. We should support both properties for now.

## 👩‍💻 Implementation

- Check both properties

## 🧪 Testing

n/a, temporary bandaid

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).