### PR TITLE
feat(assets): fix explorer rendering for assets plugin

### DIFF
--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -55,13 +55,13 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
   }, [queryType]);
 
   useEffect(() => {
-    if (!queryType) {
+    if (!query.queryType) {
       const firstFilterOption = filterOptions.length > 0 ? filterOptions[0].value : undefined;
-      if(firstFilterOption){
+      if (firstFilterOption) {
         handleQueryTypeChange({ value: firstFilterOption });
       }
     }
-  }, [handleQueryTypeChange, filterOptions, queryType]);
+  }, [query.queryType, handleQueryTypeChange, filterOptions]);
 
   return (
     <div style={{ position: 'relative' }}>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The explorer fails to start when the asset plugin is selected

<img width="1844" alt="image" src="https://github.com/user-attachments/assets/73463e57-91bd-4454-9733-080297cd6259">

## 👩‍💻 Implementation

Avoid getting to render in loop when query type is set on the explorer

## 🧪 Testing

Unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).