### PR TITLE
fix(asset): fix empty string error on Linq filter for assets

### DIFF
--- a/src/datasources/asset/data-sources/AssetDataSourceBase.ts
+++ b/src/datasources/asset/data-sources/AssetDataSourceBase.ts
@@ -115,7 +115,7 @@ export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, Ass
           return `Location.MinionId ${operation} "${value}"`
         }
 
-        return `(Location.MinionId ${operation} "${value}" ${this.getLocicalOperator(operation)} Location.PhysicalLocation ${operation} "${value}")`;
+        return `Locations.Any(l => l.MinionId ${operation} "${value}" ${this.getLocicalOperator(operation)} l.PhysicalLocation ${operation} "${value}")`;
       }]]);
 
   protected multipleValuesQuery(field: string): ExpressionTransformFunction {

--- a/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.test.ts
+++ b/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.test.ts
@@ -558,7 +558,7 @@ describe('Asset calibration location queries', () => {
     expect(processCalibrationForecastQuerySpy).toHaveBeenCalledWith(
       expect.objectContaining({
         groupBy: [AssetCalibrationTimeBasedGroupByType.Month],
-        filter: "(Location.MinionId = \"Location1\" || Location.PhysicalLocation = \"Location1\")"
+        filter: "Locations.Any(l => l.MinionId = \"Location1\" || l.PhysicalLocation = \"Location1\")"
       }),
       expect.anything()
     );

--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.test.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.test.ts
@@ -35,7 +35,7 @@ describe('List assets location queries', () => {
 
         expect(processlistAssetsQuerySpy).toHaveBeenCalledWith(
             expect.objectContaining({
-                filter: "(Location.MinionId = \"Location1\" || Location.PhysicalLocation = \"Location1\")"
+                filter: "Locations.Any(l => l.MinionId = \"Location1\" || l.PhysicalLocation = \"Location1\")"
             })
         );
     });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The query location fails on empty strings when comparing direct values due to preprocessing on the backend. In order to fix this, I will change the expression to use LINQ that's also supported by the API

## 👩‍💻 Implementation

- Manual testing
- Updated Unit tests

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements.

Include automated test additions or modifications, manual testing done on a local build, and additional testing not covered by automatic pull request validation.
-->

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).