### PR TITLE
fix(notebook): fix notebook plugin not loading notebook parameters when opening visualization

### DIFF
--- a/src/datasources/notebook/QueryEditor.tsx
+++ b/src/datasources/notebook/QueryEditor.tsx
@@ -47,7 +47,7 @@ export class QueryEditor extends PureComponent<Props, State> {
       this.setState({ notebooks, loadingNotebooks: false });
 
       if (this.props.query.id) {
-        const notebook = this.getNotebook(this.props.query.id);
+        const notebook = notebooks.find((notebook: Notebook) => notebook.id === this.props.query.id);
         if (notebook) {
           await this.populateNotebookMetadata(notebook);
         }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The notebook parameters are not loading when reopening a visualisation from notebook plugin data source.
Steps to produce:
1) Open a Grafana dashboard which uses a python notebook as a datasource for a vizualition
2) Open the configuration for the visualization
3) Open the query

## 👩‍💻 Implementation

Use queried notebooks instead of notebooks from actual state. This is a problem because in the same function a state was both set and used. Here is a overview of how calls are made:

componentDidMount: setState, getNotebook, getNotebookMetadata (on retrieved notebook)
getNotebook: get notebook from saved state

Only after componentDidMount & getNotebook is finished the state is actually updated. So, because getNotebook actually called componentDidMount, the saved state there is actually the previous saved state, wich is null when the page loads.

 This is a frequenctly bug in react. Here is a nice blog about it: [link](https://blog.logrocket.com/why-react-doesnt-update-state-immediately/)

## 🧪 Testing

N/A

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).