### PR TITLE
feat(asset): avoid side effects on field constants

### DIFF
--- a/src/datasources/asset/components/editors/calibration-forecast/CalibrationForecastEditor.tsx
+++ b/src/datasources/asset/components/editors/calibration-forecast/CalibrationForecastEditor.tsx
@@ -104,7 +104,7 @@ export function CalibrationForecastEditor({ query, handleQueryChange, datasource
           filter={query.filter}
           workspaces={workspaces}
           systems={systems}
-          globalVariableOptions={datasource.globalVariableOptions}
+          globalVariableOptions={datasource.globalVariableOptions()}
           areDependenciesLoaded={areDependenciesLoaded}
           onChange={(event: any) => onParameterChange(event)}
         ></CalibrationForecastQueryBuilder>

--- a/src/datasources/asset/components/editors/calibration-forecast/query-builder/CalibrationForecastQueryBuilder.test.tsx
+++ b/src/datasources/asset/components/editors/calibration-forecast/query-builder/CalibrationForecastQueryBuilder.test.tsx
@@ -1,17 +1,19 @@
 import React, { ReactNode } from "react";
 import { CalibrationForecastQueryBuilder } from "./CalibrationForecastQueryBuilder";
 import { render } from "@testing-library/react";
-import { Workspace } from "core/types";
+import { QueryBuilderOption, Workspace } from "core/types";
 import { SystemMetadata } from "datasources/system/types";
 
 describe('CalibrationForecastQueryBuilder', () => {
   describe('useEffects', () => {
     let reactNode: ReactNode
 
-    const containerClass = 'smart-filter-group-condition-container'
+    const containerClass = 'smart-filter-group-condition-container';
+    const workspace = { id: '1', name: 'Selected workspace' } as Workspace;
+    const system = { id: '1', alias: 'Selected system' } as SystemMetadata;
 
-    function renderElement(workspaces: Workspace[], systems: SystemMetadata[], filter?: string) {
-      reactNode = React.createElement(CalibrationForecastQueryBuilder, { workspaces, systems, filter, globalVariableOptions: [], onChange: jest.fn(), areDependenciesLoaded: true });
+    function renderElement(workspaces: Workspace[], systems: SystemMetadata[], filter?: string, globalVariableOptions: QueryBuilderOption[] = []) {
+      reactNode = React.createElement(CalibrationForecastQueryBuilder, { workspaces, systems, filter, globalVariableOptions, onChange: jest.fn(), areDependenciesLoaded: true });
       const renderResult = render(reactNode);
       return {
         renderResult,
@@ -21,13 +23,12 @@ describe('CalibrationForecastQueryBuilder', () => {
 
     it('should render empty query builder', () => {
       const { renderResult, conditionsContainer } = renderElement([], [], '');
+
       expect(conditionsContainer.length).toBe(1);
       expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
     })
 
     it('should select workspace in query builder', () => {
-      const workspace = { id: '1', name: 'Selected workspace' } as Workspace;
-      const system = { id: '1', alias: 'Selected system' } as SystemMetadata;
       const { conditionsContainer } = renderElement([workspace], [system], 'Workspace = "1" && ModelName = "SomeRandomModelName"');
 
       expect(conditionsContainer?.length).toBe(2);
@@ -36,13 +37,18 @@ describe('CalibrationForecastQueryBuilder', () => {
     })
 
     it('should select system in query builder', () => {
-      const workspace = { id: '1', name: 'Selected workspace' } as Workspace;
-      const system = { id: '1', alias: 'Selected system' } as SystemMetadata;
-
       const { conditionsContainer } = renderElement([workspace], [system], 'Location = "1"');
 
       expect(conditionsContainer?.length).toBe(1);
       expect(conditionsContainer.item(0)?.textContent).toContain(system.alias);
+    });
+
+    it('should select global variable option', () => {
+      const globalVariableOption = { label: 'Global variable', value: 'global_variable' };
+      const { conditionsContainer } = renderElement([workspace], [system], 'AssetType = \"global_variable\"', [globalVariableOption]);
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
     });
   });
 });

--- a/src/datasources/asset/components/editors/calibration-forecast/query-builder/CalibrationForecastQueryBuilder.tsx
+++ b/src/datasources/asset/components/editors/calibration-forecast/query-builder/CalibrationForecastQueryBuilder.tsx
@@ -66,7 +66,12 @@ export const CalibrationForecastQueryBuilder: React.FC<CalibrationForecastQueryB
       const fields = [workspaceField, locationField, ...AssetCalibrationStaticFields]
         .map(field => {
           if (field.lookup?.dataSource) {
-            field.lookup.dataSource = [...globalVariableOptions, ...field.lookup.dataSource];
+            return {
+              ...field,
+              lookup: {
+                dataSource: [...globalVariableOptions, ...field.lookup.dataSource]
+              }
+            }
           }
 
           return field;

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.tsx
@@ -47,7 +47,7 @@ export function ListAssetsEditor({ query, handleQueryChange, datasource }: Props
           filter={query.filter}
           workspaces={workspaces}
           systems={systems}
-          globalVariableOptions={datasource.globalVariableOptions}
+          globalVariableOptions={datasource.globalVariableOptions()}
           areDependenciesLoaded={areDependenciesLoaded}
           onChange={(event: any) => onParameterChange(event)}
         ></AssetQueryBuilder>

--- a/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.tsx
+++ b/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.tsx
@@ -76,7 +76,12 @@ export const AssetQueryBuilder: React.FC<AssetCalibrationQueryBuilderProps> = ({
     const fields = [workspaceField, locationField]
       .map(field => {
         if (field.lookup?.dataSource) {
-          field.lookup.dataSource = [...globalVariableOptions, ...field.lookup.dataSource];
+          return {
+            ...field,
+            lookup: {
+              dataSource: [...globalVariableOptions, ...field.lookup.dataSource]
+            }
+          }
         }
 
         return field;

--- a/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.tsx
+++ b/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.tsx
@@ -37,7 +37,7 @@ export function AssetVariableQueryEditor({ datasource, query, onChange }: Props)
         filter={assetVariableQuery.filter}
         workspaces={workspaces}
         systems={systems}
-        globalVariableOptions={assetListDatasource.current.globalVariableOptions}
+        globalVariableOptions={assetListDatasource.current.globalVariableOptions()}
         areDependenciesLoaded={areDependenciesLoaded}
         onChange={(event: any) => onParameterChange(event)}
       ></AssetQueryBuilder>

--- a/src/datasources/asset/data-sources/AssetDataSourceBase.ts
+++ b/src/datasources/asset/data-sources/AssetDataSourceBase.ts
@@ -8,6 +8,7 @@ import { QueryBuilderOption, Workspace } from "../../../core/types";
 import { ExpressionTransformFunction } from "../../../core/query-builder.utils";
 import { QueryBuilderOperations } from "../../../core/query-builder.constants";
 import { AllFieldNames } from "../constants/constants";
+import { getVariableOptions } from "core/utils";
 
 export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, AssetDataSourceOptions> {
   private systemsLoaded!: () => void;
@@ -21,11 +22,6 @@ export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, Ass
   public readonly systemAliasCache = new Map<string, SystemMetadata>([]);
   public readonly workspacesCache = new Map<string, Workspace>([]);
 
-  public readonly globalVariableOptions = (): QueryBuilderOption[] => {
-    return this.templateSrv.getVariables()
-      .filter(({ state }) => state === 'Done')
-      .map(({ name }) => ({ label: `$${name}`, value: `$${name}` })) || []
-  };
 
   abstract runQuery(query: AssetQuery, options: DataQueryRequest): Promise<DataFrameDTO>;
 
@@ -56,6 +52,8 @@ export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, Ass
   public getCachedWorkspaces(): Workspace[] {
     return Array.from(this.workspacesCache.values());
   }
+
+  public readonly globalVariableOptions = (): QueryBuilderOption[] => getVariableOptions(this);
 
   public async loadDependencies(): Promise<void> {
     this.error = '';

--- a/src/datasources/asset/data-sources/AssetDataSourceBase.ts
+++ b/src/datasources/asset/data-sources/AssetDataSourceBase.ts
@@ -21,7 +21,11 @@ export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, Ass
   public readonly systemAliasCache = new Map<string, SystemMetadata>([]);
   public readonly workspacesCache = new Map<string, Workspace>([]);
 
-  public readonly globalVariableOptions: QueryBuilderOption[] = this.templateSrv.getVariables()?.map(({ name }) => ({ label: `$${name}`, value: `$${name}` })) || [];
+  public readonly globalVariableOptions = (): QueryBuilderOption[] => {
+    return this.templateSrv.getVariables()
+      .filter(({ state }) => state === 'Done')
+      .map(({ name }) => ({ label: `$${name}`, value: `$${name}` })) || []
+  };
 
   abstract runQuery(query: AssetQuery, options: DataQueryRequest): Promise<DataFrameDTO>;
 
@@ -114,7 +118,7 @@ export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, Ass
         }
 
         return `(Location.MinionId ${operation} "${value}" ${this.getLocicalOperator(operation)} Location.PhysicalLocation ${operation} "${value}")`;
-  }]]);
+      }]]);
 
   protected multipleValuesQuery(field: string): ExpressionTransformFunction {
     return (value: string, operation: string, _options?: any) => {


### PR DESCRIPTION
# Pull Request

[Task 2908406](https://dev.azure.com/ni/DevCentral/_workitems/edit/2908406): Fix duplicate variable in query builder dropdown for asset type and bus type

## 👩‍💻 Implementation

Return a new instance instead of modifying the object.

## 🧪 Testing

![image](https://github.com/user-attachments/assets/7c8f6197-7ff8-4910-96a1-ebfd86dd79e2)

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).