### PR TITLE
chore: don't emit eslint warnings in PR build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm run typecheck
 
       - name: Lint
-        run: npm run lint
+        run: npm run lint -- --quiet
 
       - name: Unit tests
         run: npm run test:ci


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

eslint is producing some warnings because of deprecations. We should fix these at some point, but until then it's cluttering up the PR review because of a new GitHub feature that can't be disabled 😐

<img width="990" alt="image" src="https://github.com/ni/systemlink-grafana-plugins/assets/9257800/b485937f-e0b4-4ca4-8010-5ebeeaf1d479">

## 👩‍💻 Implementation

- Pass the `--quiet` flag to eslint in the PR workflow

## 🧪 Testing

- Ran command locally and verified it does what we expect

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).