### PR TITLE
feat(dataframe): Column variable support

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -2,6 +2,7 @@ import { SelectableValue } from '@grafana/data';
 import { useAsync } from 'react-use';
 import { DataSourceBase } from './DataSourceBase';
 import { Workspace } from './types';
+import { TemplateSrv } from '@grafana/runtime';
 
 export function enumToOptions<T>(stringEnum: { [name: string]: T }): Array<SelectableValue<T>> {
   const RESULT = [];
@@ -61,4 +62,23 @@ export function getWorkspaceName(workspaces: Workspace[], id: string) {
  */
 export function sleep(timeout: number) {
   return new Promise(res => window.setTimeout(res, timeout));
+}
+
+/**
+ * Replace variables in an array of values.
+ * Useful for multi-value variables.
+ */
+export function replaceVariables(values: string[], templateSrv: TemplateSrv) {
+  const replaced: string[] = [];
+  values.forEach((col: string, index) => {
+    let value = col;
+    if (templateSrv.containsTemplate(col)) {
+      const variables = templateSrv.getVariables() as any[];
+      const variable = variables.find(v => v.name === col.split('$')[1]);
+      value = variable.current.value;
+    }
+    replaced.push(value);
+  });
+  // Dedupe and flatten
+  return [...new Set(replaced.flat())];
 }

--- a/src/datasources/data-frame/DataFrameDataSource.test.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.test.ts
@@ -227,7 +227,7 @@ it('attempts to replace variables in data query', async () => {
 });
 
 it('metricFindQuery returns table columns', async () => {
-  const tableId = '12345';
+  const tableId = '1';
   const expectedColumns = fakeMetadataResponse.columns.map(col => ({ text: col.name, value: col.name }));
 
   const columns = await ds.metricFindQuery({ tableId } as DataFrameQuery);

--- a/src/datasources/data-frame/components/DataFrameQueryEditor.tsx
+++ b/src/datasources/data-frame/components/DataFrameQueryEditor.tsx
@@ -1,58 +1,29 @@
 import React, { useState } from 'react';
 import { useAsync } from 'react-use';
-import { CoreApp, QueryEditorProps, SelectableValue, toOption } from '@grafana/data';
-import { DataFrameDataSource } from '../DataFrameDataSource';
-import { DataFrameQuery } from '../types';
-import { InlineField, InlineSwitch, MultiSelect, Select, AsyncSelect, LoadOptionsCallback } from '@grafana/ui';
+import { SelectableValue, toOption } from '@grafana/data';
+import { InlineField, InlineSwitch, MultiSelect, Select, AsyncSelect } from '@grafana/ui';
 import { decimationMethods } from '../constants';
 import _ from 'lodash';
 import { getTemplateSrv } from '@grafana/runtime';
 import { isValidId } from '../utils';
 import { FloatingError, parseErrorMessage } from '../errors';
-import { getWorkspaceName } from 'core/utils';
-
-type Props = QueryEditorProps<DataFrameDataSource, DataFrameQuery>;
+import { DataFrameQueryEditorCommon, Props } from './DataFrameQueryEditorCommon';
 
 export const DataFrameQueryEditor = (props: Props) => {
-  const { datasource, onChange } = props;
-  const query = datasource.processQuery(props.query);
-  const onRunQuery = () => props.app !== CoreApp.Explore && props.onRunQuery();
-
   const [errorMsg, setErrorMsg] = useState<string>('');
   const handleError = (error: Error) => setErrorMsg(parseErrorMessage(error));
-
-  const tableMetadata = useAsync(() => datasource.getTableMetadata(query.tableId).catch(handleError), [query.tableId]);
-
-  const handleQueryChange = (value: DataFrameQuery, runQuery: boolean) => {
-    onChange(value);
-    if (runQuery) {
-      onRunQuery();
-    }
-  };
-
-  const handleIdChange = (item: SelectableValue<string>) => {
-    if (query.tableId !== item.value) {
-      handleQueryChange({ ...query, tableId: item.value, columns: [] }, false);
-    }
-  };
+  const common = new DataFrameQueryEditorCommon(props, handleError);
+  const tableMetadata = useAsync(() => common.datasource.getTableMetadata(common.query.tableId).catch(handleError), [common.query.tableId]);
 
   const handleColumnChange = (items: Array<SelectableValue<string>>) => {
-    handleQueryChange({ ...query, columns: items.map(i => i.value!) }, false);
+    common.handleQueryChange({ ...common.query, columns: items.map(i => i.value!) }, false);
   };
 
-  const loadTableOptions = _.debounce((query: string, cb?: LoadOptionsCallback<string>) => {
-    Promise.all([datasource.queryTables(query), datasource.getWorkspaces()])
-      .then(([tables, workspaces]) => cb?.(tables.map((t) => ({ label: t.name, value: t.id, title: t.id, description: getWorkspaceName(workspaces, t.workspace) }))))
-      .catch(handleError);
-  }, 300);
-
-  const handleLoadOptions = (query: string, cb?: LoadOptionsCallback<string>) => {
-    if (!query || query.startsWith('$')) {
-      return cb?.(getVariableOptions().filter((v) => v.value?.includes(query)));
-    }
-
-    loadTableOptions(query, cb);
-  };
+  const loadColumnOptions = () => {
+    const columnOptions = (tableMetadata.value?.columns ?? []).map(c => toOption(c.name));
+    columnOptions.unshift(...getVariableOptions());
+    return columnOptions;
+  }
 
   return (
     <div style={{ position: 'relative' }}>
@@ -63,33 +34,33 @@ export const DataFrameQueryEditor = (props: Props) => {
           cacheOptions={false}
           defaultOptions
           isValidNewOption={isValidId}
-          loadOptions={handleLoadOptions}
-          onChange={handleIdChange}
+          loadOptions={common.handleLoadOptions}
+          onChange={common.handleIdChange}
           placeholder="Search by name or enter id"
           width={30}
-          value={query.tableId ? toOption(query.tableId) : null}
+          value={common.query.tableId ? toOption(common.query.tableId) : null}
         />
       </InlineField>
       <InlineField label="Columns" shrink={true} tooltip="Specifies the columns to include in the response data.">
         <MultiSelect
           isLoading={tableMetadata.loading}
-          options={(tableMetadata.value?.columns ?? []).map(c => toOption(c.name))}
+          options={loadColumnOptions()}
           onChange={handleColumnChange}
-          onBlur={onRunQuery}
-          value={(query.columns).map(toOption)}
+          onBlur={common.onRunQuery}
+          value={(common.query.columns).map(toOption)}
         />
       </InlineField>
       <InlineField label="Decimation" tooltip="Specifies the method used to decimate the data.">
         <Select
           options={decimationMethods}
-          onChange={(item) => handleQueryChange({ ...query, decimationMethod: item.value! }, true)}
-          value={query.decimationMethod}
+          onChange={(item) => common.handleQueryChange({ ...common.query, decimationMethod: item.value! }, true)}
+          value={common.query.decimationMethod}
         />
       </InlineField>
       <InlineField label="Filter nulls" tooltip="Filters out null and NaN values before decimating the data.">
         <InlineSwitch
-          value={query.filterNulls}
-          onChange={(event) => handleQueryChange({ ...query, filterNulls: event.currentTarget.checked }, true)}
+          value={common.query.filterNulls}
+          onChange={(event) => common.handleQueryChange({ ...common.query, filterNulls: event.currentTarget.checked }, true)}
         ></InlineSwitch>
       </InlineField>
       <InlineField
@@ -97,8 +68,8 @@ export const DataFrameQueryEditor = (props: Props) => {
         tooltip="Queries only for data within the dashboard time range if the table index is a timestamp. Enable when interacting with your data on a graph."
       >
         <InlineSwitch
-          value={query.applyTimeFilters}
-          onChange={(event) => handleQueryChange({ ...query, applyTimeFilters: event.currentTarget.checked }, true)}
+          value={common.query.applyTimeFilters}
+          onChange={(event) => common.handleQueryChange({ ...common.query, applyTimeFilters: event.currentTarget.checked }, true)}
         ></InlineSwitch>
       </InlineField>
       <FloatingError message={errorMsg} />

--- a/src/datasources/data-frame/components/DataFrameQueryEditor.tsx
+++ b/src/datasources/data-frame/components/DataFrameQueryEditor.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
 import { useAsync } from 'react-use';
 import { SelectableValue, toOption } from '@grafana/data';
-import { InlineField, InlineSwitch, MultiSelect, Select, AsyncSelect } from '@grafana/ui';
+import { InlineField, InlineSwitch, MultiSelect, Select, AsyncSelect, RadioButtonGroup } from '@grafana/ui';
 import { decimationMethods } from '../constants';
 import _ from 'lodash';
 import { getTemplateSrv } from '@grafana/runtime';
 import { isValidId } from '../utils';
 import { FloatingError, parseErrorMessage } from '../errors';
 import { DataFrameQueryEditorCommon, Props } from './DataFrameQueryEditorCommon';
+import { enumToOptions } from 'core/utils';
+import { DataFrameQueryType } from '../types';
 
 export const DataFrameQueryEditor = (props: Props) => {
   const [errorMsg, setErrorMsg] = useState<string>('');
@@ -30,8 +32,8 @@ export const DataFrameQueryEditor = (props: Props) => {
       <InlineField label="Query type" tooltip={tooltips.queryType}>
         <RadioButtonGroup
           options={enumToOptions(DataFrameQueryType)}
-          value={query.type}
-          onChange={value => handleQueryChange({ ...query, type: value }, true)}
+          value={common.query.type}
+          onChange={value => common.handleQueryChange({ ...common.query, type: value }, true)}
         />
       </InlineField>
       <InlineField label="Id">
@@ -48,37 +50,38 @@ export const DataFrameQueryEditor = (props: Props) => {
           value={common.query.tableId ? toOption(common.query.tableId) : null}
         />
       </InlineField>
-      <InlineField label="Columns" shrink={true} tooltip="Specifies the columns to include in the response data.">
-        <MultiSelect
-          isLoading={tableMetadata.loading}
-          options={loadColumnOptions()}
-          onChange={handleColumnChange}
-          onBlur={common.onRunQuery}
-          value={(common.query.columns).map(toOption)}
-        />
-      </InlineField>
-      <InlineField label="Decimation" tooltip="Specifies the method used to decimate the data.">
-        <Select
-          options={decimationMethods}
-          onChange={(item) => common.handleQueryChange({ ...common.query, decimationMethod: item.value! }, true)}
-          value={common.query.decimationMethod}
-        />
-      </InlineField>
-      <InlineField label="Filter nulls" tooltip="Filters out null and NaN values before decimating the data.">
-        <InlineSwitch
-          value={common.query.filterNulls}
-          onChange={(event) => common.handleQueryChange({ ...common.query, filterNulls: event.currentTarget.checked }, true)}
-        ></InlineSwitch>
-      </InlineField>
-      <InlineField
-        label="Use time range"
-        tooltip="Queries only for data within the dashboard time range if the table index is a timestamp. Enable when interacting with your data on a graph."
-      >
-        <InlineSwitch
-          value={common.query.applyTimeFilters}
-          onChange={(event) => common.handleQueryChange({ ...common.query, applyTimeFilters: event.currentTarget.checked }, true)}
-        ></InlineSwitch>
-      </InlineField>
+      {common.query.type === DataFrameQueryType.Data && (
+        <>
+          <InlineField label="Columns" shrink={true} tooltip={tooltips.columns}>
+            <MultiSelect
+              isLoading={tableMetadata.loading}
+              options={loadColumnOptions()}
+              onChange={handleColumnChange}
+              onBlur={common.onRunQuery}
+              value={common.query.columns.map(toOption)}
+            />
+          </InlineField>
+          <InlineField label="Decimation" tooltip={tooltips.decimation}>
+            <Select
+              options={decimationMethods}
+              onChange={item => common.handleQueryChange({ ...common.query, decimationMethod: item.value! }, true)}
+              value={common.query.decimationMethod}
+            />
+          </InlineField>
+          <InlineField label="Filter nulls" tooltip={tooltips.filterNulls}>
+            <InlineSwitch
+              value={common.query.filterNulls}
+              onChange={event => common.handleQueryChange({ ...common.query, filterNulls: event.currentTarget.checked }, true)}
+            ></InlineSwitch>
+          </InlineField>
+          <InlineField label="Use time range" tooltip={tooltips.useTimeRange}>
+            <InlineSwitch
+              value={common.query.applyTimeFilters}
+              onChange={event => common.handleQueryChange({ ...common.query, applyTimeFilters: event.currentTarget.checked }, true)}
+            ></InlineSwitch>
+          </InlineField>
+        </>
+      )}
       <FloatingError message={errorMsg} />
     </div>
   );

--- a/src/datasources/data-frame/components/DataFrameQueryEditorCommon.tsx
+++ b/src/datasources/data-frame/components/DataFrameQueryEditorCommon.tsx
@@ -1,0 +1,51 @@
+import { QueryEditorProps, CoreApp, SelectableValue } from "@grafana/data";
+import { LoadOptionsCallback } from "@grafana/ui";
+import { getWorkspaceName, getVariableOptions } from "core/utils";
+import _ from "lodash";
+import { DataFrameDataSource } from "../DataFrameDataSource";
+import { DataFrameQuery, ValidDataFrameQuery } from "../types";
+
+export type Props = QueryEditorProps<DataFrameDataSource, DataFrameQuery>;
+
+export class DataFrameQueryEditorCommon {
+  readonly datasource: DataFrameDataSource;
+  readonly onChange: (value: DataFrameQuery) => void;
+  readonly query: ValidDataFrameQuery;
+  readonly onRunQuery: () => false | void;
+  readonly handleError: (error: Error) => void;
+
+  constructor(readonly props: Props, readonly errorHandler: (error: Error) => void) {
+    this.datasource = props.datasource;
+    this.onChange = props.onChange;
+    this.query = this.datasource.processQuery(props.query);
+    this.onRunQuery = () => props.app !== CoreApp.Explore && props.onRunQuery();
+    this.handleError = errorHandler;
+  }
+
+  readonly handleQueryChange = (value: DataFrameQuery, runQuery: boolean) => {
+    this.onChange(value);
+    if (runQuery) {
+      this.onRunQuery();
+    }
+  };
+
+  readonly handleIdChange = (item: SelectableValue<string>) => {
+    if (this.query.tableId !== item.value) {
+      this.handleQueryChange({ ...this.query, tableId: item.value, columns: [] }, false);
+    }
+  };
+
+  readonly loadTableOptions = _.debounce((query: string, cb?: LoadOptionsCallback<string>) => {
+    Promise.all([this.datasource.queryTables(query), this.datasource.getWorkspaces()])
+      .then(([tables, workspaces]) => cb?.(tables.map((t) => ({ label: t.name, value: t.id, title: t.id, description: getWorkspaceName(workspaces, t.workspace) }))))
+      .catch(this.handleError);
+  }, 300);
+
+  readonly handleLoadOptions = (query: string, cb?: LoadOptionsCallback<string>) => {
+    if (!query || query.startsWith('$')) {
+      return cb?.(getVariableOptions(this.datasource).filter((v) => v.value?.includes(query)));
+    }
+
+    this.loadTableOptions(query, cb);
+  };
+}

--- a/src/datasources/data-frame/components/DataFrameQueryEditorCommon.tsx
+++ b/src/datasources/data-frame/components/DataFrameQueryEditorCommon.tsx
@@ -3,7 +3,7 @@ import { LoadOptionsCallback } from "@grafana/ui";
 import { getWorkspaceName, getVariableOptions } from "core/utils";
 import _ from "lodash";
 import { DataFrameDataSource } from "../DataFrameDataSource";
-import { DataFrameQuery, ValidDataFrameQuery } from "../types";
+import { DataFrameQuery, DataFrameQueryType, ValidDataFrameQuery } from "../types";
 
 export type Props = QueryEditorProps<DataFrameDataSource, DataFrameQuery>;
 
@@ -31,14 +31,23 @@ export class DataFrameQueryEditorCommon {
 
   readonly handleIdChange = (item: SelectableValue<string>) => {
     if (this.query.tableId !== item.value) {
-      this.handleQueryChange({ ...this.query, tableId: item.value, columns: [] }, false);
+      this.handleQueryChange({ ...this.query, tableId: item.value, columns: [] }, this.query.type === DataFrameQueryType.Metadata);
     }
   };
 
   readonly loadTableOptions = _.debounce((query: string, cb?: LoadOptionsCallback<string>) => {
     Promise.all([this.datasource.queryTables(query), this.datasource.getWorkspaces()])
-      .then(([tables, workspaces]) => cb?.(tables.map((t) => ({ label: t.name, value: t.id, title: t.id, description: getWorkspaceName(workspaces, t.workspace) }))))
-      .catch(this.handleError);
+      .then(([tables, workspaces]) =>
+      cb?.(
+        tables.map(t => ({
+          label: t.name,
+          value: t.id,
+          title: t.id,
+          description: getWorkspaceName(workspaces, t.workspace),
+        }))
+      )
+    )
+    .catch(this.handleError);
   }, 300);
 
   readonly handleLoadOptions = (query: string, cb?: LoadOptionsCallback<string>) => {

--- a/src/datasources/data-frame/components/DataFrameVariableQueryEditor.test.tsx
+++ b/src/datasources/data-frame/components/DataFrameVariableQueryEditor.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { select } from 'react-select-event';
+import { setupDataSource } from 'test/fixtures';
+import { DataFrameDataSource } from '../DataFrameDataSource';
+import { DataFrameVariableQueryEditor } from './DataFrameVariableQueryEditor';
+import { DataFrameQuery } from '../types';
+
+const onChange = jest.fn();
+const onRunQuery = jest.fn();
+const [datasource] = setupDataSource(DataFrameDataSource);
+
+test('renders with no data table selected', async () => {
+  render(<DataFrameVariableQueryEditor {...{ onChange, onRunQuery, datasource, query: '' as unknown as  DataFrameQuery }} />);
+
+  expect(screen.getByRole('combobox')).toHaveAccessibleDescription('Search by name or enter id');
+});
+
+test('populates data table drop-down with variables', async () => {
+  render(<DataFrameVariableQueryEditor {...{ onChange, onRunQuery, datasource, query: { tableId: '$test_var' } as DataFrameQuery }} />);
+
+  expect(screen.getByText('$test_var')).toBeInTheDocument();
+});
+
+test('user selects new data table', async () => {
+  render(<DataFrameVariableQueryEditor {...{ onChange, onRunQuery, datasource, query: '' as unknown as DataFrameQuery }} />);
+
+  await select(screen.getByRole('combobox'), '$test_var', { container: document.body });
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ tableId: '$test_var' }));
+});
+

--- a/src/datasources/data-frame/components/DataFrameVariableQueryEditor.tsx
+++ b/src/datasources/data-frame/components/DataFrameVariableQueryEditor.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { AsyncSelect } from '@grafana/ui';
+import { InlineField } from 'core/components/InlineField';
+import { toOption } from '@grafana/data';
+import { isValidId } from '../utils';
+import _ from 'lodash';
+import { FloatingError, parseErrorMessage } from '../errors';
+import { DataFrameQueryEditorCommon, Props } from './DataFrameQueryEditorCommon';
+
+export function DataFrameVariableQueryEditor(props: Props) {
+  const [errorMsg, setErrorMsg] = useState<string>('');
+  const handleError = (error: Error) => setErrorMsg(parseErrorMessage(error));
+  const common = new DataFrameQueryEditorCommon(props, handleError);
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <InlineField label="Id">
+        <AsyncSelect
+          allowCreateWhileLoading
+          allowCustomValue
+          cacheOptions={false}
+          defaultOptions
+          isValidNewOption={isValidId}
+          loadOptions={common.handleLoadOptions}
+          onChange={common.handleIdChange}
+          placeholder="Search by name or enter id"
+          width={30}
+          value={common.query.tableId ? toOption(common.query.tableId) : null}
+        />
+      </InlineField>
+      <FloatingError message={errorMsg} />
+    </div>
+  );
+};

--- a/src/datasources/data-frame/module.ts
+++ b/src/datasources/data-frame/module.ts
@@ -2,7 +2,9 @@ import { DataSourcePlugin } from '@grafana/data';
 import { DataFrameDataSource } from './DataFrameDataSource';
 import { DataFrameQueryEditor } from './components/DataFrameQueryEditor';
 import { HttpConfigEditor } from 'core/components/HttpConfigEditor';
+import { DataFrameVariableQueryEditor } from './components/DataFrameVariableQueryEditor';
 
 export const plugin = new DataSourcePlugin(DataFrameDataSource)
   .setConfigEditor(HttpConfigEditor)
-  .setQueryEditor(DataFrameQueryEditor);
+  .setQueryEditor(DataFrameQueryEditor)
+  .setVariableQueryEditor(DataFrameVariableQueryEditor);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://ni.visualstudio.com/DevCentral/_workitems/edit/2566754

## 👩‍💻 Implementation

- Added variable support to query editor columns field.
- Added variable query editor to data frame data source that displays a table id field. This field also supports variables. Implemented `metricFindQuery` to return the selected tables columns.
- Since the data frame query editor and variable query editor shared the majority of their logic, this was split out to a helper class that is accessed by both.

## 🧪 Testing

- Verified functionality locally
- Added new tests and existing tests continue to pass

## ✅ Checklist

- [X] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).