### PR TITLE
feat(asset): added support for IncludeOnlyDataInTimeRange

### DIFF
--- a/src/datasources/asset/data-sources/AssetDataSourceBase.ts
+++ b/src/datasources/asset/data-sources/AssetDataSourceBase.ts
@@ -45,6 +45,14 @@ export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, Ass
     }
   }
 
+  getQueryParams(): URLSearchParams {
+    return new URLSearchParams(window.location.search);
+  }
+
+  getQueryParam(param: string): string | null {
+    return this.getQueryParams().get(param);
+  }
+
   public getCachedSystems(): SystemMetadata[] {
     return Array.from(this.systemAliasCache.values());
   }

--- a/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.ts
+++ b/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.ts
@@ -9,6 +9,12 @@ import { AssetModel, AssetsResponse } from '../../../asset-common/types';
 export class CalibrationForecastDataSource extends AssetDataSourceBase {
     private dependenciesLoadedPromise: Promise<void>;
 
+    private readonly forecastDateFormatterMap = new Map<AssetCalibrationForecastKey, (date: string) => string>([
+        [AssetCalibrationForecastKey.Day, this.formatDateForDay],
+        [AssetCalibrationForecastKey.Week, this.formatDateForWeek],
+        [AssetCalibrationForecastKey.Month, this.formatDateForMonth]
+    ]);
+
     constructor(
         readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,
         readonly backendSrv: BackendSrv = getBackendSrv(),
@@ -46,6 +52,7 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
             );
         }
 
+        calibrationForecastQuery.IncludeOnlyDataInTimeRange = this.getQueryParam('IncludeOnlyDataInTimeRange')?.toLowerCase() === 'true';
         return await this.processCalibrationForecastQuery(calibrationForecastQuery, options);
     }
 
@@ -63,7 +70,13 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
         const from = options.range!.from.toISOString();
         const to = options.range!.to.toISOString();
 
-        const calibrationForecastResponse: CalibrationForecastResponse = await this.queryCalibrationForecast(query.groupBy, from, to, query.filter);
+        const calibrationForecastResponse: CalibrationForecastResponse = await this.queryCalibrationForecast(
+            query.groupBy,
+            from,
+            to,
+            query.filter,
+            query.IncludeOnlyDataInTimeRange
+        );
 
         result.fields = calibrationForecastResponse.calibrationForecast.columns || [];
 
@@ -91,46 +104,65 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
     }
 
     processResultsGroupedByTime(result: DataFrameDTO, timeGrouping: AssetCalibrationForecastKey) {
+        const timeFieldFirstValue = result.fields.find(field => field.name === timeGrouping)?.values?.at(0);
+        const startDate = this.forecastDateFormatterMap.get(timeGrouping)!(timeFieldFirstValue);
+
         result.fields.forEach(field => {
             field.name = this.createColumnNameFromDescriptor(field as FieldDTOWithDescriptor);
-            switch (field.name) {
-                case AssetCalibrationForecastKey.Day:
-                    field.values = field.values!.map(this.formatDateForDay)
-                    break;
-                case AssetCalibrationForecastKey.Week:
-                    field.values = field.values!.map(this.formatDateForWeek)
-                    break;
-                case AssetCalibrationForecastKey.Month:
-                    field.values = field.values!.map(this.formatDateForMonth)
-                    break;
-                default:
-                    field.config = { links: this.createDataLinks(timeGrouping) };
-                    break;
+            const formatter = this.forecastDateFormatterMap.get(field.name as AssetCalibrationForecastKey);
+
+            if (formatter) {
+                field.values = field.values!.map(formatter);
+            }
+            
+            if (!formatter && !Boolean(this.getQueryParam('IncludeOnlyDataInTimeRange'))) {
+                field.config = { links: this.createDataLinks(timeGrouping, startDate) };
             }
         });
     }
 
-    private createDataLinks(timeGrouping: AssetCalibrationForecastKey): DataLink[] {
+    private createDataLinks(timeGrouping: AssetCalibrationForecastKey, startDate: string): DataLink[] {
         const url = '/d/${__dashboard.uid}/${__dashboard}?orgId=${__org.id}&${__all_variables}';
 
         return [
             {
                 title: `View ${timeGrouping}`, targetBlank: true, url: `${url}`,
                 onBuildUrl: function (options) {
-                    if (options.replaceVariables) {
-                        const value = options.replaceVariables(`\${__data.fields.${timeGrouping}}`);
-                        if (timeGrouping === AssetCalibrationForecastKey.Week) {
-                            const [from, to] = value.split(' : ').map(rangeItem => new Date(rangeItem).valueOf());
-                            return `${url}&from=${from}&to=${to}`;
-                        }
-
-                        const date = new Date(value);
-                        if (timeGrouping === AssetCalibrationForecastKey.Month) {
-                            date.setHours(12);
-                        }
-                        return `${url}&from=${date.valueOf()}&to=${date.valueOf()}`;
+                    if (!options.replaceVariables) {
+                        return url;
                     }
-                    return url;
+
+                    const value = options.replaceVariables(`\${__data.fields.${timeGrouping}}`);
+                    const IncludeOnlyDataInTimeRange = value !== startDate;
+
+                    let from, to;
+
+                    const parseDate = (dateStr: string) => {
+                        const date = new Date(dateStr);
+                        date.setUTCHours(0);
+                        return date;
+                    };
+
+                    switch (timeGrouping) {
+                        case AssetCalibrationForecastKey.Day:
+                            const dayDate = parseDate(value);
+                            from = dayDate.valueOf();
+                            dayDate.setUTCDate(dayDate.getUTCDate() + 1);
+                            to = dayDate.valueOf();
+                            break;
+                        case AssetCalibrationForecastKey.Week:
+                            [from, to] = value.split(' : ').map(dateStr => parseDate(dateStr).valueOf());
+                            break;
+                        case AssetCalibrationForecastKey.Month:
+                            const monthDate = parseDate(value);
+                            monthDate.setUTCDate(monthDate.getUTCDate() + 1);
+                            from = monthDate.valueOf();
+                            monthDate.setUTCMonth(monthDate.getUTCMonth() + 1);
+                            to = monthDate.valueOf();
+                            break;
+                    }
+
+                    return `${url}&from=${from}&to=${to}&IncludeOnlyDataInTimeRange=${IncludeOnlyDataInTimeRange}`;
                 }
             }
         ];
@@ -173,9 +205,11 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
     }
 
     formatDateForWeek(date: string): string {
+        console.log(date);
         const startDate = new Date(date);
         const endDate = new Date(startDate);
         endDate.setDate(startDate.getDate() + 6);
+        console.log(startDate)
         return `${startDate.toISOString().split('T')[0]} : ${endDate.toISOString().split('T')[0]}`;
     }
 
@@ -193,8 +227,8 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
         }
     }
 
-    async queryCalibrationForecast(groupBy: string[], startTime: string, endTime: string, filter = ''): Promise<CalibrationForecastResponse> {
-        let data = { groupBy, startTime, endTime, filter };
+    async queryCalibrationForecast(groupBy: string[], startTime: string, endTime: string, filter = '', IncludeOnlyDataInTimeRange = false): Promise<CalibrationForecastResponse> {
+        let data = { groupBy, startTime, endTime, filter, IncludeOnlyDataInTimeRange };
         try {
             let response = await this.post<CalibrationForecastResponse>(this.baseUrl + '/assets/calibration-forecast', data);
             return response;

--- a/src/datasources/asset/data-sources/calibration-forecast/__snapshots__/CalibrationForecastDataSource.test.ts.snap
+++ b/src/datasources/asset/data-sources/calibration-forecast/__snapshots__/CalibrationForecastDataSource.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Time based data links creates data links for Day grouping 1`] = `"/d/\${__dashboard.uid}/\${__dashboard}?orgId=\${__org.id}&\${__all_variables}&from=1640995200000&to=1641081600000&IncludeOnlyDataInTimeRange=true"`;
+
+exports[`Time based data links creates data links for Month grouping 1`] = `"/d/\${__dashboard.uid}/\${__dashboard}?orgId=\${__org.id}&\${__all_variables}&from=1641081600000&to=1643760000000&IncludeOnlyDataInTimeRange=true"`;
+
+exports[`Time based data links creates data links for Week grouping 1`] = `"/d/\${__dashboard.uid}/\${__dashboard}?orgId=\${__org.id}&\${__all_variables}&from=1641168000000&to=1641689999999&IncludeOnlyDataInTimeRange=true"`;
+
 exports[`queries asset calibration forecast with day groupBy 1`] = `
 [
   {

--- a/src/datasources/asset/types/CalibrationForecastQuery.types.ts
+++ b/src/datasources/asset/types/CalibrationForecastQuery.types.ts
@@ -5,6 +5,7 @@ import { AssetQuery } from './types';
 export interface CalibrationForecastQuery extends AssetQuery {
     groupBy: string[];
     filter?: string;
+    IncludeOnlyDataInTimeRange?: boolean;
 }
 
 export interface CalibrationForecastResponse {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We need the ability to add a flag so the service knows that it needs to query only data in the interval.

## 👩‍💻 Implementation

Updated data links and runQuery method to take into consideration IncludeOnlyDataInTimeRange

## 🧪 Testing

Added tests for the flag

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).