### PR TITLE
feat(asset): add group by vendor, assetType, busType

### DIFF
--- a/src/datasources/asset-calibration/AssetCalibrationDataSource.test.ts
+++ b/src/datasources/asset-calibration/AssetCalibrationDataSource.test.ts
@@ -12,6 +12,8 @@ import {
   AssetCalibrationPropertyGroupByType,
   AssetCalibrationQuery,
   AssetCalibrationTimeBasedGroupByType,
+  AssetType,
+  BusType,
   CalibrationForecastResponse,
   ColumnDescriptorType,
 } from "./types";
@@ -132,6 +134,36 @@ const workspaceGroupCalibrationForecastResponseMock: CalibrationForecastResponse
   }
 }
 
+const vendorGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
+{
+  calibrationForecast: {
+    columns: [
+      { name: "", values: [1], columnDescriptors: [{ value: "Vendor1", type: ColumnDescriptorType.StringValue }] },
+      { name: "", values: [2], columnDescriptors: [{ value: "Vendor2", type: ColumnDescriptorType.StringValue }] }
+    ]
+  }
+}
+
+const assetTypeGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
+{
+  calibrationForecast: {
+    columns: [
+      { name: "", values: [1], columnDescriptors: [{ value: AssetType.GENERIC, type: ColumnDescriptorType.AssetType }] },
+      { name: "", values: [2], columnDescriptors: [{ value: AssetType.DEVICE_UNDER_TEST, type: ColumnDescriptorType.AssetType }] }
+    ]
+  }
+}
+
+const busTypeGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
+{
+  calibrationForecast: {
+    columns: [
+      { name: "", values: [1], columnDescriptors: [{ value: BusType.BUILT_IN_SYSTEM, type: ColumnDescriptorType.BusType }] },
+      { name: "", values: [2], columnDescriptors: [{ value: BusType.FIRE_WIRE, type: ColumnDescriptorType.BusType }] }
+    ]
+  }
+}
+
 const modelWorkspaceGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
 {
   calibrationForecast: {
@@ -150,6 +182,42 @@ const monthWorkspaceGroupCalibrationForecastResponseMock: CalibrationForecastRes
       { name: "", values: [1, 2, 3], columnDescriptors: [{ value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] },
       { name: "", values: [2, 4, 1], columnDescriptors: [{ value: "Workspace2", type: ColumnDescriptorType.WorkspaceId }] },
       { name: "", values: [4, 3, 1], columnDescriptors: [{ value: "Workspace3", type: ColumnDescriptorType.WorkspaceId }] }
+    ]
+  }
+}
+
+const monthVendorGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
+{
+  calibrationForecast: {
+    columns: [
+      { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
+      { name: "", values: [1, 2, 3], columnDescriptors: [{ value: "Vendor1", type: ColumnDescriptorType.StringValue }] },
+      { name: "", values: [2, 4, 1], columnDescriptors: [{ value: "Vendor2", type: ColumnDescriptorType.StringValue }] },
+      { name: "", values: [4, 3, 1], columnDescriptors: [{ value: "Vendor3", type: ColumnDescriptorType.StringValue }] }
+    ]
+  }
+}
+
+const monthAssetTypeGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
+{
+  calibrationForecast: {
+    columns: [
+      { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
+      { name: "", values: [1, 2, 3], columnDescriptors: [{ value: AssetType.DEVICE_UNDER_TEST, type: ColumnDescriptorType.AssetType }] },
+      { name: "", values: [2, 4, 1], columnDescriptors: [{ value: AssetType.FIXTURE, type: ColumnDescriptorType.AssetType }] },
+      { name: "", values: [4, 3, 1], columnDescriptors: [{ value: AssetType.GENERIC, type: ColumnDescriptorType.AssetType }] }
+    ]
+  }
+}
+
+const monthBusTypeGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
+{
+  calibrationForecast: {
+    columns: [
+      { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
+      { name: "", values: [1, 2, 3], columnDescriptors: [{ value: BusType.BUILT_IN_SYSTEM, type: ColumnDescriptorType.BusType }] },
+      { name: "", values: [2, 4, 1], columnDescriptors: [{ value: BusType.ACCESSORY, type: ColumnDescriptorType.BusType }] },
+      { name: "", values: [4, 3, 1], columnDescriptors: [{ value: BusType.SERIAL, type: ColumnDescriptorType.BusType }] }
     ]
   }
 }
@@ -355,6 +423,72 @@ describe('queries', () => {
     expect(result.data).toMatchSnapshot()
   })
 
+  test('calibration forecast with vendor groupBy', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
+      .mockReturnValue(createFetchResponse(vendorGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+
+    const result = await datastore.query(buildCalibrationForecastQuery({ groupBy: [AssetCalibrationPropertyGroupByType.Vendor] }))
+
+    expect(result.data).toMatchSnapshot();
+  })
+
+  test('calibration forecast with month and vendor groupBy', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
+      .mockReturnValue(createFetchResponse(monthVendorGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+
+    const result = await datastore.query(buildCalibrationForecastQuery({
+      groupBy: [AssetCalibrationTimeBasedGroupByType.Month, AssetCalibrationPropertyGroupByType.Vendor]
+    }));
+
+    expect(result.data).toMatchSnapshot();
+  })
+
+  test('calibration forecast with assetType groupBy', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
+      .mockReturnValue(createFetchResponse(assetTypeGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+
+    const result = await datastore.query(buildCalibrationForecastQuery({ groupBy: [AssetCalibrationPropertyGroupByType.AssetType] }))
+
+    expect(result.data).toMatchSnapshot();
+  })
+
+  test('calibration forecast with month and assetType groupBy', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
+      .mockReturnValue(createFetchResponse(monthAssetTypeGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+
+    const result = await datastore.query(buildCalibrationForecastQuery({
+      groupBy: [AssetCalibrationTimeBasedGroupByType.Month, AssetCalibrationPropertyGroupByType.AssetType]
+    }));
+
+    expect(result.data).toMatchSnapshot();
+  })
+
+  test('calibration forecast with busType groupBy', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
+      .mockReturnValue(createFetchResponse(busTypeGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+
+    const result = await datastore.query(buildCalibrationForecastQuery({ groupBy: [AssetCalibrationPropertyGroupByType.BusType] }))
+
+    expect(result.data).toMatchSnapshot();
+  })
+
+  test('calibration forecast with month and busType groupBy', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
+      .mockReturnValue(createFetchResponse(monthBusTypeGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+
+    const result = await datastore.query(buildCalibrationForecastQuery({
+      groupBy: [AssetCalibrationTimeBasedGroupByType.Month, AssetCalibrationPropertyGroupByType.BusType]
+    }));
+
+    expect(result.data).toMatchSnapshot();
+  })
+
   test('calibration forecast with month groupBy returns empty results', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
@@ -372,7 +506,7 @@ describe('queries', () => {
 
     await expect(datastore.query(buildCalibrationForecastQuery(monthBasedCalibrationForecastQueryMock))).rejects.toThrow()
   })
-  
+
   test('validate DAY grouping', async () => {
     const request = buildCalibrationForecastQuery(dayBasedCalibrationForecastQueryMock);
     const numberOfDays = 31 * 3 + 1;

--- a/src/datasources/asset-calibration/__snapshots__/AssetCalibrationDataSource.test.ts.snap
+++ b/src/datasources/asset-calibration/__snapshots__/AssetCalibrationDataSource.test.ts.snap
@@ -114,6 +114,54 @@ exports[`queries asset calibration forecast with week groupBy 1`] = `
 ]
 `;
 
+exports[`queries calibration forecast with assetType groupBy 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "Group",
+        "values": [
+          "Generic",
+          "Device under test",
+        ],
+      },
+      {
+        "name": "Assets",
+        "values": [
+          1,
+          2,
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries calibration forecast with busType groupBy 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "Group",
+        "values": [
+          "Built-in-system",
+          "FireWire",
+        ],
+      },
+      {
+        "name": "Assets",
+        "values": [
+          1,
+          2,
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
 exports[`queries calibration forecast with location groupBy 1`] = `
 [
   {
@@ -238,6 +286,138 @@ exports[`queries calibration forecast with model groupBy 1`] = `
 ]
 `;
 
+exports[`queries calibration forecast with month and assetType groupBy 1`] = `
+[
+  {
+    "fields": [
+      {
+        "columnDescriptors": [
+          {
+            "type": "TIME",
+            "value": "Month",
+          },
+        ],
+        "name": "Month",
+        "values": [
+          "January 2022",
+          "February 2022",
+          "March 2022",
+        ],
+      },
+      {
+        "columnDescriptors": [
+          {
+            "type": "ASSET_TYPE",
+            "value": "DEVICE_UNDER_TEST",
+          },
+        ],
+        "name": "Device under test",
+        "values": [
+          1,
+          2,
+          3,
+        ],
+      },
+      {
+        "columnDescriptors": [
+          {
+            "type": "ASSET_TYPE",
+            "value": "FIXTURE",
+          },
+        ],
+        "name": "Fixture",
+        "values": [
+          2,
+          4,
+          1,
+        ],
+      },
+      {
+        "columnDescriptors": [
+          {
+            "type": "ASSET_TYPE",
+            "value": "GENERIC",
+          },
+        ],
+        "name": "Generic",
+        "values": [
+          4,
+          3,
+          1,
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries calibration forecast with month and busType groupBy 1`] = `
+[
+  {
+    "fields": [
+      {
+        "columnDescriptors": [
+          {
+            "type": "TIME",
+            "value": "Month",
+          },
+        ],
+        "name": "Month",
+        "values": [
+          "January 2022",
+          "February 2022",
+          "March 2022",
+        ],
+      },
+      {
+        "columnDescriptors": [
+          {
+            "type": "BUS_TYPE",
+            "value": "BUILT_IN_SYSTEM",
+          },
+        ],
+        "name": "Built-in-system",
+        "values": [
+          1,
+          2,
+          3,
+        ],
+      },
+      {
+        "columnDescriptors": [
+          {
+            "type": "BUS_TYPE",
+            "value": "ACCESSORY",
+          },
+        ],
+        "name": "ACCESSORY",
+        "values": [
+          2,
+          4,
+          1,
+        ],
+      },
+      {
+        "columnDescriptors": [
+          {
+            "type": "BUS_TYPE",
+            "value": "SERIAL",
+          },
+        ],
+        "name": "Serial",
+        "values": [
+          4,
+          3,
+          1,
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
 exports[`queries calibration forecast with month and location groupBy 1`] = `
 [
   {
@@ -292,6 +472,72 @@ exports[`queries calibration forecast with month and location groupBy 1`] = `
           },
         ],
         "name": "Location3",
+        "values": [
+          4,
+          3,
+          1,
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries calibration forecast with month and vendor groupBy 1`] = `
+[
+  {
+    "fields": [
+      {
+        "columnDescriptors": [
+          {
+            "type": "TIME",
+            "value": "Month",
+          },
+        ],
+        "name": "Month",
+        "values": [
+          "January 2022",
+          "February 2022",
+          "March 2022",
+        ],
+      },
+      {
+        "columnDescriptors": [
+          {
+            "type": "STRING_VALUE",
+            "value": "Vendor1",
+          },
+        ],
+        "name": "Vendor1",
+        "values": [
+          1,
+          2,
+          3,
+        ],
+      },
+      {
+        "columnDescriptors": [
+          {
+            "type": "STRING_VALUE",
+            "value": "Vendor2",
+          },
+        ],
+        "name": "Vendor2",
+        "values": [
+          2,
+          4,
+          1,
+        ],
+      },
+      {
+        "columnDescriptors": [
+          {
+            "type": "STRING_VALUE",
+            "value": "Vendor3",
+          },
+        ],
+        "name": "Vendor3",
         "values": [
           4,
           3,
@@ -374,6 +620,30 @@ exports[`queries calibration forecast with month groupBy returns empty results 1
 [
   {
     "fields": [],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`queries calibration forecast with vendor groupBy 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "Group",
+        "values": [
+          "Vendor1",
+          "Vendor2",
+        ],
+      },
+      {
+        "name": "Assets",
+        "values": [
+          1,
+          2,
+        ],
+      },
+    ],
     "refId": "A",
   },
 ]

--- a/src/datasources/asset-calibration/types.ts
+++ b/src/datasources/asset-calibration/types.ts
@@ -16,6 +16,9 @@ export enum AssetCalibrationPropertyGroupByType {
   Location = "LOCATION",
   Model = "MODEL",
   Workspace = "WORKSPACE",
+  Vendor = "VENDOR_NAME",
+  AssetType = "ASSET_TYPE",
+  BusType = "BUS_TYPE",
 }
 
 export enum AssetCalibrationTimeBasedGroupByType {
@@ -73,6 +76,8 @@ export enum ColumnDescriptorType {
   StringValue = "STRING_VALUE",
   MinionId = "MINION_ID",
   WorkspaceId = "WORKSPACE_ID",
+  AssetType = "ASSET_TYPE",
+  BusType = "BUS_TYPE",
 }
 
 export interface QBField extends QueryBuilderField {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
[Task 2883056](https://dev.azure.com/ni/DevCentral/_workitems/edit/2883056): [Grafana][UI] Add VendorName, BusType and AssetType GroupBy

## 👩‍💻 Implementation
Updated the enum, added maps for labels, resolved the values.

## 🧪 Testing
Added tests for grouping

![image](https://github.com/user-attachments/assets/bac5f148-a946-48ae-8db1-5ac49aef186e)

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).