### PR TITLE
feat(tag): visualize history of multiple tags

### DIFF
--- a/src/datasources/tag/TagDataSource.test.ts
+++ b/src/datasources/tag/TagDataSource.test.ts
@@ -275,7 +275,7 @@ describe('queries', () => {
     expect(result.data).toMatchSnapshot();
   });
 
-  test('history of tags from different workspaces', async () => {
+  test('add workspace prefix only when a tag with the same path exists in multiple workspaces', async () => {
     const queryRequest = buildQuery({ type: TagQueryType.History, path: 'my.tag.*' });
 
     backendSrv.fetch
@@ -283,6 +283,8 @@ describe('queries', () => {
       .mockReturnValue(createQueryTagsResponse([
         { tag: { path: 'my.tag.1', workspace: '1' } },
         { tag: { path: 'my.tag.2', workspace: '1' } },
+        { tag: { path: 'my.tag.1', workspace: '2' } },
+        { tag: { path: 'my.tag.2', workspace: '2' } },
         { tag: { path: 'my.tag.3', workspace: '2' } },
         { tag: { path: 'my.tag.4', workspace: '2' } }
       ]));
@@ -325,7 +327,7 @@ describe('queries', () => {
       requestMatching({
         url: '/nitaghistorian/v2/tags/query-decimated-history',
         data: {
-          paths: ['my.tag.3', 'my.tag.4'],
+          paths: ['my.tag.1', 'my.tag.2', 'my.tag.3', 'my.tag.4'],
           workspace: '2',
           startTime: queryRequest.range.from.toISOString(),
           endTime: queryRequest.range.to.toISOString(),
@@ -335,6 +337,22 @@ describe('queries', () => {
     )
       .mockReturnValue(
         createTagHistoryResponse([
+          {
+            path: 'my.tag.1',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '1' },
+              { timestamp: '2023-01-01T00:01:00Z', value: '2' },
+            ],
+          },
+          {
+            path: 'my.tag.2',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '2' },
+              { timestamp: '2023-01-01T00:01:00Z', value: '3' },
+            ]
+          },
           {
             path: 'my.tag.3',
             type: TagDataType.DOUBLE,

--- a/src/datasources/tag/TagDataSource.test.ts
+++ b/src/datasources/tag/TagDataSource.test.ts
@@ -275,6 +275,90 @@ describe('queries', () => {
     expect(result.data).toMatchSnapshot();
   });
 
+  test('history of tags from different workspaces', async () => {
+    const queryRequest = buildQuery({ type: TagQueryType.History, path: 'my.tag.*' });
+
+    backendSrv.fetch
+      .calledWith(requestMatching({ url: '/nitag/v2/query-tags-with-values', data: { filter: 'path = "my.tag.*"' } }))
+      .mockReturnValue(createQueryTagsResponse([
+        { tag: { path: 'my.tag.1', workspace: '1' } },
+        { tag: { path: 'my.tag.2', workspace: '1' } },
+        { tag: { path: 'my.tag.3', workspace: '2' } },
+        { tag: { path: 'my.tag.4', workspace: '2' } }
+      ]));
+
+    backendSrv.fetch
+      .calledWith(
+        requestMatching({
+          url: '/nitaghistorian/v2/tags/query-decimated-history',
+          data: {
+            paths: ['my.tag.1', 'my.tag.2'],
+            workspace: '1',
+            startTime: queryRequest.range.from.toISOString(),
+            endTime: queryRequest.range.to.toISOString(),
+            decimation: 300,
+          },
+        })
+      )
+      .mockReturnValue(
+        createTagHistoryResponse([
+          {
+            path: 'my.tag.1',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '1' },
+              { timestamp: '2023-01-01T00:01:00Z', value: '2' },
+            ],
+          },
+          {
+            path: 'my.tag.2',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '2' },
+              { timestamp: '2023-01-01T00:01:00Z', value: '3' },
+            ]
+          }
+        ])
+      )
+
+    backendSrv.fetch.calledWith(
+      requestMatching({
+        url: '/nitaghistorian/v2/tags/query-decimated-history',
+        data: {
+          paths: ['my.tag.3', 'my.tag.4'],
+          workspace: '2',
+          startTime: queryRequest.range.from.toISOString(),
+          endTime: queryRequest.range.to.toISOString(),
+          decimation: 300,
+        },
+      })
+    )
+      .mockReturnValue(
+        createTagHistoryResponse([
+          {
+            path: 'my.tag.3',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '3' },
+              { timestamp: '2023-01-01T00:01:00Z', value: '4' },
+            ],
+          },
+          {
+            path: 'my.tag.4',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '4' },
+              { timestamp: '2023-01-01T00:01:00Z', value: '5' },
+            ]
+          }
+        ])
+      )
+
+    const result = await ds.query(queryRequest);
+
+    expect(result.data).toMatchSnapshot();
+  });
+
   test('decimation parameter does not go above 1000', async () => {
     const queryRequest = buildQuery({ type: TagQueryType.History, path: 'my.tag' });
     queryRequest.maxDataPoints = 1500;

--- a/src/datasources/tag/TagDataSource.test.ts
+++ b/src/datasources/tag/TagDataSource.test.ts
@@ -12,7 +12,7 @@ import {
   setupDataSource,
 } from 'test/fixtures';
 import { TagDataSource } from './TagDataSource';
-import { TagQuery, TagQueryType, TagWithValue } from './types';
+import { TagQuery, TagQueryType, TagWithValue, TagDataType } from './types';
 
 let ds: TagDataSource, backendSrv: MockProxy<BackendSrv>, templateSrv: MockProxy<TemplateSrv>;
 
@@ -124,24 +124,24 @@ describe('queries', () => {
   test('current value for all data types', async () => {
     backendSrv.fetch
       .mockReturnValueOnce(createQueryTagsResponse([{
-        tag: { type: 'INT', path: 'tag1' },
+        tag: { type: TagDataType.INT, path: 'tag1' },
         current: { value: { value: '3' } }
       }]))
       .mockReturnValueOnce(createQueryTagsResponse([{
-        tag: { type: 'DOUBLE', path: 'tag2' },
+        tag: { type: TagDataType.DOUBLE, path: 'tag2' },
         current: { value: { value: '3.3' } }
       }]))
       .mockReturnValueOnce(createQueryTagsResponse([{
-        tag: { type: 'STRING', path: 'tag3' },
+        tag: { type: TagDataType.STRING, path: 'tag3' },
         current: { value: { value: 'foo' } }
       }]))
       .mockReturnValueOnce(createQueryTagsResponse([{
-        tag: { type: 'BOOLEAN', path: 'tag4' },
+        tag: { type: TagDataType.BOOLEAN, path: 'tag4' },
         current: { value: { value: 'True' } }
       }]))
       .mockReturnValueOnce(
         createQueryTagsResponse([{
-          tag: { type: 'U_INT64', path: 'tag5' },
+          tag: { type: TagDataType.U_INT64, path: 'tag5' },
           current: { value: { value: '2147483648' } }
         }])
       );
@@ -180,9 +180,73 @@ describe('queries', () => {
         })
       )
       .mockReturnValue(
-        createTagHistoryResponse('my.tag', 'DOUBLE', [
-          { timestamp: '2023-01-01T00:00:00Z', value: '1' },
-          { timestamp: '2023-01-01T00:01:00Z', value: '2' },
+        createTagHistoryResponse([
+          {
+            path: 'my.tag',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '1' },
+              { timestamp: '2023-01-01T00:01:00Z', value: '2' },
+            ]
+          }
+        ])
+      );
+
+    const result = await ds.query(queryRequest);
+
+    expect(result.data).toMatchSnapshot();
+  });
+
+  test('numeric multiple tags history', async () => {
+    const queryRequest = buildQuery({ type: TagQueryType.History, path: 'my.tag.*' });
+
+    backendSrv.fetch
+      .calledWith(requestMatching({ url: '/nitag/v2/query-tags-with-values', data: { filter: 'path = "my.tag.*"' } }))
+      .mockReturnValue(createQueryTagsResponse([
+        { tag: { path: 'my.tag.1' } },
+        { tag: { path: 'my.tag.2' } },
+        { tag: { path: 'my.tag.3' } }
+      ]));
+
+    backendSrv.fetch
+      .calledWith(
+        requestMatching({
+          url: '/nitaghistorian/v2/tags/query-decimated-history',
+          data: {
+            paths: ['my.tag.1', 'my.tag.2', 'my.tag.3'],
+            workspace: '1',
+            startTime: queryRequest.range.from.toISOString(),
+            endTime: queryRequest.range.to.toISOString(),
+            decimation: 300,
+          },
+        })
+      )
+      .mockReturnValue(
+        createTagHistoryResponse([
+          {
+            path: 'my.tag.1',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '1' },
+              { timestamp: '2023-01-01T00:01:00Z', value: '2' },
+            ]
+          },
+          {
+            path: 'my.tag.2',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '2' },
+              { timestamp: '2023-01-01T00:01:00Z', value: '3' },
+            ]
+          },
+          {
+            path: 'my.tag.3',
+            type: TagDataType.DOUBLE,
+            values: [
+              { timestamp: '2023-01-01T00:00:00Z', value: '3' },
+              { timestamp: '2023-01-01T00:02:00Z', value: '4' },
+            ]
+          }
         ])
       );
 
@@ -194,9 +258,15 @@ describe('queries', () => {
   test('string tag history', async () => {
     backendSrv.fetch.mockReturnValueOnce(createQueryTagsResponse());
     backendSrv.fetch.mockReturnValueOnce(
-      createTagHistoryResponse('my.tag', 'STRING', [
-        { timestamp: '2023-01-01T00:00:00Z', value: '3.14' },
-        { timestamp: '2023-01-01T00:01:00Z', value: 'foo' },
+      createTagHistoryResponse([
+        {
+          path: 'my.tag',
+          type: TagDataType.STRING,
+          values: [
+            { timestamp: '2023-01-01T00:00:00Z', value: '3.14' },
+            { timestamp: '2023-01-01T00:01:00Z', value: 'foo' },
+          ]
+        }
       ])
     );
 
@@ -212,9 +282,15 @@ describe('queries', () => {
     backendSrv.fetch.mockReturnValueOnce(createQueryTagsResponse());
 
     backendSrv.fetch.mockReturnValueOnce(
-      createTagHistoryResponse('my.tag', 'INT', [
-        { timestamp: '2023-01-01T00:00:00Z', value: '1' },
-        { timestamp: '2023-01-01T00:01:00Z', value: '2' },
+      createTagHistoryResponse([
+        {
+          path: 'my.tag',
+          type: TagDataType.INT,
+          values: [
+            { timestamp: '2023-01-01T00:00:00Z', value: '1' },
+            { timestamp: '2023-01-01T00:01:00Z', value: '2' },
+          ]
+        }
       ])
     );
 
@@ -236,7 +312,12 @@ describe('queries', () => {
 
   test('filters by workspace if provided', async () => {
     backendSrv.fetch.mockReturnValueOnce(createQueryTagsResponse([{ tag: { workspace: '2' } }]));
-    backendSrv.fetch.mockReturnValueOnce(createTagHistoryResponse('my.tag', 'DOUBLE', []));
+    backendSrv.fetch.mockReturnValueOnce(createTagHistoryResponse([{
+      path: 'my.tag',
+      type: TagDataType.DOUBLE,
+      values: []
+    }
+    ]));
 
     await ds.query(buildQuery({ type: TagQueryType.History, path: 'my.tag', workspace: '2' }));
 
@@ -247,7 +328,11 @@ describe('queries', () => {
   test('retries failed request with 429 status', async () => {
     backendSrv.fetch.mockReturnValueOnce(createQueryTagsResponse());
     backendSrv.fetch.mockReturnValueOnce(createFetchError(429));
-    backendSrv.fetch.mockReturnValueOnce(createTagHistoryResponse('my.tag', 'INT', []));
+    backendSrv.fetch.mockReturnValueOnce(createTagHistoryResponse([{
+      path: 'my.tag',
+      type: TagDataType.INT,
+      values: []
+    }]));
 
     await ds.query(buildQuery({ type: TagQueryType.History, path: 'my.tag' }));
 
@@ -299,7 +384,7 @@ describe('queries', () => {
           tagsWithValues: [{ tag: { datatype: 'DOUBLE', path: 'my.tag', workspace_id: '1' } }],
         })
       )
-      .mockReturnValueOnce(createTagHistoryResponse('my.tag', 'DOUBLE', []));
+      .mockReturnValueOnce(createTagHistoryResponse([{ path: 'my.tag', type: TagDataType.DOUBLE, values: [] }]));
 
     await ds.query(buildQuery({ path: 'my.tag', type: TagQueryType.History }));
 
@@ -352,12 +437,21 @@ function createQueryTagsResponse(
     return createFetchResponse({
       tagsWithValues: [{
         current: { value: { value: '3.14' }, timestamp: '2023-10-04T00:00:00.000000Z' },
-        tag: { type: 'DOUBLE', path: 'my.tag', properties: {}, workspace: '1' },
+        tag: { type: TagDataType.DOUBLE, path: 'my.tag', properties: {}, workspace: '1' },
       }],
     });
   }
 }
 
-function createTagHistoryResponse(path: string, type: string, values: Array<{ timestamp: string; value: string }>) {
-  return createFetchResponse({ results: { [path]: { type, values } } });
+
+function createTagHistoryResponse(tagsHistory: Array<{
+  path: string,
+  type: TagDataType,
+  values: Array<{ timestamp: string; value: string }>
+}>) {
+  const results: { [key: string]: { type: string, values: any[] } } = {};
+  tagsHistory.forEach(({ path, type, values }) => {
+    results[path] = { type, values };
+  });
+  return createFetchResponse({ results });
 }

--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -6,6 +6,7 @@ import {
   FieldType,
   TestDataSourceResponse,
   FieldConfig,
+  dateTime,
 } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
@@ -94,10 +95,10 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
         }
         workspaceTagMap[workspace].push(tagWithValue);
         const prefixedPath = tagPathCount[tagWithValue.tag.path] > 1
-            ? `${getWorkspaceName(workspaces, workspace)}.${tagWithValue.tag.path}`
-            : tagWithValue.tag.path;
+          ? `${getWorkspaceName(workspaces, workspace)}.${tagWithValue.tag.path}`
+          : tagWithValue.tag.path;
         tagPropertiesMap[prefixedPath] = tagWithValue.tag.properties;
-      };
+      }
 
       let tagsDecimatedHistory: { [key: string]: TypeAndValues } = {};
       for (const workspace in workspaceTagMap) {
@@ -117,7 +118,7 @@ export class TagDataSource extends DataSourceBase<TagQuery> {
 
       const mergedTagValuesWithType = this.mergeTagsHistoryValues(tagsDecimatedHistory);
       result.fields.push({
-        name: 'time', values: mergedTagValuesWithType.timestamps, type: FieldType.time
+        name: 'time', values: mergedTagValuesWithType.timestamps.map(v => dateTime(v).valueOf()), type: FieldType.time
       });
 
       for (const path in mergedTagValuesWithType.values) {

--- a/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
+++ b/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
@@ -649,3 +649,53 @@ exports[`queries uses displayName property 1`] = `
   },
 ]
 `;
+
+exports[`queries history of tags from different workspaces 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "time",
+        "type": "time",
+        "values": [
+          "2023-01-01T00:00:00Z",
+          "2023-01-01T00:01:00Z",
+        ],
+      },
+      {
+        "config": {},
+        "name": "Default workspace.my.tag.1",
+        "values": [
+          1,
+          2,
+        ],
+      },
+      {
+        "config": {},
+        "name": "Default workspace.my.tag.2",
+        "values": [
+          2,
+          3,
+        ],
+      },
+      {
+        "config": {},
+        "name": "Other workspace.my.tag.3",
+        "values": [
+          3,
+          4,
+        ],
+      },
+      {
+        "config": {},
+        "name": "Other workspace.my.tag.4",
+        "values": [
+          4,
+          5,
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;

--- a/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
+++ b/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
@@ -432,8 +432,8 @@ exports[`queries numeric tag history 1`] = `
         "name": "time",
         "type": "time",
         "values": [
-          "2023-01-01T00:00:00Z",
-          "2023-01-01T00:01:00Z",
+          1672531200000,
+          1672531260000,
         ],
       },
       {
@@ -458,9 +458,9 @@ exports[`queries numeric multiple tags history 1`] = `
         "name": "time",
         "type": "time",
         "values": [
-          "2023-01-01T00:00:00Z",
-          "2023-01-01T00:01:00Z",
-          "2023-01-01T00:02:00Z",
+          1672531200000,
+          1672531260000,
+          1672531320000,
         ],
       },
       {
@@ -536,8 +536,8 @@ exports[`queries string tag history 1`] = `
         "name": "time",
         "type": "time",
         "values": [
-          "2023-01-01T00:00:00Z",
-          "2023-01-01T00:01:00Z",
+          1672531200000,
+          1672531260000,
         ],
       },
       {
@@ -658,8 +658,8 @@ exports[`queries add workspace prefix only when a tag with the same path exists 
         "name": "time",
         "type": "time",
         "values": [
-          "2023-01-01T00:00:00Z",
-          "2023-01-01T00:01:00Z",
+          1672531200000,
+          1672531260000,
         ],
       },
       {

--- a/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
+++ b/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
@@ -650,7 +650,7 @@ exports[`queries uses displayName property 1`] = `
 ]
 `;
 
-exports[`queries history of tags from different workspaces 1`] = `
+exports[`queries add workspace prefix only when a tag with the same path exists in multiple workspaces 1`] = `
 [
   {
     "fields": [
@@ -680,7 +680,23 @@ exports[`queries history of tags from different workspaces 1`] = `
       },
       {
         "config": {},
-        "name": "Other workspace.my.tag.3",
+        "name": "Other workspace.my.tag.1",
+        "values": [
+          1,
+          2,
+        ],
+      },
+      {
+        "config": {},
+        "name": "Other workspace.my.tag.2",
+        "values": [
+          2,
+          3,
+        ],
+      },
+      {
+        "config": {},
+        "name": "my.tag.3",
         "values": [
           3,
           4,
@@ -688,7 +704,7 @@ exports[`queries history of tags from different workspaces 1`] = `
       },
       {
         "config": {},
-        "name": "Other workspace.my.tag.4",
+        "name": "my.tag.4",
         "values": [
           4,
           5,

--- a/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
+++ b/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
@@ -430,16 +430,64 @@ exports[`queries numeric tag history 1`] = `
     "fields": [
       {
         "name": "time",
+        "type": "time",
         "values": [
-          1672531200000,
-          1672531260000,
+          "2023-01-01T00:00:00Z",
+          "2023-01-01T00:01:00Z",
         ],
       },
       {
+        "config": {},
         "name": "my.tag",
         "values": [
           1,
           2,
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries numeric multiple tags history 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "time",
+        "type": "time",
+        "values": [
+          "2023-01-01T00:00:00Z",
+          "2023-01-01T00:01:00Z",
+          "2023-01-01T00:02:00Z",
+        ],
+      },
+      {
+        "config": {},
+        "name": "my.tag.1",
+        "values": [
+          1,
+          2,
+          null,
+        ],
+      },
+      {
+        "config": {},
+        "name": "my.tag.2",
+        "values": [
+          2,
+          3,
+          null,
+        ],
+      },
+      {
+        "config": {},
+        "name": "my.tag.3",
+        "values": [
+          3,
+          null,
+          4,
         ],
       },
     ],
@@ -486,12 +534,14 @@ exports[`queries string tag history 1`] = `
     "fields": [
       {
         "name": "time",
+        "type": "time",
         "values": [
-          1672531200000,
-          1672531260000,
+          "2023-01-01T00:00:00Z",
+          "2023-01-01T00:01:00Z",
         ],
       },
       {
+        "config": {},
         "name": "my.tag",
         "values": [
           "3.14",

--- a/src/datasources/tag/components/TagQueryEditor.test.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.test.tsx
@@ -27,9 +27,11 @@ it('renders with initial query and updates when user makes changes', async () =>
   expect(screen.getByRole('radio', { name: 'History' })).toBeChecked();
   expect(screen.getByLabelText('Tag path')).toHaveValue('my.tag');
   expect(screen.getByText('Default workspace')).toBeInTheDocument();
+  expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
 
   // Users changes query type
   await userEvent.click(screen.getByRole('radio', { name: 'Current' }));
+  expect(screen.queryByRole('checkbox')).toBeInTheDocument();
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ type: TagQueryType.Current }));
 
   // User types in new tag path

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -10,7 +10,6 @@ type Props = QueryEditorProps<TagDataSource, TagQuery>;
 
 export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   query = datasource.prepareQuery(query);
-
   const workspaces = useWorkspaceOptions(datasource);
 
   const onTypeChange = (value: TagQueryType) => {
@@ -36,10 +35,10 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
   return (
     <>
       <InlineField label="Query type" labelWidth={14} tooltip={tooltips.queryType}>
-        <RadioButtonGroup options={enumToOptions(TagQueryType)} value={query.type} onChange={onTypeChange} />
+        <RadioButtonGroup options={enumToOptions(TagQueryType)} value={query.type} onChange={onTypeChange}/>
       </InlineField>
       <InlineField label="Tag path" labelWidth={14} tooltip={tooltips.tagPath}>
-        <AutoSizeInput minWidth={20} maxWidth={80} defaultValue={query.path} onCommitChange={onPathChange} />
+        <AutoSizeInput minWidth={20} maxWidth={80} defaultValue={query.path} onCommitChange={onPathChange}/>
       </InlineField>
       <InlineField label="Workspace" labelWidth={14} tooltip={tooltips.workspace}>
         <Select
@@ -51,19 +50,21 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
           value={query.workspace}
         />
       </InlineField>
-      <InlineField label="Properties" labelWidth={14} tooltip={tooltips.properties}>
-        <InlineSwitch onChange={onPropertiesChange} value={query.properties} />
-      </InlineField>
+      {query.type === TagQueryType.Current && (
+        <InlineField label="Properties" labelWidth={14} tooltip={tooltips.properties}>
+          <InlineSwitch onChange={onPropertiesChange} value={query.properties}/>
+        </InlineField>
+      )}
     </>
   );
 }
 
 const tooltips = {
-  queryType: `Current allows you to visualize the most recent tag value. History allows you to
-              visualize tag values over time. Historical values use the time range set on the
+  queryType: `Current allows you to visualize the most recent value of multiple tags. History allows you to
+              visualize the values of multiple tags over time. Historical values use the time range set on the
               dashboard and are decimated according to the width of the panel.`,
 
-  tagPath: `The full path of the tag to visualize. You can enter a variable into this field.`,
+  tagPath: `The path to search for the tags you want to visualize. You can enter a variable into this field and use glob-style patterns as wildcards.`,
 
   workspace: `The workspace to search for the given tag path. If left blank, the plugin
               finds the most recently updated tag in any workspace.`,

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -60,11 +60,11 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
 }
 
 const tooltips = {
-  queryType: `Current allows you to visualize the most recent value of multiple tags. History allows you to
+  queryType: `Current allows you to visualize the most recent value of one or more tags. History allows you to
               visualize the values of multiple tags over time. Historical values use the time range set on the
               dashboard and are decimated according to the width of the panel.`,
 
-  tagPath: `The path to search for the tags you want to visualize. You can enter a variable into this field and use glob-style patterns as wildcards.`,
+  tagPath: `The path to search for the tags you want to visualize. Use * as a wildcard to match multiple tags.`,
 
   workspace: `The workspace to search for the given tag path. If left blank, the plugin
               finds the most recently updated tag in any workspace.`,

--- a/src/datasources/tag/types.ts
+++ b/src/datasources/tag/types.ts
@@ -27,7 +27,7 @@ interface TagWithValueBase {
 interface TagWithValueV1 {
   tag: {
     collect_aggregates: boolean;
-    datatype: string;
+    datatype: TagDataType;
     last_updated: number;
     workspace_id: string;
   }
@@ -36,7 +36,7 @@ interface TagWithValueV1 {
 // Tag properties renamed in SystemLink Server and Enterprise
 interface TagWithValueV2 {
   tag: {
-    type: string;
+    type: TagDataType;
     workspace: string;
   }
 }
@@ -47,11 +47,30 @@ export interface TagsWithValues {
   tagsWithValues: TagWithValue[];
 }
 
+export interface TimestampedValue {
+  timestamp: string;
+  value: string
+}
+
+export interface TypeAndValues {
+  type: TagDataType;
+  values: TimestampedValue[];
+}
+
 export interface TagHistoryResponse {
-  results: {
-    [path: string]: {
-      type: string;
-      values: Array<{ timestamp: string; value: string }>;
-    };
-  };
+  results: Record<string, TypeAndValues>
+}
+
+export enum TagDataType {
+  DOUBLE = "DOUBLE",
+  INT = "INT",
+  STRING = "STRING",
+  BOOLEAN = "BOOLEAN",
+  U_INT64 = "U_INT64",
+  DATE_TIME = "DATE_TIME"
+}
+
+export interface TimeAndTagTypeValues {
+  timestamps: string[],
+  values: Record<string, { type: TagDataType, values: string[] }>
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The "history" query type currently visualizes data only for the first matched tag. Need to visualize data from all matched tags.

## 👩‍💻 Implementation

Implemented functions to retrieve tag history in chunks and merge responses into a single dataframe. Since it is impossible to have properties of multiple tags in one dataframe with those historical values, "Properties" option in now available only for query type "Current".

## 🧪 Testing

Added a test to check if the history of multiple tags is processed correctly. Added a test to ensure the properties switch button is hidden when the query type is "History".

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).