### PR TITLE
feat(dataframe): visualize table properties

### DIFF
--- a/src/core/DataSourceBase.ts
+++ b/src/core/DataSourceBase.ts
@@ -1,18 +1,11 @@
 import {
-  DataFrame,
   DataFrameDTO,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
   DataSourceInstanceSettings,
 } from '@grafana/data';
-import {
-  BackendSrv,
-  BackendSrvRequest,
-  TemplateSrv,
-  TestingStatus,
-  isFetchError
-} from '@grafana/runtime';
+import { BackendSrv, BackendSrvRequest, TemplateSrv, TestingStatus, isFetchError } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { Workspace } from './types';
 import { sleep } from './utils';
@@ -28,7 +21,7 @@ export abstract class DataSourceBase<TQuery extends DataQuery> extends DataSourc
   }
 
   abstract defaultQuery: Partial<TQuery> & Omit<TQuery, 'refId'>;
-  abstract runQuery(query: TQuery, options: DataQueryRequest): Promise<DataFrame | DataFrameDTO>;
+  abstract runQuery(query: TQuery, options: DataQueryRequest): Promise<DataFrameDTO>;
   abstract shouldRunQuery(query: TQuery): boolean;
   abstract testDatasource(): Promise<TestingStatus>;
 

--- a/src/datasources/data-frame/DataFrameDataSource.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.ts
@@ -1,22 +1,7 @@
 import TTLCache from '@isaacs/ttlcache';
 import deepEqual from 'fast-deep-equal';
-import {
-  DataQueryRequest,
-  DataSourceInstanceSettings,
-  toDataFrame,
-  TableData,
-  FieldType,
-  standardTransformers,
-  DataFrame,
-  TimeRange
-} from '@grafana/data';
-import {
-  BackendSrv,
-  TemplateSrv,
-  TestingStatus,
-  getBackendSrv,
-  getTemplateSrv
-} from '@grafana/runtime';
+import { DataQueryRequest, DataSourceInstanceSettings, FieldType, TimeRange, FieldDTO, dateTime } from '@grafana/data';
+import { BackendSrv, TemplateSrv, TestingStatus, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import {
   ColumnDataType,
   DataFrameQuery,
@@ -27,6 +12,7 @@ import {
   Column,
   defaultQuery,
   ValidDataFrameQuery,
+  DataFrameQueryType,
 } from './types';
 import { metadataCacheTTL } from './constants';
 import _ from 'lodash';
@@ -45,32 +31,39 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery> {
 
   baseUrl = this.instanceSettings.url + '/nidataframe/v1';
 
-  defaultQuery = defaultQuery
+  defaultQuery = defaultQuery;
 
-  async runQuery(query: DataFrameQuery, { range, scopedVars, maxDataPoints }: DataQueryRequest): Promise<DataFrame> {
+  async runQuery(query: DataFrameQuery, { range, scopedVars, maxDataPoints }: DataQueryRequest) {
     const processedQuery = this.processQuery(query);
     processedQuery.tableId = getTemplateSrv().replace(processedQuery.tableId, scopedVars);
-    const tableMetadata = await this.getTableMetadata(processedQuery.tableId);
-    const columns = this.getColumnTypes(processedQuery.columns, tableMetadata?.columns ?? []);
-    const tableData = await this.getDecimatedTableData(processedQuery, columns, range, maxDataPoints);
-    return this.convertDataFrameFields({
-      refId: processedQuery.refId,
-      name: processedQuery.tableId,
-      columns: processedQuery.columns.map((name) => ({ text: name })),
-      rows: tableData.frame.data,
-    } as TableData, columns);
+    const metadata = await this.getTableMetadata(processedQuery.tableId);
+
+    if (processedQuery.type === DataFrameQueryType.Metadata) {
+      return {
+        refId: processedQuery.refId,
+        name: metadata.name,
+        fields: [
+          { name: 'name', values: Object.keys(metadata.properties) },
+          { name: 'value', values: Object.values(metadata.properties) },
+        ],
+      };
+    } else {
+      const columns = this.getColumnTypes(processedQuery.columns, metadata?.columns ?? []);
+      const tableData = await this.getDecimatedTableData(processedQuery, columns, range, maxDataPoints);
+      return {
+        refId: processedQuery.refId,
+        name: metadata.name,
+        fields: this.dataFrameToFields(tableData.frame.data, columns),
+      };
+    }
   }
 
   shouldRunQuery(query: ValidDataFrameQuery): boolean {
-    return Boolean(query.tableId) && Boolean(query.columns.length);
+    return Boolean(query.tableId) && (query.type === DataFrameQueryType.Metadata || Boolean(query.columns.length));
   }
 
-  async getTableMetadata(id?: string): Promise<TableMetadata | null> {
+  async getTableMetadata(id?: string): Promise<TableMetadata> {
     const resolvedId = getTemplateSrv().replace(id);
-    if (!resolvedId) {
-      return null;
-    }
-
     let metadata = this.metadataCache.get(resolvedId);
 
     if (!metadata) {
@@ -98,7 +91,7 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery> {
       decimation: {
         intervals,
         method: query.decimationMethod,
-        yColumns: this.getNumericColumns(columns).map((c) => c.name),
+        yColumns: this.getNumericColumns(columns).map(c => c.name),
       },
     });
   }
@@ -106,7 +99,7 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery> {
   async queryTables(query: string): Promise<TableMetadata[]> {
     const filter = `name.Contains("${query}")`;
 
-    return (await this.post<TableMetadataList>(`${this.baseUrl}/query-tables`,  { filter, take: 5 })).tables;
+    return (await this.post<TableMetadataList>(`${this.baseUrl}/query-tables`, { filter, take: 5 })).tables;
   }
 
   async testDatasource(): Promise<TestingStatus> {
@@ -119,15 +112,15 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery> {
 
     // Migration for 1.6.0: DataFrameQuery.columns changed to string[]
     if (_.isObject(migratedQuery.columns[0])) {
-      migratedQuery.columns = (migratedQuery.columns as any[]).map((c) => c.name);
+      migratedQuery.columns = (migratedQuery.columns as any[]).map(c => c.name);
     }
 
     // If we didn't make any changes to the query, then return the original object
-    return deepEqual(migratedQuery, query) ? query as ValidDataFrameQuery : migratedQuery;
-  };
+    return deepEqual(migratedQuery, query) ? (query as ValidDataFrameQuery) : migratedQuery;
+  }
 
   private getColumnTypes(columnNames: string[], tableMetadata: Column[]): Column[] {
-    return columnNames.map((c) => {
+    return columnNames.map(c => {
       const column = tableMetadata.find(({ name }) => name === c);
 
       if (!column) {
@@ -138,52 +131,33 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery> {
     });
   }
 
-  private getFieldType(dataType: ColumnDataType): FieldType {
+  private getFieldTypeAndConverter(dataType: ColumnDataType): [FieldType, (v: string) => any] {
     switch (dataType) {
       case 'BOOL':
-        return FieldType.boolean;
+        return [FieldType.boolean, v => v.toLowerCase() === 'true'];
       case 'STRING':
-        return FieldType.string;
+        return [FieldType.string, v => v];
       case 'TIMESTAMP':
-        return FieldType.time;
+        return [FieldType.time, v => dateTime(v).valueOf()];
       default:
-        return FieldType.number;
+        return [FieldType.number, v => Number(v)];
     }
   }
 
-  private convertDataFrameFields(tableData: TableData, columns: Column[]): DataFrame {
-    this.transformBooleanFields(tableData, columns);
-    const frame = toDataFrame(tableData);
-    frame.fields.forEach(field => {
-      if (field.name.toLowerCase() === 'value') {
-        field.config.displayName = field.name;
-      }
-    })
-    const transformer = standardTransformers.convertFieldTypeTransformer.transformer;
-    const conversions = columns.map(({ name, dataType }) => ({
-      targetField: name,
-      destinationType: this.getFieldType(dataType),
-      dateFormat: 'YYYY-MM-DDTHH:mm:ss.SZ',
-    }));
-    return transformer({ conversions }, { interpolate: _.identity })([frame])[0];
-  }
-
-  private transformBooleanFields(tableData: TableData, columns: Column[]): void {
-    const boolColumnIndices: number[] = [];
-    columns.forEach((column, i) => {
-      if (column.dataType === 'BOOL') {
-        boolColumnIndices.push(i);
-      }
+  private dataFrameToFields(rows: string[][], columns: Column[]): FieldDTO[] {
+    return columns.map((col, ix) => {
+      const [type, converter] = this.getFieldTypeAndConverter(col.dataType);
+      return {
+        name: col.name,
+        type,
+        values: rows.map(row => (row[ix] !== null ? converter(row[ix]) : null)),
+        ...(col.name.toLowerCase() === 'value' && { config: { displayName: col.name } }),
+      };
     });
-    if (!!boolColumnIndices.length) {
-      tableData.rows.forEach(row => {
-        boolColumnIndices.forEach(i => row[i] = row[i].toLowerCase() === 'true');
-      })
-    }
   }
 
   private constructTimeFilters(columns: Column[], timeRange: TimeRange): ColumnFilter[] {
-    const timeIndex = columns.find((c) => c.dataType === 'TIMESTAMP' && c.columnType === 'INDEX');
+    const timeIndex = columns.find(c => c.dataType === 'TIMESTAMP' && c.columnType === 'INDEX');
 
     if (!timeIndex) {
       return [];

--- a/src/datasources/data-frame/DataFrameDataSource.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.ts
@@ -1,6 +1,6 @@
 import TTLCache from '@isaacs/ttlcache';
 import deepEqual from 'fast-deep-equal';
-import { DataQueryRequest, DataSourceInstanceSettings, FieldType, TimeRange, FieldDTO, dateTime } from '@grafana/data';
+import { DataQueryRequest, DataSourceInstanceSettings, FieldType, TimeRange, FieldDTO, dateTime, DataFrameDTO } from '@grafana/data';
 import { BackendSrv, TemplateSrv, TestingStatus, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import {
   ColumnDataType,
@@ -33,7 +33,7 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery> {
 
   defaultQuery = defaultQuery;
 
-  async runQuery(query: DataFrameQuery, { range, scopedVars, maxDataPoints }: DataQueryRequest) {
+  async runQuery(query: DataFrameQuery, { range, scopedVars, maxDataPoints }: DataQueryRequest): Promise<DataFrameDTO> {
     const processedQuery = this.processQuery(query);
     processedQuery.tableId = getTemplateSrv().replace(processedQuery.tableId, scopedVars);
     const metadata = await this.getTableMetadata(processedQuery.tableId);

--- a/src/datasources/data-frame/components/DataFrameQueryEditor.tsx
+++ b/src/datasources/data-frame/components/DataFrameQueryEditor.tsx
@@ -138,15 +138,14 @@ const getVariableOptions = () => {
 };
 
 const tooltips = {
-  queryType: `Data allows you to visualize the rows of data in a table. Metadata allows you
-              to visualize the properties associated with a table.`,
+  queryType: `Specifies whether to visualize the data rows or properties associated with a table.`,
 
   columns: `Specifies the columns to include in the response data.`,
 
   decimation: `Specifies the method used to decimate the data.`,
 
-  filterNulls: `Filters out null and NaN values before decimating the data.`,
+  filterNulls: `Specifies whether to filter out null and NaN values before decimating the data.`,
 
-  useTimeRange: `Queries only for data within the dashboard time range if the table index is a
-                timestamp. Enable when interacting with your data on a graph.`,
+  useTimeRange: `Specifies whether to query only for data within the dashboard time range if the
+                table index is a timestamp. Enable when interacting with your data on a graph.`,
 };

--- a/src/datasources/data-frame/types.ts
+++ b/src/datasources/data-frame/types.ts
@@ -1,6 +1,12 @@
 import { DataQuery } from '@grafana/schema';
 
+export enum DataFrameQueryType {
+  Data = 'Data',
+  Metadata = 'Metadata',
+}
+
 export interface DataFrameQuery extends DataQuery {
+  type: DataFrameQueryType;
   tableId?: string;
   columns?: string[];
   decimationMethod?: string;
@@ -9,6 +15,7 @@ export interface DataFrameQuery extends DataQuery {
 }
 
 export const defaultQuery: Omit<ValidDataFrameQuery, 'refId'> = {
+  type: DataFrameQueryType.Data,
   tableId: '',
   columns: [],
   decimationMethod: 'LOSSY',
@@ -46,6 +53,7 @@ export interface TableMetadata {
   id: string;
   name: string;
   workspace: string;
+  properties: Record<string, string>;
 }
 
 export interface TableMetadataList {
@@ -55,7 +63,6 @@ export interface TableMetadataList {
 
 export interface TableDataRows {
   frame: { columns: string[]; data: string[][] };
-  continuationToken: string;
 }
 
 export interface SystemLinkError {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://dev.azure.com/ni/DevCentral/_workitems/edit/2566752

## 👩‍💻 Implementation

- Added a new field to the data frame query model, `type`. "Data" is the original behavior of the plugin and "Metadata" is a new mode that returns a table's properties as a data frame with two fields: name and value.
- I did some refactoring while prototyping. The major things were:
  - Cleaned up the data conversion logic to not rely on the transform built in to Grafana (it didn't work for booleans and had an awkward API)
  - Added logic to the fake routes in the tests to better match what the actual service does. We were returning all of the columns of fake data in every test, which wasn't technically correct.

## 🧪 Testing

- Added a unit test for the metadata query

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).