### PR TITLE
feat(asset): load dependencies only once, change ttlcache to map

### DIFF
--- a/src/core/query-builder.utils.test.ts
+++ b/src/core/query-builder.utils.test.ts
@@ -1,5 +1,4 @@
 import { expressionBuilderCallback, expressionReaderCallback, ExpressionTransformFunction, transformComputedFieldsQuery } from "./query-builder.utils"
-import TTLCache from "@isaacs/ttlcache";
 
 describe('QueryBuilderUtils', () => {
   describe('transformComputedFieldsQuery', () => {
@@ -50,9 +49,9 @@ describe('QueryBuilderUtils', () => {
     });
 
     it('should handle options correctly', () => {
-      const options = new Map<string, TTLCache<string, unknown>>();
-      const cache = new TTLCache<string, unknown>();
-      cache.set('key', 'value', { ttl: 1 });
+      const options = new Map<string, Map<string, unknown>>();
+      const cache = new Map<string, unknown>();
+      cache.set('key', 'value');
       options.set('Object1', cache);
 
       const query = 'Object1 = "value1"';

--- a/src/core/query-builder.utils.ts
+++ b/src/core/query-builder.utils.ts
@@ -1,6 +1,5 @@
 import { QueryBuilderCustomOperation } from "smart-webcomponents-react";
 import { QueryBuilderOption } from "./types";
-import TTLCache from "@isaacs/ttlcache";
 
 /**
  * Should be used when looking to build a custom expression for a field
@@ -9,7 +8,7 @@ import TTLCache from "@isaacs/ttlcache";
  * @param options The options to be used in the transformation
  * @returns The transformed value
  */
-export type ExpressionTransformFunction = (value: string, operation: string, options?: TTLCache<string, unknown>) => string;
+export type ExpressionTransformFunction = (value: string, operation: string, options?: Map<string, unknown>) => string;
 
 /**
  * Supported operations for computed fields
@@ -27,7 +26,7 @@ export const computedFieldsupportedOperations = ['=', '!='];
 export function transformComputedFieldsQuery(
   query: string,
   computedDataFields: Map<string, ExpressionTransformFunction>,
-  options?: Map<string, TTLCache<string, unknown>>
+  options?: Map<string, Map<string, unknown>>
 ) {
   for (const [field, transformation] of computedDataFields.entries()) {
     const regex = new RegExp(`\\b${field}\\s*(${computedFieldsupportedOperations.join('|')})\\s*"([^"]*)"`, 'g');

--- a/src/datasources/asset-calibration/AssetCalibrationDataSource.ts
+++ b/src/datasources/asset-calibration/AssetCalibrationDataSource.ts
@@ -28,7 +28,6 @@ import { defaultOrderBy, defaultProjection } from 'datasources/system/constants'
 import { QueryBuilderOperations } from 'core/query-builder.constants';
 import { Workspace } from 'core/types';
 import { parseErrorMessage } from 'core/errors';
-import { Subject } from 'rxjs';
 
 export class AssetCalibrationDataSource extends DataSourceBase<AssetCalibrationQuery, DataSourceJsonData> {
   public defaultQuery = {
@@ -36,8 +35,11 @@ export class AssetCalibrationDataSource extends DataSourceBase<AssetCalibrationQ
     filter: ''
   };
 
-  public areSystemsLoaded$ = new Subject<void>();
-  public areWorkspacesLoaded$ = new Subject<void>();
+  private systemsLoaded!: () => void;
+  private workspacesLeaded!: () => void;
+
+  public areSystemsLoaded$ = new Promise<void>(resolve => this.systemsLoaded = resolve);
+  public areWorkspacesLoaded$ = new Promise<void>(resolve => this.workspacesLeaded = resolve);
 
   public error = '';
 
@@ -295,8 +297,7 @@ export class AssetCalibrationDataSource extends DataSourceBase<AssetCalibrationQ
 
     systems?.forEach(system => this.systemAliasCache.set(system.id, system));
 
-    this.areSystemsLoaded$.next();
-    this.areSystemsLoaded$.complete();
+    this.systemsLoaded();
   }
 
   private async loadWorkspaces(): Promise<void> {
@@ -311,8 +312,7 @@ export class AssetCalibrationDataSource extends DataSourceBase<AssetCalibrationQ
 
     workspaces?.forEach(workspace => this.workspacesCache.set(workspace.id, workspace));
 
-    this.areWorkspacesLoaded$.next();
-    this.areWorkspacesLoaded$.complete();
+    this.workspacesLeaded();
   }
 
   async loadDependencies(): Promise<void> {

--- a/src/datasources/asset-calibration/__snapshots__/AssetCalibrationDataSource.test.ts.snap
+++ b/src/datasources/asset-calibration/__snapshots__/AssetCalibrationDataSource.test.ts.snap
@@ -195,7 +195,7 @@ exports[`queries calibration forecast with minion ID location groupBy 1`] = `
       {
         "name": "Group",
         "values": [
-          "Minion1-alias",
+          "Minion1",
           "Minion2",
           "Minion3",
         ],

--- a/src/datasources/asset-calibration/components/AssetCalibrationQueryEditor.tsx
+++ b/src/datasources/asset-calibration/components/AssetCalibrationQueryEditor.tsx
@@ -10,7 +10,6 @@ import { Workspace } from 'core/types';
 import { FloatingError } from 'core/errors';
 import { SystemMetadata } from 'datasources/system/types';
 import './AssetCalibrationQueryEditor.scss';
-import { forkJoin } from 'rxjs';
 
 type Props = QueryEditorProps<AssetCalibrationDataSource, AssetCalibrationQuery>;
 
@@ -21,12 +20,11 @@ export const AssetCalibrationQueryEditor = ({ query, onChange, onRunQuery, datas
   const [areDependenciesLoaded, setAreDependenciesLoaded] = useState<boolean>(false);
 
   useEffect(() => {
-    forkJoin([datasource.areWorkspacesLoaded$, datasource.areSystemsLoaded$])
-      .subscribe(() => {
-        setWorkspaces(Array.from(datasource.workspacesCache.values()));
-        setSystems(Array.from(datasource.systemAliasCache.values()));
-        setAreDependenciesLoaded(true);
-      })
+    Promise.all([datasource.areSystemsLoaded$, datasource.areWorkspacesLoaded$]).then(() => {
+      setWorkspaces(Array.from(datasource.workspacesCache.values()));
+      setSystems(Array.from(datasource.systemAliasCache.values()));
+      setAreDependenciesLoaded(true);
+    });
   }, [datasource]);
 
   const handleQueryChange = (value: AssetCalibrationQuery, runQuery: boolean): void => {

--- a/src/datasources/asset-calibration/components/AssetCalibrationQueryEditor.tsx
+++ b/src/datasources/asset-calibration/components/AssetCalibrationQueryEditor.tsx
@@ -10,6 +10,7 @@ import { Workspace } from 'core/types';
 import { FloatingError } from 'core/errors';
 import { SystemMetadata } from 'datasources/system/types';
 import './AssetCalibrationQueryEditor.scss';
+import { forkJoin } from 'rxjs';
 
 type Props = QueryEditorProps<AssetCalibrationDataSource, AssetCalibrationQuery>;
 
@@ -20,16 +21,13 @@ export const AssetCalibrationQueryEditor = ({ query, onChange, onRunQuery, datas
   const [areDependenciesLoaded, setAreDependenciesLoaded] = useState<boolean>(false);
 
   useEffect(() => {
-    if (datasource.areWorkspacesLoaded) {
-      setWorkspaces(Array.from(datasource.workspacesCache.values()));
-    }
-
-    if (datasource.areSystemsLoaded) {
-      setSystems(Array.from(datasource.systemAliasCache.values()));
-    }
-
-    setAreDependenciesLoaded(datasource.areSystemsLoaded && datasource.areWorkspacesLoaded);
-  }, [datasource, datasource.areSystemsLoaded, datasource.areWorkspacesLoaded]);
+    forkJoin([datasource.areWorkspacesLoaded$, datasource.areSystemsLoaded$])
+      .subscribe(() => {
+        setWorkspaces(Array.from(datasource.workspacesCache.values()));
+        setSystems(Array.from(datasource.systemAliasCache.values()));
+        setAreDependenciesLoaded(true);
+      })
+  }, [datasource]);
 
   const handleQueryChange = (value: AssetCalibrationQuery, runQuery: boolean): void => {
     onChange(value);


### PR DESCRIPTION
# Pull Request

We don't need Cache for our dependencies, storing them in memory once it's enough.
Setting the dependencies in queryEditor wasn't consistent.
Dependencies wouldn't load unless a query was made.

## 👩‍💻 Implementation

Used Map for easy retrieval of data instead of TTLCache.
Updated how the queryEditor knows when the loading is finished, used rxjs for it in order to make sure we load the data after everything is set.
Dependencies are loading regardless, if a query is ran at the start it will wait for the dependencies to load, no extra loading is done.

## 🧪 Testing
Plugin behaves the same.

## ✅ Checklist

- [x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).