### PR TITLE
feat(asset): more friendly options for calibration due date and add new option

### DIFF
--- a/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.test.tsx
+++ b/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.test.tsx
@@ -61,5 +61,15 @@ describe('AssetQueryBuilder', () => {
       expect(conditionsContainer?.length).toBe(1);
       expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
     });
+
+    it('should select user friendly value for calibration due date', () => {
+      const workspace = { id: '1', name: 'Selected workspace' } as Workspace;
+      const system = { id: '1', alias: 'Selected system' } as SystemMetadata;
+
+      const { conditionsContainer } = renderElement([workspace], [system], 'ExternalCalibration.NextRecommendedDate > \"${__from:date}\"');
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain("From");
+    });
   });
 });

--- a/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.tsx
+++ b/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.tsx
@@ -68,12 +68,29 @@ export const AssetQueryBuilder: React.FC<AssetCalibrationQueryBuilderProps> = ({
     };
   }, [systems]);
 
+  const calibrationDueDateField = useMemo(() =>
+  {
+    const calibrationField = ListAssetsFields.CALIBRATION_DUE_DATE;
+    return {
+      ...calibrationField,
+      lookup: {
+        ...calibrationField.lookup,
+        dataSource: [
+          ...(calibrationField.lookup?.dataSource || []),
+          { label: 'From', value: '${__from:date}' },
+          { label: 'To', value: '${__to:date}' },
+          { label: 'Now', value: new Date().toISOString() },
+        ],
+      },
+    };
+  }, []);
+
   useEffect(() => {
     if (!areDependenciesLoaded) {
       return;
     }
 
-    const fields = [workspaceField, locationField, ...ListAssetsStaticFields]
+    const fields = [workspaceField, locationField, calibrationDueDateField, ...ListAssetsStaticFields]
       .map(field => {
         if (field.lookup?.dataSource) {
           return {
@@ -113,12 +130,24 @@ export const AssetQueryBuilder: React.FC<AssetCalibrationQueryBuilderProps> = ({
       },
       QueryBuilderOperations.CONTAINS,
       QueryBuilderOperations.DOES_NOT_CONTAIN,
-      QueryBuilderOperations.LESS_THAN,
-      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO,
-      QueryBuilderOperations.GREATER_THAN,
-      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO
+      {
+        ...QueryBuilderOperations.LESS_THAN,
+        ...callbacks,
+      },
+      {
+        ...QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO,
+        ...callbacks,
+      },
+      {
+        ...QueryBuilderOperations.GREATER_THAN,
+        ...callbacks,
+      },
+      {
+        ...QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO,
+        ...callbacks,
+      }
     ]);
-  }, [workspaceField, locationField, areDependenciesLoaded, globalVariableOptions]);
+  }, [workspaceField, locationField, calibrationDueDateField, areDependenciesLoaded, globalVariableOptions]);
 
   return (
     <QueryBuilder

--- a/src/datasources/asset/constants/ListAssets.constants.ts
+++ b/src/datasources/asset/constants/ListAssets.constants.ts
@@ -1,6 +1,6 @@
 import { QueryBuilderOperations } from "../../../core/query-builder.constants";
 import { QBField } from "../types/CalibrationForecastQuery.types";
-import { AssetTypeOptions, BusTypeOptions, ResolvedDueDateOptions } from "../types/types";
+import { AssetTypeOptions, BusTypeOptions } from "../types/types";
 
 export enum ListAssetsFieldNames {
     LOCATION = 'Location',
@@ -83,7 +83,7 @@ export const ListAssetsFields: Record<string, QBField> = {
             QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name
         ],
         lookup: {
-            dataSource: ResolvedDueDateOptions
+            dataSource: []
         }
     }
 };
@@ -92,6 +92,5 @@ export const ListAssetsStaticFields = [
     ListAssetsFields.MODEL_NAME,
     ListAssetsFields.VENDOR_NAME,
     ListAssetsFields.ASSET_TYPE,
-    ListAssetsFields.BUS_TYPE,
-    ListAssetsFields.CALIBRATION_DUE_DATE
+    ListAssetsFields.BUS_TYPE
 ];

--- a/src/datasources/asset/types/types.ts
+++ b/src/datasources/asset/types/types.ts
@@ -82,8 +82,3 @@ export const AssetTypeOptions = [
   { label: 'Fixture', value: AssetType.FIXTURE },
   { label: 'System', value: AssetType.SYSTEM },
 ];
-
-export const ResolvedDueDateOptions = [
-  { label: '${__from:date}', value: '${__from:date}' },
-  { label: '${__to:date}', value: '${__to:date}' }
-];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Task: [link](https://ni.visualstudio.com/DevCentral/_backlogs/backlog/ASW%20SystemLink%20Asset%20Mgmt/Features/?workitem=2914265)

## 👩‍💻 Implementation

Add a new option, and make current calibration due date options more friendly

## 🧪 Testing

Added a test+
![from to now options](https://github.com/user-attachments/assets/6bb34caa-995c-469f-8404-98f878206264)


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).