### PR TITLE
fix(system): Run query on initial load

### DIFF
--- a/src/datasources/system/components/SystemQueryEditor.tsx
+++ b/src/datasources/system/components/SystemQueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent } from 'react';
+import React, { FormEvent, useEffect } from 'react';
 import { AutoSizeInput, RadioButtonGroup, Select } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { SystemDataSource } from '../SystemDataSource';
@@ -10,6 +10,14 @@ type Props = QueryEditorProps<SystemDataSource, SystemQuery>;
 
 export function SystemQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   query = datasource.prepareQuery(query);
+
+  useEffect(() => {
+    if (query.queryKind === SystemQueryType.Summary) {
+      onChange(query);
+      onRunQuery();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Only run on mount
 
   const workspaces = useWorkspaceOptions(datasource);
 

--- a/src/datasources/workspace/components/WorkspaceQueryEditor.tsx
+++ b/src/datasources/workspace/components/WorkspaceQueryEditor.tsx
@@ -6,12 +6,11 @@ import { WorkspaceDataSource } from '../WorkspaceDataSource';
 type Props = QueryEditorProps<WorkspaceDataSource, WorkspaceQuery>;
 
 export function WorkspaceQueryEditor({ query, onChange, onRunQuery }: Props) {
-  // useEffect(onRunQuery, [onRunQuery]);
-
-  // query = datasource.prepareQuery(query);
-
   useEffect(() => {
-    onChange(query);
+    // The "init" property is required for the initial query in Explore to work since the query
+    // only runs if a change to a property is detected. It otherwise has no use and can be removed
+    // if a property is added to "WorkspaceQuery".
+    onChange(Object.assign({ init: true }, query));
     onRunQuery();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);  // Only run on mount

--- a/src/datasources/workspace/components/WorkspaceQueryEditor.tsx
+++ b/src/datasources/workspace/components/WorkspaceQueryEditor.tsx
@@ -5,8 +5,16 @@ import { WorkspaceDataSource } from '../WorkspaceDataSource';
 
 type Props = QueryEditorProps<WorkspaceDataSource, WorkspaceQuery>;
 
-export function WorkspaceQueryEditor({ onRunQuery }: Props) {
-  useEffect(onRunQuery, [onRunQuery]);
+export function WorkspaceQueryEditor({ query, onChange, onRunQuery }: Props) {
+  // useEffect(onRunQuery, [onRunQuery]);
+
+  // query = datasource.prepareQuery(query);
+
+  useEffect(() => {
+    onChange(query);
+    onRunQuery();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);  // Only run on mount
 
   return (
     <span>This data source returns all SystemLink workspaces and does not include a query editor.</span>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://ni.visualstudio.com/DevCentral/_workitems/edit/2598196

## 👩‍💻 Implementation

- Call `useEffect` to force a query on init
- Also fixed a related issue in the Workspace data source

## 🧪 Testing

- Verified functionality locally
- Tests and linter pass

## ✅ Checklist

- [X] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).