### PR TITLE
feat(asset): add feature flag support

### DIFF
--- a/src/core/DataSourceBase.ts
+++ b/src/core/DataSourceBase.ts
@@ -12,7 +12,7 @@ import { QuerySystemsResponse, QuerySystemsRequest, Workspace } from './types';
 import { sleep } from './utils';
 import { lastValueFrom } from 'rxjs';
 
-export abstract class DataSourceBase<TQuery extends DataQuery, TOptions extends DataSourceJsonData> extends DataSourceApi<TQuery, TOptions> {
+export abstract class DataSourceBase<TQuery extends DataQuery, TOptions extends DataSourceJsonData = DataSourceJsonData> extends DataSourceApi<TQuery, TOptions> {
   constructor(
     readonly instanceSettings: DataSourceInstanceSettings<TOptions>,
     readonly backendSrv: BackendSrv,

--- a/src/core/DataSourceBase.ts
+++ b/src/core/DataSourceBase.ts
@@ -4,6 +4,7 @@ import {
   DataQueryResponse,
   DataSourceApi,
   DataSourceInstanceSettings,
+  DataSourceJsonData,
 } from '@grafana/data';
 import { BackendSrv, BackendSrvRequest, TemplateSrv, isFetchError } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
@@ -11,9 +12,9 @@ import { QuerySystemsResponse, QuerySystemsRequest, Workspace } from './types';
 import { sleep } from './utils';
 import { lastValueFrom } from 'rxjs';
 
-export abstract class DataSourceBase<TQuery extends DataQuery> extends DataSourceApi<TQuery> {
+export abstract class DataSourceBase<TQuery extends DataQuery, TOptions extends DataSourceJsonData> extends DataSourceApi<TQuery, TOptions> {
   constructor(
-    readonly instanceSettings: DataSourceInstanceSettings,
+    readonly instanceSettings: DataSourceInstanceSettings<TOptions>,
     readonly backendSrv: BackendSrv,
     readonly templateSrv: TemplateSrv
   ) {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -35,7 +35,7 @@ export function throwIfNullish<T>(value: T, error: string | Error): NonNullable<
 }
 
 /** Gets available workspaces as an array of {@link SelectableValue}. */
-export function useWorkspaceOptions<DSType extends DataSourceBase<any>>(datasource: DSType) {
+export function useWorkspaceOptions<DSType extends DataSourceBase<any, any>>(datasource: DSType) {
   return useAsync(async () => {
     const workspaces = await datasource.getWorkspaces();
     const workspaceOptions = workspaces.map(w => ({ label: w.name, value: w.id }));
@@ -45,7 +45,7 @@ export function useWorkspaceOptions<DSType extends DataSourceBase<any>>(datasour
 }
 
 /** Gets Dashboard variables as an array of {@link SelectableValue}. */
-export function getVariableOptions<DSType extends DataSourceBase<any>>(datasource: DSType) {
+export function getVariableOptions<DSType extends DataSourceBase<any, any>>(datasource: DSType) {
   return datasource.templateSrv
     .getVariables()
     .filter((variable: any) => !variable.datasource || variable.datasource.uid !== datasource.uid)

--- a/src/datasources/asset-calibration/AssetCalibrationDataSource.ts
+++ b/src/datasources/asset-calibration/AssetCalibrationDataSource.ts
@@ -2,6 +2,7 @@ import {
   DataFrameDTO,
   DataQueryRequest,
   DataSourceInstanceSettings,
+  DataSourceJsonData,
   FieldDTO,
   TestDataSourceResponse,
 } from '@grafana/data';
@@ -26,7 +27,7 @@ import { QueryBuilderOperations } from 'core/query-builder.constants';
 import { Workspace } from 'core/types';
 import { parseErrorMessage } from 'core/errors';
 
-export class AssetCalibrationDataSource extends DataSourceBase<AssetCalibrationQuery> {
+export class AssetCalibrationDataSource extends DataSourceBase<AssetCalibrationQuery, DataSourceJsonData> {
   public defaultQuery = {
     groupBy: [],
     filter: ''

--- a/src/datasources/asset-calibration/components/AssetCalibrationQueryEditor.tsx
+++ b/src/datasources/asset-calibration/components/AssetCalibrationQueryEditor.tsx
@@ -15,7 +15,6 @@ type Props = QueryEditorProps<AssetCalibrationDataSource, AssetCalibrationQuery>
 
 export const AssetCalibrationQueryEditor = ({ query, onChange, onRunQuery, datasource }: Props) => {
   query = datasource.prepareQuery(query) as AssetCalibrationQuery;
-
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [systems, setSystems] = useState<SystemMetadata[]>([]);
   const [areDependenciesLoaded, setAreDependenciesLoaded] = useState<boolean>(false);

--- a/src/datasources/asset/AssetConfigEditor.tsx
+++ b/src/datasources/asset/AssetConfigEditor.tsx
@@ -4,7 +4,7 @@
  */
 import React, { ChangeEvent } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { DataSourceHttpSettings, InlineField, InlineSwitch, Text } from '@grafana/ui';
+import { DataSourceHttpSettings, InlineField, InlineSegmentGroup, InlineSwitch, Tag, Text } from '@grafana/ui';
 import { AssetDataSourceOptions, AssetFeatureTogglesDefaults } from './types/types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<AssetDataSourceOptions> { }
@@ -32,21 +32,30 @@ export const AssetConfigEditor: React.FC<Props> = ({ options, onOptionsChange })
             Features
           </Text>
         </div>
-        <InlineField label="Asset list" labelWidth={25}>
-          <InlineSwitch
-            value={options.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList}
-            onChange={handleFeatureChange('assetList')} />
-        </InlineField>
-        <InlineField label="Calibration forecast" labelWidth={25}>
-          <InlineSwitch
-            value={options.jsonData?.featureToggles?.calibrationForecast ?? AssetFeatureTogglesDefaults.calibrationForecast}
-            onChange={handleFeatureChange('calibrationForecast')} />
-        </InlineField>
-        <InlineField label="Asset summary" labelWidth={25}>
-          <InlineSwitch
-            value={options.jsonData?.featureToggles?.assetSummary ?? AssetFeatureTogglesDefaults.assetSummary}
-            onChange={handleFeatureChange('assetSummary')} />
-        </InlineField>
+        <InlineSegmentGroup>
+          <InlineField label="Asset list" labelWidth={25}>
+            <InlineSwitch
+              value={options.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList}
+              onChange={handleFeatureChange('assetList')} />
+          </InlineField>
+          <Tag name='Beta' colorIndex={5} />
+        </InlineSegmentGroup>
+        <InlineSegmentGroup>
+          <InlineField label="Calibration forecast" labelWidth={25}>
+            <InlineSwitch
+              value={options.jsonData?.featureToggles?.calibrationForecast ?? AssetFeatureTogglesDefaults.calibrationForecast}
+              onChange={handleFeatureChange('calibrationForecast')} />
+          </InlineField>
+          <Tag name='Beta' colorIndex={5} />
+        </InlineSegmentGroup>
+        <InlineSegmentGroup>
+          <InlineField label="Asset summary" labelWidth={25}>
+            <InlineSwitch
+              value={options.jsonData?.featureToggles?.assetSummary ?? AssetFeatureTogglesDefaults.assetSummary}
+              onChange={handleFeatureChange('assetSummary')} />
+          </InlineField>
+          <Tag name='Beta' colorIndex={5} />
+        </InlineSegmentGroup>
       </>
     </>
   );

--- a/src/datasources/asset/AssetConfigEditor.tsx
+++ b/src/datasources/asset/AssetConfigEditor.tsx
@@ -12,39 +12,18 @@ interface Props extends DataSourcePluginOptionsEditorProps<AssetDataSourceOption
 interface State { }
 
 export class AssetConfigEditor extends PureComponent<Props, State> {
+  handleFeatureChange = (featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
+    console.log(event.target.value);
+    const jsonData = {
+      ...this.props.options.jsonData,
+      [featureKey]: event.target.checked,
+    };
+    this.props.onOptionsChange({ ...this.props.options, jsonData });
+  };
+
+
   render() {
     const { options, onOptionsChange } = this.props;
-
-    const onCalibrationFeatureEnabledChange = (event: ChangeEvent<HTMLInputElement>) => {
-      console.log(event.target.value);
-      const jsonData: AssetDataSourceOptions = {
-        ...this.props.options.jsonData,
-        calibrationForecastEnabled: !this.props.options.jsonData.calibrationForecastEnabled,
-      };
-
-      onOptionsChange({ ...this.props.options, jsonData });
-    };
-
-    const onAssetSummaryFeatureEnabledChange = (event: ChangeEvent<HTMLInputElement>) => {
-      console.log(event.target.value);
-      const jsonData: AssetDataSourceOptions = {
-        ...this.props.options.jsonData,
-        assetSummaryEnabled: !this.props.options.jsonData.assetSummaryEnabled,
-      };
-
-      onOptionsChange({ ...this.props.options, jsonData });
-    };
-
-    const onAssetListEnabledChange = (event: ChangeEvent<HTMLInputElement>) => {
-      console.log(event.target.value);
-      const jsonData: AssetDataSourceOptions = {
-        ...this.props.options.jsonData,
-        assetListEnabled: !this.props.options.jsonData.assetListEnabled,
-      };
-
-      onOptionsChange({ ...this.props.options, jsonData });
-    };
-
     return (
       <>
         <DataSourceHttpSettings
@@ -60,13 +39,19 @@ export class AssetConfigEditor extends PureComponent<Props, State> {
             </Text>
           </div>
           <InlineField label="Asset list" labelWidth={25}>
-            <InlineSwitch disabled={false} value={this.props.options.jsonData.assetListEnabled ?? true} onChange={onAssetListEnabledChange} />
+            <InlineSwitch
+              value={this.props.options.jsonData.assetListEnabled ?? true}
+              onChange={this.handleFeatureChange('assetListEnabled')} />
           </InlineField>
           <InlineField label="Asset summary" labelWidth={25}>
-            <InlineSwitch disabled={false} value={this.props.options.jsonData.assetSummaryEnabled ?? false} onChange={onAssetSummaryFeatureEnabledChange} />
+            <InlineSwitch
+              value={this.props.options.jsonData.assetSummaryEnabled ?? false}
+              onChange={this.handleFeatureChange('assetSummaryEnabled')} />
           </InlineField>
           <InlineField label="Calibration forecast" labelWidth={25}>
-            <InlineSwitch disabled={false} value={this.props.options.jsonData.calibrationForecastEnabled ?? false} onChange={onCalibrationFeatureEnabledChange} />
+            <InlineSwitch
+              value={this.props.options.jsonData.calibrationForecastEnabled ?? false}
+              onChange={this.handleFeatureChange('calibrationForecastEnabled')} />
           </InlineField>
         </>
       </>

--- a/src/datasources/asset/AssetConfigEditor.tsx
+++ b/src/datasources/asset/AssetConfigEditor.tsx
@@ -1,60 +1,53 @@
 /**
- * ConfigEditor is a React component that implements the UI for editing the asset
+ * AssetConfigEditor is a React component that implements the UI for editing the asset
  * datasource configuration options.
  */
-import React, { ChangeEvent, PureComponent } from 'react';
+import React, { ChangeEvent } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { DataSourceHttpSettings, InlineField, InlineSwitch, Text } from '@grafana/ui';
-import { AssetDataSourceOptions } from './types/types';
+import { AssetDataSourceOptions, AssetFeatureTogglesDefaults } from './types/types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<AssetDataSourceOptions> { }
 
-interface State { }
-
-export class AssetConfigEditor extends PureComponent<Props, State> {
-  handleFeatureChange = (featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
-    console.log(event.target.value);
+export const AssetConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
+  const handleFeatureChange = (featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
     const jsonData = {
-      ...this.props.options.jsonData,
-      [featureKey]: event.target.checked,
+      ...options.jsonData,
+      ...{ featureToggles: { ...options.jsonData.featureToggles, [featureKey]: event.target.checked } }
     };
-    this.props.onOptionsChange({ ...this.props.options, jsonData });
+    onOptionsChange({ ...options, jsonData });
   };
 
-
-  render() {
-    const { options, onOptionsChange } = this.props;
-    return (
+  return (
+    <>
+      <DataSourceHttpSettings
+        defaultUrl=""
+        dataSourceConfig={options}
+        showAccessOptions={false}
+        onChange={onOptionsChange}
+      />
       <>
-        <DataSourceHttpSettings
-          defaultUrl=""
-          dataSourceConfig={options}
-          showAccessOptions={false}
-          onChange={onOptionsChange}
-        />
-        <>
-          <div style={{ paddingBottom: "10px" }}>
-            <Text element="h6">
-              Features
-            </Text>
-          </div>
-          <InlineField label="Asset list" labelWidth={25}>
-            <InlineSwitch
-              value={this.props.options.jsonData.assetListEnabled ?? true}
-              onChange={this.handleFeatureChange('assetListEnabled')} />
-          </InlineField>
-          <InlineField label="Asset summary" labelWidth={25}>
-            <InlineSwitch
-              value={this.props.options.jsonData.assetSummaryEnabled ?? false}
-              onChange={this.handleFeatureChange('assetSummaryEnabled')} />
-          </InlineField>
-          <InlineField label="Calibration forecast" labelWidth={25}>
-            <InlineSwitch
-              value={this.props.options.jsonData.calibrationForecastEnabled ?? false}
-              onChange={this.handleFeatureChange('calibrationForecastEnabled')} />
-          </InlineField>
-        </>
+        <div style={{ paddingBottom: "10px" }}>
+          <Text element="h6">
+            Features
+          </Text>
+        </div>
+        <InlineField label="Asset list" labelWidth={25}>
+          <InlineSwitch
+            value={options.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList}
+            onChange={handleFeatureChange('assetList')} />
+        </InlineField>
+        <InlineField label="Calibration forecast" labelWidth={25}>
+          <InlineSwitch
+            value={options.jsonData?.featureToggles?.calibrationForecast ?? AssetFeatureTogglesDefaults.calibrationForecast}
+            onChange={handleFeatureChange('calibrationForecast')} />
+        </InlineField>
+        <InlineField label="Asset summary" labelWidth={25}>
+          <InlineSwitch
+            value={options.jsonData?.featureToggles?.assetSummary ?? AssetFeatureTogglesDefaults.assetSummary}
+            onChange={handleFeatureChange('assetSummary')} />
+        </InlineField>
       </>
-    );
-  }
+    </>
+  );
 }

--- a/src/datasources/asset/AssetConfigEditor.tsx
+++ b/src/datasources/asset/AssetConfigEditor.tsx
@@ -1,0 +1,75 @@
+/**
+ * ConfigEditor is a React component that implements the UI for editing the asset
+ * datasource configuration options.
+ */
+import React, { ChangeEvent, PureComponent } from 'react';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { DataSourceHttpSettings, InlineField, InlineSwitch, Text } from '@grafana/ui';
+import { AssetDataSourceOptions } from './types/types';
+
+interface Props extends DataSourcePluginOptionsEditorProps<AssetDataSourceOptions> { }
+
+interface State { }
+
+export class AssetConfigEditor extends PureComponent<Props, State> {
+  render() {
+    const { options, onOptionsChange } = this.props;
+
+    const onCalibrationFeatureEnabledChange = (event: ChangeEvent<HTMLInputElement>) => {
+      console.log(event.target.value);
+      const jsonData: AssetDataSourceOptions = {
+        ...this.props.options.jsonData,
+        calibrationForecastEnabled: !this.props.options.jsonData.calibrationForecastEnabled,
+      };
+
+      onOptionsChange({ ...this.props.options, jsonData });
+    };
+
+    const onAssetSummaryFeatureEnabledChange = (event: ChangeEvent<HTMLInputElement>) => {
+      console.log(event.target.value);
+      const jsonData: AssetDataSourceOptions = {
+        ...this.props.options.jsonData,
+        assetSummaryEnabled: !this.props.options.jsonData.assetSummaryEnabled,
+      };
+
+      onOptionsChange({ ...this.props.options, jsonData });
+    };
+
+    const onAssetListEnabledChange = (event: ChangeEvent<HTMLInputElement>) => {
+      console.log(event.target.value);
+      const jsonData: AssetDataSourceOptions = {
+        ...this.props.options.jsonData,
+        assetListEnabled: !this.props.options.jsonData.assetListEnabled,
+      };
+
+      onOptionsChange({ ...this.props.options, jsonData });
+    };
+
+    return (
+      <>
+        <DataSourceHttpSettings
+          defaultUrl=""
+          dataSourceConfig={options}
+          showAccessOptions={false}
+          onChange={onOptionsChange}
+        />
+        <>
+          <div style={{ paddingBottom: "10px" }}>
+            <Text element="h6">
+              Features
+            </Text>
+          </div>
+          <InlineField label="Asset list" labelWidth={25}>
+            <InlineSwitch disabled={false} value={this.props.options.jsonData.assetListEnabled ?? true} onChange={onAssetListEnabledChange} />
+          </InlineField>
+          <InlineField label="Asset summary" labelWidth={25}>
+            <InlineSwitch disabled={false} value={this.props.options.jsonData.assetSummaryEnabled ?? false} onChange={onAssetSummaryFeatureEnabledChange} />
+          </InlineField>
+          <InlineField label="Calibration forecast" labelWidth={25}>
+            <InlineSwitch disabled={false} value={this.props.options.jsonData.calibrationForecastEnabled ?? false} onChange={onCalibrationFeatureEnabledChange} />
+          </InlineField>
+        </>
+      </>
+    );
+  }
+}

--- a/src/datasources/asset/AssetConfigEditor.tsx
+++ b/src/datasources/asset/AssetConfigEditor.tsx
@@ -2,7 +2,7 @@
  * AssetConfigEditor is a React component that implements the UI for editing the asset
  * datasource configuration options.
  */
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useCallback } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { DataSourceHttpSettings, InlineField, InlineSegmentGroup, InlineSwitch, Tag, Text } from '@grafana/ui';
 import { AssetDataSourceOptions, AssetFeatureTogglesDefaults } from './types/types';
@@ -10,13 +10,13 @@ import { AssetDataSourceOptions, AssetFeatureTogglesDefaults } from './types/typ
 interface Props extends DataSourcePluginOptionsEditorProps<AssetDataSourceOptions> { }
 
 export const AssetConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
-  const handleFeatureChange = (featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
+  const handleFeatureChange =  useCallback((featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
     const jsonData = {
       ...options.jsonData,
       ...{ featureToggles: { ...options.jsonData.featureToggles, [featureKey]: event.target.checked } }
     };
     onOptionsChange({ ...options, jsonData });
-  };
+  }, [options, onOptionsChange]);
 
   return (
     <>

--- a/src/datasources/asset/AssetDataSource.test.ts
+++ b/src/datasources/asset/AssetDataSource.test.ts
@@ -13,9 +13,14 @@ import { AssetPresenceWithSystemConnectionModel, AssetsResponse } from "datasour
 import { ListAssetsQuery } from "./types/ListAssets.types";
 
 let ds: AssetDataSource, backendSrv: MockProxy<BackendSrv>
+let assetOptions = {
+  assetListEnabled: true,
+  calibrationForecastEnabled: true,
+  assetSummaryEnabled: true,
+}
 
 beforeEach(() => {
-  [ds, backendSrv] = setupDataSource(AssetDataSource);
+  [ds, backendSrv] = setupDataSource(AssetDataSource, () => assetOptions);
 });
 
 const assetsResponseMock: AssetsResponse =

--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -2,12 +2,12 @@ import {
   DataFrameDTO,
   DataQueryRequest,
   DataSourceInstanceSettings,
-  DataSourceJsonData,
   TestDataSourceResponse,
 } from '@grafana/data';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import {
+  AssetDataSourceOptions,
   AssetQuery,
   AssetQueryType,
 } from './types/types';
@@ -19,13 +19,13 @@ import { AssetSummaryQuery } from './types/AssetSummaryQuery.types';
 import { CalibrationForecastQuery } from './types/CalibrationForecastQuery.types';
 import { ListAssetsQuery } from './types/ListAssets.types';
 
-export class AssetDataSource extends DataSourceBase<AssetQuery, DataSourceJsonData> {
+export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceOptions> {
   private assetSummaryDataSource: AssetSummaryDataSource;
   private calibrationForecastDataSource: CalibrationForecastDataSource;
   private listAssetsDataSource: ListAssetsDataSource;
 
   constructor(
-    readonly instanceSettings: DataSourceInstanceSettings,
+    readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,
     readonly backendSrv: BackendSrv = getBackendSrv(),
     readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {

--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -14,7 +14,6 @@ import {
 import { ListAssetsDataSource } from './components/editors/list-assets/ListAssetsDataSource';
 import { CalibrationForecastDataSource } from './components/editors/calibration-forecast/CalibrationForecastDataSource';
 import { AssetSummaryDataSource } from './components/editors/asset-summary/AssetSummaryDataSource';
-import { defaultAssetQuery, defaultAssetQueryType } from './defaults';
 import { AssetSummaryQuery } from './types/AssetSummaryQuery.types';
 import { CalibrationForecastQuery } from './types/CalibrationForecastQuery.types';
 import { ListAssetsQuery } from './types/ListAssets.types';
@@ -38,32 +37,33 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
   baseUrl = this.instanceSettings.url + '/niapm/v1';
 
   defaultQuery = {
-    queryType: defaultAssetQueryType,
-    ...defaultAssetQuery
+    queryType: AssetQueryType.None,
   };
 
   async runQuery(query: AssetQuery, options: DataQueryRequest): Promise<DataFrameDTO> {
     if (query.queryType === AssetQueryType.AssetSummary) {
       return this.getAssetSummarySource().runQuery(query as AssetSummaryQuery, options);
     }
-    else if (query.queryType === AssetQueryType.CalibrationForecast) {
+    if (query.queryType === AssetQueryType.CalibrationForecast) {
       return this.getCalibrationForecastSource().runQuery(query as CalibrationForecastQuery, options);
     }
-    else {
+    if (query.queryType === AssetQueryType.ListAssets) {
       return this.getListAssetsSource().runQuery(query as ListAssetsQuery, options);
     }
+    throw new Error('Unknown query type');
   }
 
   shouldRunQuery(query: AssetQuery): boolean {
     if (query.queryType === AssetQueryType.AssetSummary) {
       return this.getAssetSummarySource().shouldRunQuery(query as AssetSummaryQuery);
     }
-    else if (query.queryType === AssetQueryType.CalibrationForecast) {
+    if (query.queryType === AssetQueryType.CalibrationForecast) {
       return this.getCalibrationForecastSource().shouldRunQuery(query as CalibrationForecastQuery);
     }
-    else {
+    if (query.queryType === AssetQueryType.ListAssets) {
       return this.getListAssetsSource().shouldRunQuery(query as ListAssetsQuery);
     }
+    return false;
   }
 
   async testDatasource(): Promise<TestDataSourceResponse> {

--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -2,6 +2,7 @@ import {
   DataFrameDTO,
   DataQueryRequest,
   DataSourceInstanceSettings,
+  DataSourceJsonData,
   TestDataSourceResponse,
 } from '@grafana/data';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
@@ -18,7 +19,7 @@ import { AssetSummaryQuery } from './types/AssetSummaryQuery.types';
 import { CalibrationForecastQuery } from './types/CalibrationForecastQuery.types';
 import { ListAssetsQuery } from './types/ListAssets.types';
 
-export class AssetDataSource extends DataSourceBase<AssetQuery> {
+export class AssetDataSource extends DataSourceBase<AssetQuery, DataSourceJsonData> {
   private assetSummaryDataSource: AssetSummaryDataSource;
   private calibrationForecastDataSource: CalibrationForecastDataSource;
   private listAssetsDataSource: ListAssetsDataSource;

--- a/src/datasources/asset/components/AssetQueryEditor.test.ts
+++ b/src/datasources/asset/components/AssetQueryEditor.test.ts
@@ -1,0 +1,90 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { SystemMetadata } from '../../system/types';
+import { AssetDataSource } from '../AssetDataSource';
+import { setupRenderer } from '../../../test/fixtures';
+import { ListAssetsDataSource } from './editors/list-assets/ListAssetsDataSource';
+import { AssetSummaryDataSource } from './editors/asset-summary/AssetSummaryDataSource';
+import { CalibrationForecastDataSource } from './editors/calibration-forecast/CalibrationForecastDataSource';
+import { AssetQueryEditor } from './AssetQueryEditor';
+import { ListAssetsQuery } from '../types/ListAssets.types';
+import { CalibrationForecastQuery } from '../types/CalibrationForecastQuery.types';
+import { select } from 'react-select-event';
+import { AssetSummaryQuery } from '../types/AssetSummaryQuery.types';
+import { AssetFeatureTogglesDefaults } from '../types/types';
+
+const fakeSystems: SystemMetadata[] = [
+    {
+        id: '1',
+        state: 'CONNECTED',
+        workspace: '1',
+    },
+    {
+        id: '2',
+        state: 'CONNECTED',
+        workspace: '2',
+    },
+];
+
+let assetDatasourceOptions = {
+    featureToggles: {...AssetFeatureTogglesDefaults}
+}
+
+class FakeAssetsSource extends ListAssetsDataSource {
+    querySystems(filter?: string, projection?: string[]): Promise<SystemMetadata[]> {
+        return Promise.resolve(fakeSystems);
+    }
+}
+
+class FakeAssetDataSource extends AssetDataSource {
+    getCalibrationForecastSource(): CalibrationForecastDataSource {
+        return new CalibrationForecastDataSource(this.instanceSettings, this.backendSrv, this.templateSrv);
+    }
+    getAssetSummarySource(): AssetSummaryDataSource {
+        return new AssetSummaryDataSource(this.instanceSettings, this.backendSrv, this.templateSrv);
+    }
+    getListAssetsSource(): ListAssetsDataSource {
+        return new FakeAssetsSource(this.instanceSettings, this.backendSrv, this.templateSrv);
+    }
+}
+
+const workspacesLoaded = () => waitForElementToBeRemoved(screen.getByTestId('Spinner'));
+const render = setupRenderer(AssetQueryEditor, FakeAssetDataSource, () => assetDatasourceOptions);
+
+beforeEach(() => {
+    assetDatasourceOptions = {
+        featureToggles: {...AssetFeatureTogglesDefaults}
+    }
+})
+
+it('renders Asset list when feature is ', async () => {
+    assetDatasourceOptions.featureToggles.assetList = true;
+    render({} as ListAssetsQuery);
+    await workspacesLoaded();
+
+    expect(screen.getAllByRole('combobox').length).toBe(3);
+    expect(screen.getAllByRole('combobox')[1]).toHaveAccessibleDescription('Any workspace');
+    expect(screen.getAllByRole('combobox')[2]).toHaveAccessibleDescription('Select systems');
+});
+
+it('does not render when Asset list feature is not enabled', async () => {
+    assetDatasourceOptions.featureToggles.assetList = false;
+    render({} as ListAssetsQuery);
+
+    expect(screen.getAllByRole('combobox').length).toBe(1);
+});
+
+it('does not render when Asset calibration forecast feature is not enabled', async () => {
+    assetDatasourceOptions.featureToggles.calibrationForecast = true;
+    render({} as CalibrationForecastQuery);
+    const queryType = screen.getAllByRole('combobox')[0];
+    await select(queryType, "Calibration Forecast", { container: document.body });
+    expect(screen.getAllByText("Calibration Forecast").length).toBe(2)
+});
+
+it('does not render when Asset summary feature is not enabled', async () => {
+    assetDatasourceOptions.featureToggles.assetSummary = true;
+    render({} as AssetSummaryQuery);
+    const queryType = screen.getAllByRole('combobox')[0];
+    await select(queryType, "Asset Summary", { container: document.body });
+    expect(screen.getAllByText("Asset Summary").length).toBe(2)
+});

--- a/src/datasources/asset/components/AssetQueryEditor.test.ts
+++ b/src/datasources/asset/components/AssetQueryEditor.test.ts
@@ -26,7 +26,7 @@ const fakeSystems: SystemMetadata[] = [
 ];
 
 let assetDatasourceOptions = {
-    featureToggles: {...AssetFeatureTogglesDefaults}
+    featureToggles: { ...AssetFeatureTogglesDefaults }
 }
 
 class FakeAssetsSource extends ListAssetsDataSource {
@@ -52,11 +52,11 @@ const render = setupRenderer(AssetQueryEditor, FakeAssetDataSource, () => assetD
 
 beforeEach(() => {
     assetDatasourceOptions = {
-        featureToggles: {...AssetFeatureTogglesDefaults}
-    }
-})
+        featureToggles: { ...AssetFeatureTogglesDefaults }
+    };
+});
 
-it('renders Asset list when feature is ', async () => {
+it('renders Asset list when feature is enabled', async () => {
     assetDatasourceOptions.featureToggles.assetList = true;
     render({} as ListAssetsQuery);
     await workspacesLoaded();

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -32,7 +32,17 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
 
   const handleQueryTypeChange = useCallback((item: SelectableValue<AssetQueryType>): void => {
     setQueryType(item.value!);
-    handleQueryChange({ ...query, queryType: item.value! }, true);
+
+    if (item.value === AssetQueryType.ListAssets && assetFeatures.current.assetList) {
+      handleQueryChange({ ...query, queryType: AssetQueryType.ListAssets, ...defaultListAssetsQuery }, true);
+    }
+    if (item.value === AssetQueryType.CalibrationForecast && assetFeatures.current.calibrationForecast) {
+      handleQueryChange({ ...query, queryType: AssetQueryType.CalibrationForecast, ...defaultCalibrationForecastQuery }, true);
+    }
+    if (item.value === AssetQueryType.AssetSummary && assetFeatures.current.assetSummary) {
+      handleQueryChange({ ...query, queryType: AssetQueryType.AssetSummary, ...defaultAssetSummaryQuery }, true);
+    }
+
   }, [query, handleQueryChange]);
 
   const filterOptions = useMemo(() => {
@@ -47,27 +57,11 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
   useEffect(() => {
     if (!queryType) {
       const firstFilterOption = filterOptions.length > 0 ? filterOptions[0].value : undefined;
-      setQueryType(firstFilterOption as AssetQueryType);
+      if(firstFilterOption){
+        handleQueryTypeChange({ value: firstFilterOption });
+      }
     }
-  }, [setQueryType, filterOptions, queryType]);
-
-  useEffect(() => {
-    if (queryType === query.queryType) {
-      return;
-    }
-
-    if (queryType === AssetQueryType.ListAssets && assetFeatures.current.assetList) {
-      handleQueryChange({ ...query, queryType: AssetQueryType.ListAssets, ...defaultListAssetsQuery }, true);
-    }
-    if (queryType === AssetQueryType.CalibrationForecast && assetFeatures.current.calibrationForecast) {
-      handleQueryChange({ ...query, queryType: AssetQueryType.CalibrationForecast, ...defaultCalibrationForecastQuery }, true);
-    }
-    if (queryType === AssetQueryType.AssetSummary && assetFeatures.current.assetSummary) {
-      handleQueryChange({ ...query, queryType: AssetQueryType.AssetSummary, ...defaultAssetSummaryQuery }, true);
-    }
-  }, [
-    query, queryType, handleQueryChange
-  ]);
+  }, [handleQueryTypeChange, filterOptions, queryType]);
 
   return (
     <div style={{ position: 'relative' }}>

--- a/src/datasources/asset/components/editors/AssetDataSourceBase.ts
+++ b/src/datasources/asset/components/editors/AssetDataSourceBase.ts
@@ -1,8 +1,8 @@
 import { DataFrameDTO, DataQueryRequest, TestDataSourceResponse } from "@grafana/data";
-import { AssetQuery } from "../../types/types";
+import { AssetDataSourceOptions, AssetQuery } from "../../types/types";
 import { DataSourceBase } from "../../../../core/DataSourceBase";
 
-export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery> {
+export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, AssetDataSourceOptions> {
 
   abstract runQuery(query: AssetQuery, options: DataQueryRequest): Promise<DataFrameDTO>;
 

--- a/src/datasources/asset/components/editors/asset-summary/AssetSummaryDataSource.ts
+++ b/src/datasources/asset/components/editors/asset-summary/AssetSummaryDataSource.ts
@@ -1,11 +1,11 @@
 import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@grafana/data';
-import { AssetQuery } from '../../../types/types';
+import { AssetDataSourceOptions, AssetQuery } from '../../../types/types';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { AssetDataSourceBase } from '../AssetDataSourceBase';
 
 export class AssetSummaryDataSource extends AssetDataSourceBase {
     constructor(
-        readonly instanceSettings: DataSourceInstanceSettings,
+        readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,
         readonly backendSrv: BackendSrv = getBackendSrv(),
         readonly templateSrv: TemplateSrv = getTemplateSrv()
     ) {

--- a/src/datasources/asset/components/editors/calibration-forecast/CalibrationForecastDataSource.ts
+++ b/src/datasources/asset/components/editors/calibration-forecast/CalibrationForecastDataSource.ts
@@ -1,11 +1,11 @@
 import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@grafana/data';
-import { AssetQuery } from '../../../types/types';
+import { AssetDataSourceOptions, AssetQuery } from '../../../types/types';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { AssetDataSourceBase } from '../AssetDataSourceBase';
 
 export class CalibrationForecastDataSource extends AssetDataSourceBase {
     constructor(
-        readonly instanceSettings: DataSourceInstanceSettings,
+        readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,
         readonly backendSrv: BackendSrv = getBackendSrv(),
         readonly templateSrv: TemplateSrv = getTemplateSrv()
     ) {

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsDataSource.ts
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsDataSource.ts
@@ -1,5 +1,5 @@
 import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@grafana/data';
-import { AssetQuery } from '../../../types/types';
+import { AssetDataSourceOptions, AssetQuery } from '../../../types/types';
 import { AssetModel, AssetsResponse } from '../../../../asset-common/types';
 import { SystemMetadata } from '../../../../system/types';
 import { getWorkspaceName, replaceVariables } from '../../../../../core/utils';
@@ -10,7 +10,7 @@ import { AssetFilterProperties, ListAssetsQuery } from '../../../types/ListAsset
 
 export class ListAssetsDataSource extends AssetDataSourceBase {
   constructor(
-    readonly instanceSettings: DataSourceInstanceSettings,
+    readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,
     readonly backendSrv: BackendSrv = getBackendSrv(),
     readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.test.tsx
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.test.tsx
@@ -6,6 +6,7 @@ import { setupRenderer } from '../../../../../test/fixtures';
 import { select } from 'react-select-event';
 import { ListAssetsDataSource } from './ListAssetsDataSource';
 import { ListAssetsQuery } from '../../../types/ListAssets.types';
+import { AssetFeatureTogglesDefaults } from 'datasources/asset/types/types';
 
 const fakeSystems: SystemMetadata[] = [
   {
@@ -21,9 +22,7 @@ const fakeSystems: SystemMetadata[] = [
 ];
 
 let assetDatasourceOptions = {
-  assetListEnabled: true,
-  calibrationForecastEnabled: false,
-  assetSummaryEnabled: false,
+  featureToggles: {...AssetFeatureTogglesDefaults}
 }
 
 class FakeAssetsSource extends ListAssetsDataSource {
@@ -43,21 +42,19 @@ const workspacesLoaded = () => waitForElementToBeRemoved(screen.getByTestId('Spi
 
 beforeEach(() => {
   assetDatasourceOptions = {
-    assetListEnabled: true,
-    calibrationForecastEnabled: false,
-    assetSummaryEnabled: false,
+    featureToggles: {...AssetFeatureTogglesDefaults}
   }
 })
 
 it('does not render when feature is not enabled', async () => {
-  assetDatasourceOptions.assetListEnabled = false;
+  assetDatasourceOptions.featureToggles.assetList = false;
   render({} as ListAssetsQuery);
   expect(screen.getAllByRole('combobox').length).toBe(1);
 });
 
 
 it('renders with metadata query defaults', async () => {
-  assetDatasourceOptions.assetListEnabled = true;
+  assetDatasourceOptions.featureToggles.assetList = true;
   render({} as ListAssetsQuery);
   await workspacesLoaded();
 

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.test.tsx
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.test.tsx
@@ -20,6 +20,12 @@ const fakeSystems: SystemMetadata[] = [
   },
 ];
 
+let assetDatasourceOptions = {
+  assetListEnabled: true,
+  calibrationForecastEnabled: false,
+  assetSummaryEnabled: false,
+}
+
 class FakeAssetsSource extends ListAssetsDataSource {
   querySystems(filter?: string, projection?: string[]): Promise<SystemMetadata[]> {
     return Promise.resolve(fakeSystems);
@@ -32,13 +38,30 @@ class FakeAssetDataSource extends AssetDataSource {
   }
 }
 
-const render = setupRenderer(AssetQueryEditor, FakeAssetDataSource);
+const render = setupRenderer(AssetQueryEditor, FakeAssetDataSource, () => assetDatasourceOptions);
 const workspacesLoaded = () => waitForElementToBeRemoved(screen.getByTestId('Spinner'));
 
+beforeEach(() => {
+  assetDatasourceOptions = {
+    assetListEnabled: true,
+    calibrationForecastEnabled: false,
+    assetSummaryEnabled: false,
+  }
+})
+
+it('does not render when feature is not enabled', async () => {
+  assetDatasourceOptions.assetListEnabled = false;
+  render({} as ListAssetsQuery);
+  expect(screen.getAllByRole('combobox').length).toBe(1);
+});
+
+
 it('renders with metadata query defaults', async () => {
+  assetDatasourceOptions.assetListEnabled = true;
   render({} as ListAssetsQuery);
   await workspacesLoaded();
 
+  expect(screen.getAllByRole('combobox').length).toBe(3);
   expect(screen.getAllByRole('combobox')[1]).toHaveAccessibleDescription('Any workspace');
   expect(screen.getAllByRole('combobox')[2]).toHaveAccessibleDescription('Select systems');
 });

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
@@ -8,7 +8,7 @@ import { FloatingError, parseErrorMessage } from '../../../../../core/errors';
 import { useWorkspaceOptions } from '../../../../../core/utils';
 import { isValidId } from '../../../../data-frame/utils';
 import { SystemMetadata } from '../../../../system/types';
-import { AssetQuery } from '../../../types/types';
+import { AssetFeatureTogglesDefaults, AssetQuery } from '../../../types/types';
 import { ListAssetsDataSource } from './ListAssetsDataSource';
 import { ListAssetsQuery } from '../../../types/ListAssets.types';
 
@@ -24,7 +24,7 @@ export function ListAssetsEditor({ query, handleQueryChange, datasource }: Props
   const workspaces = useWorkspaceOptions(datasource);
   const [errorMsg, setErrorMsg] = useState<string | undefined>('');
   const handleError = (error: Error) => setErrorMsg(parseErrorMessage(error));
-  const [editorEnabled] = useState(datasource.instanceSettings.jsonData?.featureToggles?.assetList ?? true);
+  const [editorEnabled] = useState(datasource.instanceSettings.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList);
 
   const minionIds = useAsync(() => {
     let filterString = '';

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
@@ -1,5 +1,5 @@
 import { SelectableValue, toOption } from '@grafana/data';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { InlineField, MultiSelect, Select } from '@grafana/ui';
 import _ from 'lodash';

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
@@ -1,5 +1,5 @@
 import { SelectableValue, toOption } from '@grafana/data';
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 
 import { InlineField, MultiSelect, Select } from '@grafana/ui';
 import _ from 'lodash';
@@ -24,7 +24,7 @@ export function ListAssetsEditor({ query, handleQueryChange, datasource }: Props
   const workspaces = useWorkspaceOptions(datasource);
   const [errorMsg, setErrorMsg] = useState<string | undefined>('');
   const handleError = (error: Error) => setErrorMsg(parseErrorMessage(error));
-  const [editorEnabled] = useState(datasource.instanceSettings.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList);
+  const editorEnabled = useRef(datasource.instanceSettings.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList);
 
   const minionIds = useAsync(() => {
     let filterString = '';
@@ -69,7 +69,7 @@ export function ListAssetsEditor({ query, handleQueryChange, datasource }: Props
 
   return (
     <div style={{ position: 'relative' }}>
-      <InlineField label="Workspace" tooltip={tooltips.workspace} labelWidth={22} disabled={!editorEnabled}>
+      <InlineField label="Workspace" tooltip={tooltips.workspace} labelWidth={22} disabled={!editorEnabled.current}>
         <Select
           isClearable
           isLoading={workspaces.loading}
@@ -79,7 +79,7 @@ export function ListAssetsEditor({ query, handleQueryChange, datasource }: Props
           value={query.workspace}
         />
       </InlineField>
-      <InlineField label="Systems" tooltip={tooltips.system} labelWidth={22} disabled={!editorEnabled}>
+      <InlineField label="Systems" tooltip={tooltips.system} labelWidth={22} disabled={!editorEnabled.current}>
         <MultiSelect
           isClearable
           allowCreateWhileLoading

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
@@ -24,6 +24,7 @@ export function ListAssetsEditor({ query, handleQueryChange, datasource }: Props
   const workspaces = useWorkspaceOptions(datasource);
   const [errorMsg, setErrorMsg] = useState<string | undefined>('');
   const handleError = (error: Error) => setErrorMsg(parseErrorMessage(error));
+  const [editorEnabled] = useState(datasource.instanceSettings.jsonData?.featureToggles?.assetList ?? true);
 
   const minionIds = useAsync(() => {
     let filterString = '';
@@ -68,7 +69,7 @@ export function ListAssetsEditor({ query, handleQueryChange, datasource }: Props
 
   return (
     <div style={{ position: 'relative' }}>
-      <InlineField label="Workspace" tooltip={tooltips.workspace} labelWidth={22}>
+      <InlineField label="Workspace" tooltip={tooltips.workspace} labelWidth={22} disabled={!editorEnabled}>
         <Select
           isClearable
           isLoading={workspaces.loading}
@@ -78,7 +79,7 @@ export function ListAssetsEditor({ query, handleQueryChange, datasource }: Props
           value={query.workspace}
         />
       </InlineField>
-      <InlineField label="Systems" tooltip={tooltips.system} labelWidth={22}>
+      <InlineField label="Systems" tooltip={tooltips.system} labelWidth={22} disabled={!editorEnabled}>
         <MultiSelect
           isClearable
           allowCreateWhileLoading

--- a/src/datasources/asset/defaults.ts
+++ b/src/datasources/asset/defaults.ts
@@ -1,4 +1,3 @@
-import { AssetQueryType } from "./types/types";
 
 export const defaultAssetSummaryQuery = {
 }
@@ -10,7 +9,3 @@ export const defaultListAssetsQuery = {
     workspace: "",
     minionIds: []
 }
-
-export const defaultAssetQuery = defaultListAssetsQuery;
-
-export const defaultAssetQueryType = AssetQueryType.ListAssets;

--- a/src/datasources/asset/module.ts
+++ b/src/datasources/asset/module.ts
@@ -1,8 +1,10 @@
 import { DataSourcePlugin } from '@grafana/data';
 import { AssetDataSource } from './AssetDataSource';
 import { AssetQueryEditor } from './components/AssetQueryEditor';
-import { HttpConfigEditor } from 'core/components/HttpConfigEditor';
+import { AssetDataSourceOptions, AssetQuery } from './types/types';
+import { AssetConfigEditor } from './AssetConfigEditor';
 
-export const plugin = new DataSourcePlugin(AssetDataSource)
-  .setConfigEditor(HttpConfigEditor)
+
+export const plugin = new DataSourcePlugin<AssetDataSource, AssetQuery, AssetDataSourceOptions>(AssetDataSource)
+  .setConfigEditor(AssetConfigEditor)
   .setQueryEditor(AssetQueryEditor);

--- a/src/datasources/asset/types/types.ts
+++ b/src/datasources/asset/types/types.ts
@@ -1,3 +1,4 @@
+import { DataSourceJsonData } from "@grafana/data";
 import { AssetSummaryQuery } from "./AssetSummaryQuery.types";
 import { CalibrationForecastQuery } from "./CalibrationForecastQuery.types";
 import { ListAssetsQuery } from "./ListAssets.types";
@@ -9,3 +10,9 @@ export enum AssetQueryType {
 }
 
 export type AssetQuery = ListAssetsQuery | CalibrationForecastQuery | AssetSummaryQuery;
+
+export interface AssetDataSourceOptions extends DataSourceJsonData {
+  calibrationForecastEnabled: boolean | null;
+  assetListEnabled: boolean | null;
+  assetSummaryEnabled: boolean | null;
+}

--- a/src/datasources/asset/types/types.ts
+++ b/src/datasources/asset/types/types.ts
@@ -4,6 +4,7 @@ import { CalibrationForecastQuery } from "./CalibrationForecastQuery.types";
 import { ListAssetsQuery } from "./ListAssets.types";
 
 export enum AssetQueryType {
+  None = "",
   ListAssets = "List Assets",
   CalibrationForecast = "Calibration Forecast",
   AssetSummary = "Asset Summary"
@@ -11,8 +12,18 @@ export enum AssetQueryType {
 
 export type AssetQuery = ListAssetsQuery | CalibrationForecastQuery | AssetSummaryQuery;
 
+export interface AssetFeatureToggles {
+  calibrationForecast: boolean;
+  assetList: boolean;
+  assetSummary: boolean;
+}
+
 export interface AssetDataSourceOptions extends DataSourceJsonData {
-  calibrationForecastEnabled: boolean | null;
-  assetListEnabled: boolean | null;
-  assetSummaryEnabled: boolean | null;
+  featureToggles: AssetFeatureToggles;
+}
+
+export const AssetFeatureTogglesDefaults: AssetFeatureToggles = {
+  assetList: true,
+  calibrationForecast: false,
+  assetSummary: false
 }

--- a/src/datasources/asset/types/types.ts
+++ b/src/datasources/asset/types/types.ts
@@ -24,6 +24,6 @@ export interface AssetDataSourceOptions extends DataSourceJsonData {
 
 export const AssetFeatureTogglesDefaults: AssetFeatureToggles = {
   assetList: true,
-  calibrationForecast: false,
-  assetSummary: false
+  calibrationForecast: true,
+  assetSummary: true
 }

--- a/src/datasources/data-frame/DataFrameDataSource.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.ts
@@ -1,6 +1,6 @@
 import TTLCache from '@isaacs/ttlcache';
 import deepEqual from 'fast-deep-equal';
-import { DataQueryRequest, DataSourceInstanceSettings, FieldType, TimeRange, FieldDTO, dateTime, DataFrameDTO, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
+import { DataQueryRequest, DataSourceInstanceSettings, FieldType, TimeRange, FieldDTO, dateTime, DataFrameDTO, MetricFindValue, TestDataSourceResponse, DataSourceJsonData } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import {
   ColumnDataType,
@@ -19,7 +19,7 @@ import _ from 'lodash';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { replaceVariables } from 'core/utils';
 
-export class DataFrameDataSource extends DataSourceBase<DataFrameQuery> {
+export class DataFrameDataSource extends DataSourceBase<DataFrameQuery, DataSourceJsonData> {
   private readonly metadataCache: TTLCache<string, TableMetadata> = new TTLCache({ ttl: metadataCacheTTL });
 
   constructor(

--- a/src/datasources/system/SystemDataSource.ts
+++ b/src/datasources/system/SystemDataSource.ts
@@ -2,6 +2,7 @@ import {
   DataFrameDTO,
   DataQueryRequest,
   DataSourceInstanceSettings,
+  DataSourceJsonData,
   MetricFindValue,
   TestDataSourceResponse
 } from '@grafana/data';
@@ -12,7 +13,7 @@ import { NetworkUtils } from './network-utils';
 import { SystemQuery, SystemQueryType, SystemSummary, SystemVariableQuery } from './types';
 import { getWorkspaceName } from 'core/utils';
 
-export class SystemDataSource extends DataSourceBase<SystemQuery> {
+export class SystemDataSource extends DataSourceBase<SystemQuery, DataSourceJsonData> {
   constructor(
     readonly instanceSettings: DataSourceInstanceSettings,
     readonly backendSrv: BackendSrv = getBackendSrv(),

--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -7,6 +7,7 @@ import {
   TestDataSourceResponse,
   FieldConfig,
   dateTime,
+  DataSourceJsonData,
 } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
@@ -21,7 +22,7 @@ import {
 } from './types';
 import { Throw, getWorkspaceName } from 'core/utils';
 
-export class TagDataSource extends DataSourceBase<TagQuery> {
+export class TagDataSource extends DataSourceBase<TagQuery, DataSourceJsonData> {
   constructor(
     readonly instanceSettings: DataSourceInstanceSettings,
     readonly backendSrv: BackendSrv = getBackendSrv(),

--- a/src/datasources/workspace/WorkspaceDataSource.ts
+++ b/src/datasources/workspace/WorkspaceDataSource.ts
@@ -1,10 +1,10 @@
-import { DataFrameDTO, DataSourceInstanceSettings, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
+import { DataFrameDTO, DataSourceInstanceSettings, DataSourceJsonData, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { Workspace } from 'core/types';
 import { WorkspaceQuery } from './types';
 
-export class WorkspaceDataSource extends DataSourceBase<WorkspaceQuery> {
+export class WorkspaceDataSource extends DataSourceBase<WorkspaceQuery, DataSourceJsonData> {
   constructor(
     readonly instanceSettings: DataSourceInstanceSettings,
     readonly backendSrv: BackendSrv = getBackendSrv(),

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -26,7 +26,8 @@ const mockVariables: TypedVariableModel[] = [{
 }]
 
 export function setupDataSource<T>(
-  ctor: new (instanceSettings: DataSourceInstanceSettings<any>, backendSrv: BackendSrv, templateSrv: TemplateSrv) => T
+  ctor: new (instanceSettings: DataSourceInstanceSettings<any>, backendSrv: BackendSrv, templateSrv: TemplateSrv) => T,
+  getDatasourceOptions:  () => any = () => {}
 ) {
   const mockBackendSrv = mock<BackendSrv>(
     {},
@@ -40,19 +41,20 @@ export function setupDataSource<T>(
     replace: calledWithFn({ fallbackMockImplementation: target => target ?? '' }),
     getVariables: calledWithFn({ fallbackMockImplementation: () => mockVariables })
   });
-  const ds = new ctor({ url: '' } as DataSourceInstanceSettings, mockBackendSrv, mockTemplateSrv);
+  const ds = new ctor({ url: '', jsonData: getDatasourceOptions() } as DataSourceInstanceSettings<any>, mockBackendSrv, mockTemplateSrv);
   return [ds, mockBackendSrv, mockTemplateSrv] as const;
 }
 
 export function setupRenderer<DSType extends DataSourceApi<TQuery, any>, TQuery extends DataQuery>(
   component: (props: QueryEditorProps<DSType, TQuery>) => React.JSX.Element,
-  ds: new (instanceSettings: DataSourceInstanceSettings<any>, backendSrv: BackendSrv) => DSType
+  ds: new (instanceSettings: DataSourceInstanceSettings<any>, backendSrv: BackendSrv) => DSType,
+  getDatasourceOptions: () => any = () => {}
 ) {
   return (initialQuery: Omit<TQuery, 'refId'>) => {
     const onChange = jest.fn<void, [TQuery]>(),
       onRunQuery = jest.fn();
 
-    const [datasource] = setupDataSource(ds);
+    const [datasource] = setupDataSource(ds, getDatasourceOptions);
 
     const createElement = (query: TQuery) =>
       React.createElement(component, { datasource, query, onRunQuery, onChange });

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -26,7 +26,7 @@ const mockVariables: TypedVariableModel[] = [{
 }]
 
 export function setupDataSource<T>(
-  ctor: new (instanceSettings: DataSourceInstanceSettings, backendSrv: BackendSrv, templateSrv: TemplateSrv) => T
+  ctor: new (instanceSettings: DataSourceInstanceSettings<any>, backendSrv: BackendSrv, templateSrv: TemplateSrv) => T
 ) {
   const mockBackendSrv = mock<BackendSrv>(
     {},
@@ -44,9 +44,9 @@ export function setupDataSource<T>(
   return [ds, mockBackendSrv, mockTemplateSrv] as const;
 }
 
-export function setupRenderer<DSType extends DataSourceApi<TQuery>, TQuery extends DataQuery>(
+export function setupRenderer<DSType extends DataSourceApi<TQuery, any>, TQuery extends DataQuery>(
   component: (props: QueryEditorProps<DSType, TQuery>) => React.JSX.Element,
-  ds: new (instanceSettings: DataSourceInstanceSettings, backendSrv: BackendSrv) => DSType
+  ds: new (instanceSettings: DataSourceInstanceSettings<any>, backendSrv: BackendSrv) => DSType
 ) {
   return (initialQuery: Omit<TQuery, 'refId'>) => {
     const onChange = jest.fn<void, [TQuery]>(),


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In order to support granular control on the plugins, we need to have a proper feature flag support. 

<img width="959" alt="image" src="https://github.com/user-attachments/assets/4079f4f2-c766-44fb-9e41-c57241857f52">

## 👩‍💻 Implementation

- Added feature flag configuration options via jsonData for asset plugins.
- Prepared feature flag support for other plugins as well.

## 🧪 Testing

- Unit test
- Manual test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).