### PR TITLE
fix(tag): support `datatype` and `type` properties

### DIFF
--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -42,7 +42,7 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
 
     if (query.type === TagQueryType.Current) {
       result.fields = [
-        { name, values: [this.convertTagValue(tag.datatype, current?.value.value)] },
+        { name, values: [this.convertTagValue(tag.type ?? tag.datatype, current?.value.value)] },
         { name: 'updated', values: [current?.timestamp], type: FieldType.time, config: { unit: 'dateTimeFromNow' } },
       ];
     } else {

--- a/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
+++ b/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
@@ -341,6 +341,32 @@ exports[`queries string tag history 1`] = `
 ]
 `;
 
+exports[`queries supports legacy tag service property "datatype" 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "my.tag",
+        "values": [
+          3.14,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
 exports[`queries tag current value 1`] = `
 [
   {

--- a/src/datasources/tag/types.ts
+++ b/src/datasources/tag/types.ts
@@ -12,19 +12,36 @@ export interface TagQuery extends DataQuery {
   properties: boolean;
 }
 
-export interface TagWithValue {
+interface TagWithValueBase {
   current: {
     value: { value: string };
     timestamp: string;
   } | null;
   tag: {
-    datatype: string;
     path: string;
     properties: Record<string, string> | null;
-    workspace: string;
-    workspace_id: string;
   };
 }
+
+// Legacy tag properties from SystemLink Server
+interface TagWithValueV1 {
+  tag: {
+    collect_aggregates: boolean;
+    datatype: string;
+    last_updated: number;
+    workspace_id: string;
+  }
+}
+
+// Tag properties renamed in SystemLink Enterprise
+interface TagWithValueV2 {
+  tag: {
+    type: string;
+    workspace: string;
+  }
+}
+
+export type TagWithValue = TagWithValueBase & TagWithValueV1 & TagWithValueV2;
 
 export interface TagsWithValues {
   tagsWithValues: TagWithValue[];

--- a/src/datasources/tag/types.ts
+++ b/src/datasources/tag/types.ts
@@ -23,7 +23,7 @@ interface TagWithValueBase {
   };
 }
 
-// Legacy tag properties from SystemLink Server
+// Legacy tag properties from SystemLink Cloud
 interface TagWithValueV1 {
   tag: {
     collect_aggregates: boolean;
@@ -33,7 +33,7 @@ interface TagWithValueV1 {
   }
 }
 
-// Tag properties renamed in SystemLink Enterprise
+// Tag properties renamed in SystemLink Server and Enterprise
 interface TagWithValueV2 {
   tag: {
     type: string;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The tag service had a [breaking change]( https://dev.azure.com/ni/DevCentral/_git/Skyline/commit/b3d9e6c8392b2d6f1b95de3512faf50d91cd410f?refName=refs%2Fheads%2Fmaster) that renamed the `datatype` field to `type`. We should handle both versions of the tag service to avoid any deployment issues.

## 👩‍💻 Implementation

- Added a separate interface for the legacy field names
- Check both `type` and `datatype`

## 🧪 Testing

- Added unit tests for the legacy fields

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).