### PR TITLE
fix(dataframe): switch orientation of metadata frame

### DIFF
--- a/src/datasources/data-frame/DataFrameDataSource.test.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.test.ts
@@ -243,8 +243,8 @@ it('returns table properties for metadata query', async () => {
 
   expect(fetchMock).toHaveBeenCalledWith(expect.objectContaining({ url: '_/nidataframe/v1/tables/1' }));
   expect(response.data[0].fields).toEqual([
-    { name: 'name', values: ['hello', 'foo'] },
-    { name: 'value', values: ['world', 'bar'] },
+    { name: 'hello', values: ['world'] },
+    { name: 'foo', values: ['bar'] },
   ])
 });
 
@@ -253,12 +253,8 @@ it('handles metadata query when table has no properties', async () => {
 
   const response = await ds.query(query);
 
-  console.log(fetchMock.mock.calls)
   expect(fetchMock).toHaveBeenCalledWith(expect.objectContaining({ url: '_/nidataframe/v1/tables/2' }));
-  expect(response.data[0].fields).toEqual([
-    { name: 'name', values: [] },
-    { name: 'value', values: [] },
-  ])
+  expect(response.data[0].fields).toEqual([]);
 });
 
 const buildQuery = (targets: DataFrameQuery[]): DataQueryRequest<DataFrameQuery> => {

--- a/src/datasources/data-frame/DataFrameDataSource.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.ts
@@ -44,10 +44,7 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery> {
       return {
         refId: processedQuery.refId,
         name: metadata.name,
-        fields: [
-          { name: 'name', values: Object.keys(metadata.properties) },
-          { name: 'value', values: Object.values(metadata.properties) },
-        ],
+        fields: Object.entries(metadata.properties).map(([name, value]) => ({ name, values: [value] })),
       };
     } else {
       const columns = this.getColumnTypes(processedQuery.columns, metadata?.columns ?? []);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The format of the metadata table returned from the data frame plugin is incorrect. It's returning a row for each property, but we want a field for each property:

![image](https://github.com/ni/systemlink-grafana-plugins/assets/9257800/561e6bab-f44d-4c99-b61b-d6382b058ce2)


## 👩‍💻 Implementation

- Transposed the data frame returned by the metadata query

## 🧪 Testing

- Updated the existing tests

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).