### PR TITLE
feat (asset) Add summary option for asset query type

### DIFF
--- a/src/datasources/asset-calibration/constants.ts
+++ b/src/datasources/asset-calibration/constants.ts
@@ -79,3 +79,11 @@ export const AssetCalibrationStaticFields = [
 export const AssetComputedDataFields = {
     'Location': '(Location.PhysicalLocation = "{value}" || Location.MinionId = "{value}")',
 }
+
+export const assetSummaryFields = {
+    TOTAL: 'Total',
+    ACTIVE: 'Active',
+    NOT_ACTIVE: 'Not active',
+    APPROACHING_DUE_DATE: 'Approaching due date',
+    PAST_DUE_DATE: 'Past due date'
+};

--- a/src/datasources/asset-common/types.ts
+++ b/src/datasources/asset-common/types.ts
@@ -1,69 +1,69 @@
 export interface AssetsResponse {
-    assets: AssetModel[],
-    totalCount: number
-  }
-  
-  export interface AssetLocationModel {
-    minionId: string,
-    parent: string,
-    resourceUri: string,
-    slotNumber: number,
-    state: AssetPresenceWithSystemConnectionModel,
-    physicalLocation?: string
-  }
-  
-  export interface AssetPresenceWithSystemConnectionModel {
-    assetPresence: "INITIALIZING" | "UNKNOWN" | "NOT_PRESENT" | "PRESENT" | string,
-    // to be compatible with both SLS and SLE
-    systemConnection?: "APPROVED" | "DISCONNECTED" | "CONNECTED_UPDATE_PENDING" | "CONNECTED_UPDATE_SUCCESSFUL" | "CONNECTED_UPDATE_FAILED" | "UNSUPPORTED" | "ACTIVATED" | "CONNECTED" | string
-  }
-  
-  export interface AssetModel {
-    modelName: string,
-    modelNumber: number,
-    serialNumber: string,
-    vendorName: string,
-    vendorNumber: number,
-    busType: 'BUILT_IN_SYSTEM' | 'PCI_PXI' | 'USB' | 'GPIB' | 'VXI' | 'SERIAL' | 'TCP_IP' | 'CRIO' | 'SCXI' | 'CDAQ' | 'SWITCH_BLOCK' | 'SCC' | 'FIRE_WIRE' | 'ACCESSORY' | 'CAN' | 'SWITCH_BLOCK_DEVICE' | 'SLSC' | string,
-    name: string,
-    assetType: 'GENERIC' | 'DEVICE_UNDER_TEST' | 'FIXTURE' | 'SYSTEM' | string,
-    firmwareVersion: string,
-    hardwareVersion: string,
-    visaResourceName: string,
-    temperatureSensors: any[],
-    supportsSelfCalibration: boolean,
-    supportsExternalCalibration: boolean,
-    customCalibrationInterval?: number,
-    selfCalibration?: any,
-    isNIAsset: boolean,
-    workspace: string,
-    fileIds: string[],
-    supportsSelfTest: boolean,
-    supportsReset: boolean,
-    id: string,
-    location: AssetLocationModel,
-    calibrationStatus: 'OK' | 'APPROACHING_RECOMMENDED_DUE_DATE' | 'PAST_RECOMMENDED_DUE_DATE' | string,
-    isSystemController: boolean,
-    externalCalibration?: ExternalCalibrationModel,
-    discoveryType: 'MANUAL' | 'AUTOMATIC' | string,
-    properties: Record<string, string>,
-    keywords: string[],
-    lastUpdatedTimestamp: string,
-  }
-  
-  export interface ExternalCalibrationModel {
-    temperatureSensors: any[],
-    isLimited?: boolean,
-    date: string,
-    recommendedInterval: number,
-    nextRecommendedDate: string,
-    nextCustomDueDate?: string,
-    comments: string,
-    entryType: "AUTOMATIC" | "MANUAL" | string,
-    operator: ExternalCalibrationOperatorModel
-  }
-  
-  export interface ExternalCalibrationOperatorModel {
-    displayName: string;
-    userId: string
-  }
+  assets: AssetModel[],
+  totalCount: number
+}
+
+export interface AssetLocationModel {
+  minionId: string,
+  parent: string,
+  resourceUri: string,
+  slotNumber: number,
+  state: AssetPresenceWithSystemConnectionModel,
+  physicalLocation?: string
+}
+
+export interface AssetPresenceWithSystemConnectionModel {
+  assetPresence: "INITIALIZING" | "UNKNOWN" | "NOT_PRESENT" | "PRESENT" | string,
+  // to be compatible with both SLS and SLE
+  systemConnection?: "APPROVED" | "DISCONNECTED" | "CONNECTED_UPDATE_PENDING" | "CONNECTED_UPDATE_SUCCESSFUL" | "CONNECTED_UPDATE_FAILED" | "UNSUPPORTED" | "ACTIVATED" | "CONNECTED" | string
+}
+
+export interface AssetModel {
+  modelName: string,
+  modelNumber: number,
+  serialNumber: string,
+  vendorName: string,
+  vendorNumber: number,
+  busType: 'BUILT_IN_SYSTEM' | 'PCI_PXI' | 'USB' | 'GPIB' | 'VXI' | 'SERIAL' | 'TCP_IP' | 'CRIO' | 'SCXI' | 'CDAQ' | 'SWITCH_BLOCK' | 'SCC' | 'FIRE_WIRE' | 'ACCESSORY' | 'CAN' | 'SWITCH_BLOCK_DEVICE' | 'SLSC' | string,
+  name: string,
+  assetType: 'GENERIC' | 'DEVICE_UNDER_TEST' | 'FIXTURE' | 'SYSTEM' | string,
+  firmwareVersion: string,
+  hardwareVersion: string,
+  visaResourceName: string,
+  temperatureSensors: any[],
+  supportsSelfCalibration: boolean,
+  supportsExternalCalibration: boolean,
+  customCalibrationInterval?: number,
+  selfCalibration?: any,
+  isNIAsset: boolean,
+  workspace: string,
+  fileIds: string[],
+  supportsSelfTest: boolean,
+  supportsReset: boolean,
+  id: string,
+  location: AssetLocationModel,
+  calibrationStatus: 'OK' | 'APPROACHING_RECOMMENDED_DUE_DATE' | 'PAST_RECOMMENDED_DUE_DATE' | string,
+  isSystemController: boolean,
+  externalCalibration?: ExternalCalibrationModel,
+  discoveryType: 'MANUAL' | 'AUTOMATIC' | string,
+  properties: Record<string, string>,
+  keywords: string[],
+  lastUpdatedTimestamp: string,
+}
+
+export interface ExternalCalibrationModel {
+  temperatureSensors: any[],
+  isLimited?: boolean,
+  date: string,
+  recommendedInterval: number,
+  nextRecommendedDate: string,
+  nextCustomDueDate?: string,
+  comments: string,
+  entryType: "AUTOMATIC" | "MANUAL" | string,
+  operator: ExternalCalibrationOperatorModel
+}
+
+export interface ExternalCalibrationOperatorModel {
+  displayName: string;
+  userId: string
+}

--- a/src/datasources/asset-common/types.ts
+++ b/src/datasources/asset-common/types.ts
@@ -1,4 +1,3 @@
-
 export interface AssetsResponse {
     assets: AssetModel[],
     totalCount: number
@@ -67,16 +66,4 @@ export interface AssetsResponse {
   export interface ExternalCalibrationOperatorModel {
     displayName: string;
     userId: string
-  }
-
-  export interface AssetSummaryQuery {
-    total: number;
-    active: number;
-    notActive: number;
-    inUse: number;
-    notInUse: number;
-    withAlarms: number;
-    approachingRecommendedDueDate: number;
-    pastRecommendedDueDate: number;
-    totalCalibrated: number;
   }

--- a/src/datasources/asset-common/types.ts
+++ b/src/datasources/asset-common/types.ts
@@ -68,3 +68,15 @@ export interface AssetsResponse {
     displayName: string;
     userId: string
   }
+
+  export interface AssetSummaryQuery {
+    total: number;
+    active: number;
+    notActive: number;
+    inUse: number;
+    notInUse: number;
+    withAlarms: number;
+    approachingRecommendedDueDate: number;
+    pastRecommendedDueDate: number;
+    totalCalibrated: number;
+  }

--- a/src/datasources/asset/components/AssetQueryEditor.test.ts
+++ b/src/datasources/asset/components/AssetQueryEditor.test.ts
@@ -10,7 +10,7 @@ import { ListAssetsQuery } from '../types/ListAssets.types';
 import { CalibrationForecastQuery } from '../types/CalibrationForecastQuery.types';
 import { select } from 'react-select-event';
 import { AssetSummaryQuery } from '../types/AssetSummaryQuery.types';
-import { AssetFeatureTogglesDefaults } from '../types/types';
+import { AssetFeatureTogglesDefaults, AssetQueryType } from '../types/types';
 
 const fakeSystems: SystemMetadata[] = [
     {
@@ -57,7 +57,7 @@ beforeEach(() => {
 
 it('renders Asset list when feature is enabled', async () => {
     assetDatasourceOptions.featureToggles.assetList = true;
-    render({} as ListAssetsQuery);
+    render({ queryType: AssetQueryType.ListAssets } as ListAssetsQuery);
     const queryType = screen.getAllByRole('combobox')[0];
     await select(queryType, "List Assets", { container: document.body });
     expect(screen.getAllByText("List Assets").length).toBe(1)
@@ -65,14 +65,14 @@ it('renders Asset list when feature is enabled', async () => {
 
 it('does not render when Asset list feature is not enabled', async () => {
     assetDatasourceOptions.featureToggles.assetList = false;
-    render({} as ListAssetsQuery);
+    render({ queryType: AssetQueryType.ListAssets } as ListAssetsQuery);
 
     expect(screen.getAllByRole('combobox').length).toBe(1);
 });
 
 it('renders Asset calibration forecast when feature is enabled', async () => {
     assetDatasourceOptions.featureToggles.calibrationForecast = true;
-    render({} as CalibrationForecastQuery);
+    render({ queryType: AssetQueryType.CalibrationForecast } as CalibrationForecastQuery);
     const queryType = screen.getAllByRole('combobox')[0];
     await select(queryType, "Calibration Forecast", { container: document.body });
     expect(screen.getAllByText("Calibration Forecast").length).toBe(2)
@@ -80,7 +80,7 @@ it('renders Asset calibration forecast when feature is enabled', async () => {
 
 it('renders Asset summary when feature is enabled', async () => {
     assetDatasourceOptions.featureToggles.assetSummary = true;
-    render({} as AssetSummaryQuery);
+    render({ queryType: AssetQueryType.AssetSummary } as AssetSummaryQuery);
     const queryType = screen.getAllByRole('combobox')[0];
     await select(queryType, "Asset Summary", { container: document.body });
     expect(screen.getAllByText("Asset Summary").length).toBe(1)

--- a/src/datasources/asset/components/AssetQueryEditor.test.ts
+++ b/src/datasources/asset/components/AssetQueryEditor.test.ts
@@ -73,7 +73,7 @@ it('does not render when Asset list feature is not enabled', async () => {
     expect(screen.getAllByRole('combobox').length).toBe(1);
 });
 
-it('does not render when Asset calibration forecast feature is not enabled', async () => {
+it('renders Asset calibration forecast when feature is enabled', async () => {
     assetDatasourceOptions.featureToggles.calibrationForecast = true;
     render({} as CalibrationForecastQuery);
     const queryType = screen.getAllByRole('combobox')[0];
@@ -81,10 +81,10 @@ it('does not render when Asset calibration forecast feature is not enabled', asy
     expect(screen.getAllByText("Calibration Forecast").length).toBe(2)
 });
 
-it('does not render when Asset summary feature is not enabled', async () => {
+it('renders Asset summary when feature is enabled', async () => {
     assetDatasourceOptions.featureToggles.assetSummary = true;
     render({} as AssetSummaryQuery);
     const queryType = screen.getAllByRole('combobox')[0];
     await select(queryType, "Asset Summary", { container: document.body });
-    expect(screen.getAllByText("Asset Summary").length).toBe(2)
+    expect(screen.getAllByText("Asset Summary").length).toBe(1)
 });

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import _ from 'lodash';
-import { AssetDataSourceOptions, AssetFeatureToggles, AssetFeatureTogglesDefaults, AssetQuery, AssetQueryType } from '../types/types';
 import { InlineField, Select } from '@grafana/ui';
 
 import { AssetDataSource } from '../AssetDataSource';
@@ -12,12 +11,12 @@ import { ListAssetsEditor } from './editors/list-assets/ListAssetsEditor';
 import { defaultAssetSummaryQuery, defaultCalibrationForecastQuery, defaultListAssetsQuery } from '../defaults';
 import { ListAssetsQuery } from '../types/ListAssets.types';
 import { AssetSummaryQuery } from '../types/AssetSummaryQuery.types';
+import { AssetDataSourceOptions, AssetFeatureToggles, AssetFeatureTogglesDefaults, AssetQuery, AssetQueryType } from '../types/types';
 
 type Props = QueryEditorProps<AssetDataSource, AssetQuery, AssetDataSourceOptions>;
 
 export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   const [queryType, setQueryType] = useState(query.queryType as AssetQueryType);
-
   const assetFeatures = useRef<AssetFeatureToggles>({
     assetList: datasource.instanceSettings.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList,
     calibrationForecast: datasource.instanceSettings.jsonData?.featureToggles?.calibrationForecast ?? AssetFeatureTogglesDefaults.calibrationForecast,

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -19,7 +19,7 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
   const queryRef = useRef(query);
   const onChangeRef = useRef(onChange);
   const onRunQueryRef = useRef(onRunQuery);
-  const [queryType, setQueryType] = useState(AssetQueryType.ListAssets);
+  const [queryType, setQueryType] = useState<string>(query.queryType || '');
 
   useEffect(() => {
     queryRef.current = query;
@@ -63,7 +63,7 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
   return (
     <div style={{ position: 'relative' }}>
       <InlineField label="Query type" labelWidth={22} tooltip={tooltips.queryType}>
-        <Select options={queryTypeOptions} onChange={handleQueryTypeChange} value={queryType} width={85} />
+        <Select options={queryTypeOptions} onChange={handleQueryTypeChange} value={queryTypeOptions.find(option => option.value === queryType)} width={85} />
       </InlineField>
       {queryType === AssetQueryType.ListAssets && (
         <ListAssetsEditor

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -16,9 +16,7 @@ import { AssetSummaryQuery } from '../types/AssetSummaryQuery.types';
 type Props = QueryEditorProps<AssetDataSource, AssetQuery, AssetDataSourceOptions>;
 
 export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
-  const [queryType, setQueryType] = useState<string>(() => {
-    return query.queryType ? query.queryType : AssetQueryType.ListAssets;
-  });
+  const [queryType, setQueryType] = useState(query.queryType as AssetQueryType);
 
   const assetFeatures = useRef<AssetFeatureToggles>({
     assetList: datasource.instanceSettings.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList,
@@ -34,8 +32,11 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
   }, [onChange, onRunQuery]);
 
   const handleQueryTypeChange = useCallback((item: SelectableValue<AssetQueryType>): void => {
-    setQueryType(item.value as AssetQueryType);
-
+    if(query.queryType === item.value){
+      return;
+    }
+    setQueryType(item.value!);
+  
     if (item.value === AssetQueryType.ListAssets && assetFeatures.current.assetList) {
       handleQueryChange({ ...query, queryType: AssetQueryType.ListAssets, ...defaultListAssetsQuery }, true);
     }
@@ -72,7 +73,7 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
         <Select
           options={filterOptions}
           onChange={handleQueryTypeChange}
-          value={queryTypeOptions.find(option => option.value === queryType)}
+          value={queryType}
           width={85}
         />
       </InlineField>

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -41,7 +41,7 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
   }, []);
 
   const handleQueryTypeChange = (item: SelectableValue<AssetQueryType>): void => {
-    setQueryType(item.value!);
+    setQueryType(item.value as AssetQueryType);
   };
 
   useEffect(() => {
@@ -56,7 +56,7 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
       });
     }
     if (queryType === AssetQueryType.AssetSummary) {
-      handleQueryChange({ ...queryRef.current, queryType: AssetQueryType.AssetSummary, ...defaultAssetSummaryQuery });
+      handleQueryChange({ ...queryRef.current, queryType: AssetQueryType.AssetSummary, ...defaultAssetSummaryQuery }, true);
     }
   }, [queryType, handleQueryChange]);
 

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -31,9 +31,6 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
   }, [onChange, onRunQuery]);
 
   const handleQueryTypeChange = useCallback((item: SelectableValue<AssetQueryType>): void => {
-    if(query.queryType === item.value){
-      return;
-    }
     setQueryType(item.value!);
   
     if (item.value === AssetQueryType.ListAssets && assetFeatures.current.assetList) {

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -6,12 +6,12 @@ import { InlineField, Select } from '@grafana/ui';
 import { AssetDataSource } from '../AssetDataSource';
 import { AssetSummaryEditor } from './editors/asset-summary/AssetSummaryEditor';
 import { CalibrationForecastEditor } from './editors/calibration-forecast/CalibrationForecastEditor';
-import { AssetCalibrationQuery } from '../../asset-calibration/types';
 import { ListAssetsEditor } from './editors/list-assets/ListAssetsEditor';
 import { defaultAssetSummaryQuery, defaultCalibrationForecastQuery, defaultListAssetsQuery } from '../defaults';
 import { ListAssetsQuery } from '../types/ListAssets.types';
 import { AssetSummaryQuery } from '../types/AssetSummaryQuery.types';
 import { AssetDataSourceOptions, AssetFeatureToggles, AssetFeatureTogglesDefaults, AssetQuery, AssetQueryType } from '../types/types';
+import { CalibrationForecastQuery } from '../types/CalibrationForecastQuery.types';
 
 type Props = QueryEditorProps<AssetDataSource, AssetQuery, AssetDataSourceOptions>;
 
@@ -82,7 +82,7 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
       )}
       {((assetFeatures.current.calibrationForecast && queryType === AssetQueryType.CalibrationForecast) || (query.queryType === AssetQueryType.CalibrationForecast)) && (
         <CalibrationForecastEditor
-          query={query as AssetCalibrationQuery}
+          query={query as CalibrationForecastQuery}
           handleQueryChange={handleQueryChange}
           datasource={datasource.getCalibrationForecastSource()}
         />

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-
-import _ from 'lodash';
-import { AssetQuery, AssetQueryType } from '../types/types';
 import { InlineField, Select } from '@grafana/ui';
+import _ from 'lodash';
+
+import { AssetQuery, AssetQueryType } from '../types/types';
 import { AssetDataSource } from '../AssetDataSource';
 import { AssetSummaryEditor } from './editors/asset-summary/AssetSummaryEditor';
 import { CalibrationForecastEditor } from './editors/calibration-forecast/CalibrationForecastEditor';
@@ -19,7 +19,9 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
   const queryRef = useRef(query);
   const onChangeRef = useRef(onChange);
   const onRunQueryRef = useRef(onRunQuery);
-  const [queryType, setQueryType] = useState<string>(query.queryType || '');
+  const [queryType, setQueryType] = useState<string>(() => {
+    return query.queryType ? query.queryType : AssetQueryType.ListAssets;
+  });
 
   useEffect(() => {
     queryRef.current = query;
@@ -56,14 +58,22 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
       });
     }
     if (queryType === AssetQueryType.AssetSummary) {
-      handleQueryChange({ ...queryRef.current, queryType: AssetQueryType.AssetSummary, ...defaultAssetSummaryQuery }, true);
+      handleQueryChange(
+        { ...queryRef.current, queryType: AssetQueryType.AssetSummary, ...defaultAssetSummaryQuery },
+        true
+      );
     }
   }, [queryType, handleQueryChange]);
 
   return (
     <div style={{ position: 'relative' }}>
       <InlineField label="Query type" labelWidth={22} tooltip={tooltips.queryType}>
-        <Select options={queryTypeOptions} onChange={handleQueryTypeChange} value={queryTypeOptions.find(option => option.value === queryType)} width={85} />
+        <Select
+          options={queryTypeOptions}
+          onChange={handleQueryTypeChange}
+          value={queryTypeOptions.find(option => option.value === queryType)}
+          width={85}
+        />
       </InlineField>
       {queryType === AssetQueryType.ListAssets && (
         <ListAssetsEditor

--- a/src/datasources/asset/components/editors/asset-summary/AssetSummaryDataSource.ts
+++ b/src/datasources/asset/components/editors/asset-summary/AssetSummaryDataSource.ts
@@ -2,6 +2,7 @@ import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@gra
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import { AssetSummaryQuery } from 'datasources/asset/types/AssetSummaryQuery.types';
+import { assetSummaryFields } from 'datasources/asset-calibration/constants';
 import { AssetQuery } from '../../../types/types';
 import { AssetDataSourceBase } from '../AssetDataSourceBase';
 
@@ -29,25 +30,19 @@ export class AssetSummaryDataSource extends AssetDataSourceBase {
 
     async processMetadataQuery(query: AssetQuery) {
         const result: DataFrameDTO = { refId: query.refId, fields: [] };
-
         const assets: AssetSummaryQuery = await this.getAssetSummary();
 
         result.fields = [
-            { name: 'Total', values: [assets.total] },
-            { name: 'Active', values: [assets.active] },
-            { name: 'Not active', values: [assets.notActive] },
-            { name: 'Approaching due date', values: [assets.approachingRecommendedDueDate] },
-            { name: 'Past due date', values: [assets.pastRecommendedDueDate] }
+            { name: assetSummaryFields.TOTAL, values: [assets.total] },
+            { name: assetSummaryFields.ACTIVE, values: [assets.active] },
+            { name: assetSummaryFields.NOT_ACTIVE, values: [assets.notActive] },
+            { name: assetSummaryFields.APPROACHING_DUE_DATE, values: [assets.approachingRecommendedDueDate] },
+            { name: assetSummaryFields.PAST_DUE_DATE, values: [assets.pastRecommendedDueDate] }
         ];
         return result;
     }
 
     async getAssetSummary(): Promise<AssetSummaryQuery> {
-        try {
-            let response = await this.get<AssetSummaryQuery>(this.baseUrl + '/asset-summary');
-            return response;
-        } catch (error) {
-            throw new Error(`An error occurred while getting asset summary: ${error}`);
-        }
+        return await this.get<AssetSummaryQuery>(this.baseUrl + '/asset-summary');
     }
 }

--- a/src/datasources/asset/components/editors/asset-summary/AssetSummaryDataSource.ts
+++ b/src/datasources/asset/components/editors/asset-summary/AssetSummaryDataSource.ts
@@ -1,8 +1,9 @@
 import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@grafana/data';
-import { AssetQuery } from '../../../types/types';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
+
+import { AssetSummaryQuery } from 'datasources/asset/types/AssetSummaryQuery.types';
+import { AssetQuery } from '../../../types/types';
 import { AssetDataSourceBase } from '../AssetDataSourceBase';
-import { AssetSummaryQuery } from 'datasources/asset-common/types';
 
 export class AssetSummaryDataSource extends AssetDataSourceBase {
     constructor(
@@ -32,9 +33,9 @@ export class AssetSummaryDataSource extends AssetDataSourceBase {
         const assets: AssetSummaryQuery = await this.getAssetSummary();
 
         result.fields = [
+            { name: 'Total', values: [assets.total] },
             { name: 'Active', values: [assets.active] },
             { name: 'Not active', values: [assets.notActive] },
-            { name: 'Total', values: [assets.total] },
             { name: 'Approaching due date', values: [assets.approachingRecommendedDueDate] },
             { name: 'Past due date', values: [assets.pastRecommendedDueDate] }
         ];

--- a/src/datasources/asset/components/editors/asset-summary/AssetSummaryDataSource.ts
+++ b/src/datasources/asset/components/editors/asset-summary/AssetSummaryDataSource.ts
@@ -1,11 +1,10 @@
 import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@grafana/data';
-import { AssetDataSourceOptions, AssetQuery } from '../../../types/types';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import { AssetSummaryQuery } from 'datasources/asset/types/AssetSummaryQuery.types';
 import { assetSummaryFields } from 'datasources/asset-calibration/constants';
 import { AssetDataSourceBase } from '../AssetDataSourceBase';
-
+import { AssetDataSourceOptions, AssetQuery } from '../../../types/types';
 export class AssetSummaryDataSource extends AssetDataSourceBase {
     constructor(
         readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,

--- a/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.test.tsx
+++ b/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.test.tsx
@@ -5,6 +5,7 @@ import { mock } from 'jest-mock-extended';
 import { AssetSummaryDataSource } from './AssetSummaryDataSource';
 import { AssetSummaryQuery } from 'datasources/asset/types/AssetSummaryQuery.types';
 import { AssetQuery } from 'datasources/asset/types/types';
+import { assetSummaryFields } from 'datasources/asset-calibration/constants';
 
 describe('AssetSummaryDataSource', () => {
   let dataSource: AssetSummaryDataSource;
@@ -33,11 +34,11 @@ describe('AssetSummaryDataSource', () => {
     expect(result).toEqual({
       refId: 'A',
       fields: [
-        { name: 'Total', values: [10] },
-        { name: 'Active', values: [5] },
-        { name: 'Not active', values: [3] },
-        { name: 'Approaching due date', values: [1] },
-        { name: 'Past due date', values: [1] },
+        { name: assetSummaryFields.TOTAL, values: [10] },
+        { name: assetSummaryFields.ACTIVE, values: [5] },
+        { name: assetSummaryFields.NOT_ACTIVE, values: [3] },
+        { name: assetSummaryFields.APPROACHING_DUE_DATE, values: [1] },
+        { name: assetSummaryFields.PAST_DUE_DATE, values: [1] },
       ],
     });
   });
@@ -53,8 +54,6 @@ describe('AssetSummaryDataSource', () => {
   it('should handle error in getAssetSummary', async () => {
     jest.spyOn(dataSource, 'get').mockRejectedValue(new Error('Network error'));
 
-    await expect(dataSource.getAssetSummary()).rejects.toThrow(
-      'An error occurred while getting asset summary: Error: Network error'
-    );
+    await expect(dataSource.getAssetSummary()).rejects.toThrow('Network error');
   });
 });

--- a/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.test.tsx
+++ b/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.test.tsx
@@ -3,8 +3,8 @@ import { BackendSrv, TemplateSrv } from '@grafana/runtime';
 import { mock } from 'jest-mock-extended';
 
 import { AssetSummaryDataSource } from './AssetSummaryDataSource';
-import { AssetSummaryQuery } from 'datasources/asset/types/AssetSummaryQuery.types';
-import { AssetDataSourceOptions, AssetQuery } from 'datasources/asset/types/types';
+import { AssetSummaryResponse } from 'datasources/asset/types/AssetSummaryQuery.types';
+import { AssetDataSourceOptions, AssetQuery, AssetQueryType } from 'datasources/asset/types/types';
 import { assetSummaryFields } from 'datasources/asset-calibration/constants';
 
 describe('AssetSummaryDataSource', () => {
@@ -12,7 +12,7 @@ describe('AssetSummaryDataSource', () => {
   const instanceSettings = mock<DataSourceInstanceSettings<AssetDataSourceOptions>>();
   const backendSrv = mock<BackendSrv>();
   const templateSrv = mock<TemplateSrv>();
-  const assetSummary: AssetSummaryQuery = {
+  const assetSummary: AssetSummaryResponse = {
     total: 10,
     active: 5,
     notActive: 3,
@@ -26,10 +26,10 @@ describe('AssetSummaryDataSource', () => {
   });
 
   it('should process metadata query correctly', async () => {
-    const query: AssetQuery = { refId: 'A' };
+    const query: AssetQuery = { refId: 'A', queryType: AssetQueryType.AssetSummary, };
 
     jest.spyOn(dataSource, 'getAssetSummary').mockResolvedValue(assetSummary);
-    const result = await dataSource.processMetadataQuery(query);
+    const result = await dataSource.processSummaryQuery(query);
 
     expect(result).toEqual({
       refId: 'A',

--- a/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.test.tsx
+++ b/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.test.tsx
@@ -1,0 +1,60 @@
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { BackendSrv, TemplateSrv } from '@grafana/runtime';
+import { mock } from 'jest-mock-extended';
+
+import { AssetSummaryDataSource } from './AssetSummaryDataSource';
+import { AssetSummaryQuery } from 'datasources/asset/types/AssetSummaryQuery.types';
+import { AssetQuery } from 'datasources/asset/types/types';
+
+describe('AssetSummaryDataSource', () => {
+  let dataSource: AssetSummaryDataSource;
+  const instanceSettings = mock<DataSourceInstanceSettings>();
+  const backendSrv = mock<BackendSrv>();
+  const templateSrv = mock<TemplateSrv>();
+  const assetSummary: AssetSummaryQuery = {
+    total: 10,
+    active: 5,
+    notActive: 3,
+    approachingRecommendedDueDate: 1,
+    pastRecommendedDueDate: 1,
+    refId: '',
+  };
+
+  beforeEach(() => {
+    dataSource = new AssetSummaryDataSource(instanceSettings, backendSrv, templateSrv);
+  });
+
+  it('should process metadata query correctly', async () => {
+    const query: AssetQuery = { refId: 'A' };
+
+    jest.spyOn(dataSource, 'getAssetSummary').mockResolvedValue(assetSummary);
+    const result = await dataSource.processMetadataQuery(query);
+
+    expect(result).toEqual({
+      refId: 'A',
+      fields: [
+        { name: 'Total', values: [10] },
+        { name: 'Active', values: [5] },
+        { name: 'Not active', values: [3] },
+        { name: 'Approaching due date', values: [1] },
+        { name: 'Past due date', values: [1] },
+      ],
+    });
+  });
+
+  it('should get asset summary correctly', async () => {
+    jest.spyOn(dataSource, 'get').mockResolvedValue(assetSummary);
+
+    const result = await dataSource.getAssetSummary();
+
+    expect(result).toEqual(assetSummary);
+  });
+
+  it('should handle error in getAssetSummary', async () => {
+    jest.spyOn(dataSource, 'get').mockRejectedValue(new Error('Network error'));
+
+    await expect(dataSource.getAssetSummary()).rejects.toThrow(
+      'An error occurred while getting asset summary: Error: Network error'
+    );
+  });
+});

--- a/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.tsx
+++ b/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
 
-import { AssetQuery } from '../../../types/types';
 import { AssetSummaryDataSource } from './AssetSummaryDataSource';
 import { AssetSummaryQuery } from '../../../types/AssetSummaryQuery.types';
 
 type Props = {
   query: AssetSummaryQuery;
-  handleQueryChange: (value: AssetQuery, runQuery: boolean) => void;
+  handleQueryChange: (value: AssetSummaryQuery, runQuery: boolean) => void;
   datasource: AssetSummaryDataSource;
 };
 
 export function AssetSummaryEditor({ query, handleQueryChange, datasource }: Props) {
   query = datasource.prepareQuery(query) as AssetSummaryQuery;
 
-  return <div style={{ position: 'relative' }}>Asset Summary</div>;
+  return <div style={{ position: 'relative' }}></div>;
 }

--- a/src/datasources/asset/components/editors/calibration-forecast/CalibrationForecastDataSource.ts
+++ b/src/datasources/asset/components/editors/calibration-forecast/CalibrationForecastDataSource.ts
@@ -1,5 +1,5 @@
 import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@grafana/data';
-import { AssetDataSourceOptions, AssetQuery } from '../../../types/types';
+import { AssetDataSourceOptions, AssetQuery, AssetQueryType } from '../../../types/types';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { AssetDataSourceBase } from '../AssetDataSourceBase';
 
@@ -15,6 +15,7 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
     baseUrl = this.instanceSettings.url + '/niapm/v1';
 
     defaultQuery = {
+        queryType: AssetQueryType.CalibrationForecast,
     };
 
     runQuery(query: AssetQuery, options: DataQueryRequest): Promise<DataFrameDTO> {

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsDataSource.ts
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsDataSource.ts
@@ -1,5 +1,5 @@
 import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@grafana/data';
-import { AssetDataSourceOptions, AssetQuery } from '../../../types/types';
+import { AssetDataSourceOptions, AssetQuery, AssetQueryType } from '../../../types/types';
 import { AssetModel, AssetsResponse } from '../../../../asset-common/types';
 import { getWorkspaceName } from '../../../../../core/utils';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
@@ -21,6 +21,7 @@ export class ListAssetsDataSource extends AssetDataSourceBase {
   baseUrl = this.instanceSettings.url + '/niapm/v1';
 
   defaultQuery = {
+    queryType: AssetQueryType.ListAssets,
     filter: ''
   };
 

--- a/src/datasources/asset/types/AssetSummaryQuery.types.ts
+++ b/src/datasources/asset/types/AssetSummaryQuery.types.ts
@@ -1,9 +1,15 @@
 import { DataQuery } from '@grafana/schema'
+import { AssetQueryType } from './types';
 
 export interface AssetSummaryQuery extends DataQuery {
-    total: number;
-    active: number;
-    notActive: number;
-    approachingRecommendedDueDate: number;
-    pastRecommendedDueDate: number;
-  }
+  queryType: AssetQueryType;
+}
+
+export interface AssetSummaryResponse extends DataQuery {
+  total: number;
+  active: number;
+  notActive: number;
+  approachingRecommendedDueDate: number;
+  pastRecommendedDueDate: number;
+}
+

--- a/src/datasources/asset/types/AssetSummaryQuery.types.ts
+++ b/src/datasources/asset/types/AssetSummaryQuery.types.ts
@@ -1,4 +1,9 @@
 import { DataQuery } from '@grafana/schema'
 
 export interface AssetSummaryQuery extends DataQuery {
-}
+    total: number;
+    active: number;
+    notActive: number;
+    approachingRecommendedDueDate: number;
+    pastRecommendedDueDate: number;
+  }

--- a/src/datasources/asset/types/CalibrationForecastQuery.types.ts
+++ b/src/datasources/asset/types/CalibrationForecastQuery.types.ts
@@ -1,7 +1,9 @@
 import { FieldDTO } from '@grafana/data'
 import { DataQuery } from '@grafana/schema'
+import { AssetQueryType } from './types';
 
 export interface CalibrationForecastQuery extends DataQuery {
+    queryType: AssetQueryType;
 }
 
 export interface CalibrationForecastResponse {

--- a/src/datasources/asset/types/ListAssets.types.ts
+++ b/src/datasources/asset/types/ListAssets.types.ts
@@ -1,8 +1,10 @@
 import { DataQuery } from '@grafana/schema'
 import { QueryBuilderOperations } from '../../../core/query-builder.constants';
 import { QBField } from '../../asset-calibration/types';
+import { AssetQueryType } from './types';
 
 export interface ListAssetsQuery extends DataQuery {
+    queryType: AssetQueryType;
     filter: string;
 }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

US: [User Story 2855720](https://dev.azure.com/ni/DevCentral/_workitems/edit/2855720): [UI][Grafana] Create 'Summary' option as part of the 'SystemLink Asset' Grafana plugin

## 👩‍💻 Implementation

Added query to /asset-summary. Modified QueryEditor to not initialize the query with ListAssets every time a different visualisation is selected (the change from useState part).

## 🧪 Testing

Added unit tests for asset summary part.
Manually tested:

![grafanaQuery](https://github.com/user-attachments/assets/0dc14fb7-7d20-41c3-950a-37a1bf5c5552)


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).