### PR TITLE
feat(asset): compute "Now" in a way that can be saved

### DIFF
--- a/src/core/query-builder.utils.test.ts
+++ b/src/core/query-builder.utils.test.ts
@@ -37,7 +37,7 @@ describe('QueryBuilderUtils', () => {
     });
 
     it('should handle unsupported operations correctly', () => {
-      const query = 'Object1 > "value1" AND Object2 < "value2"';
+      const query = 'Object1 % "value1" AND Object2 % "value2"';
       const result = transformComputedFieldsQuery(query, computedDataFields);
       expect(result).toBe(query);
     });

--- a/src/core/query-builder.utils.ts
+++ b/src/core/query-builder.utils.ts
@@ -13,7 +13,7 @@ export type ExpressionTransformFunction = (value: string, operation: string, opt
 /**
  * Supported operations for computed fields
  */
-export const computedFieldsupportedOperations = ['=', '!='];
+export const computedFieldsupportedOperations = ['=', '!=', '>', '>=', '<', '<='];
 
 /**
  * The function will replace the computed fields with their transformation

--- a/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.test.tsx
+++ b/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.test.tsx
@@ -62,14 +62,18 @@ describe('AssetQueryBuilder', () => {
       expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
     });
 
-    it('should select user friendly value for calibration due date', () => {
-      const workspace = { id: '1', name: 'Selected workspace' } as Workspace;
-      const system = { id: '1', alias: 'Selected system' } as SystemMetadata;
+    [['${__from:date}', 'From'], ['${__to:date}', 'To' ], ['${__now:date}', 'Now' ]].forEach(([value, label]) =>
+    {
+      it( `should select user friendly value for calibration due date`, () =>
+      {
+        const workspace = { id: '1', name: 'Selected workspace' } as Workspace;
+        const system = { id: '1', alias: 'Selected system' } as SystemMetadata;
 
-      const { conditionsContainer } = renderElement([workspace], [system], 'ExternalCalibration.NextRecommendedDate > \"${__from:date}\"');
+        const { conditionsContainer } = renderElement([workspace], [system], `ExternalCalibration.NextRecommendedDate > \"${value}\"` );
 
-      expect(conditionsContainer?.length).toBe(1);
-      expect(conditionsContainer.item(0)?.textContent).toContain("From");
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+      });
     });
   });
 });

--- a/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.tsx
+++ b/src/datasources/asset/components/editors/list-assets/query-builder/AssetQueryBuilder.tsx
@@ -79,7 +79,7 @@ export const AssetQueryBuilder: React.FC<AssetCalibrationQueryBuilderProps> = ({
           ...(calibrationField.lookup?.dataSource || []),
           { label: 'From', value: '${__from:date}' },
           { label: 'To', value: '${__to:date}' },
-          { label: 'Now', value: new Date().toISOString() },
+          { label: 'Now', value: '${__now:date}' },
         ],
       },
     };

--- a/src/datasources/asset/constants/constants.ts
+++ b/src/datasources/asset/constants/constants.ts
@@ -5,6 +5,7 @@ export enum AllFieldNames {
     VENDOR_NAME = 'VendorName',
     BUS_TYPE = 'BusType',
     ASSET_TYPE = 'AssetType',
+    CALIBRATION_DUE_DATE = 'ExternalCalibration.NextRecommendedDate',
 }
 
 export const QUERY_LIMIT = 1000;

--- a/src/datasources/asset/data-sources/AssetDataSourceBase.ts
+++ b/src/datasources/asset/data-sources/AssetDataSourceBase.ts
@@ -93,7 +93,8 @@ export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, Ass
   }
 
   public readonly queryTransformationOptions = new Map<string, Map<string, unknown>>([
-    [AllFieldNames.LOCATION, this.systemAliasCache]
+    [AllFieldNames.LOCATION, this.systemAliasCache],
+    [AllFieldNames.CALIBRATION_DUE_DATE, new Map<string, unknown>()]
   ]);
 
   public readonly assetComputedDataFields = new Map<string, ExpressionTransformFunction>([
@@ -116,6 +117,17 @@ export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, Ass
         }
 
         return `Locations.Any(l => l.MinionId ${operation} "${value}" ${this.getLocicalOperator(operation)} l.PhysicalLocation ${operation} "${value}")`;
+    }],
+    [
+      AllFieldNames.CALIBRATION_DUE_DATE,
+      (value: string, operation: string, options?: Map<string, unknown>) =>
+      {
+        if (value === '${__now:date}' )
+        {
+          return `${AllFieldNames.CALIBRATION_DUE_DATE} ${operation} "${new Date().toISOString()}"`;
+        }
+
+        return `${AllFieldNames.CALIBRATION_DUE_DATE} ${operation} "${value}"`;
       }]]);
 
   protected multipleValuesQuery(field: string): ExpressionTransformFunction {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Task: [link](https://ni.visualstudio.com/DevCentral/_backlogs/backlog/ASW%20SystemLink%20Asset%20Mgmt/Features/?workitem=2915649)

## 👩‍💻 Implementation

Added a hardcoded value: ${__now:date}, similar to other grafana variables. This will allow us to save the dashboard, and on reload new date will be computed.

## 🧪 Testing

Added tests+
![compute Now in a different way](https://github.com/user-attachments/assets/0056dda9-2e19-4d7f-ba7b-cbf25e5af473)

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).