### PR TITLE
fix(notebook): fix input sanitization for notebook query builder

### DIFF
--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -15,22 +15,28 @@ test('enumToOptions', () => {
 });
 
 describe("filterXSSLINQExpression", () => {
-    test('simple XSS handling', () => {
+    test('Sanitize simple XSS', () => {
         const result = filterXSSLINQExpression('test<script>alert("XSS")</script>');
 
         expect(result).toEqual('test');
     });
 
-    test('Escaped <a> attribute', () => {
+    test('Sanitize escaped <a> attribute', () => {
         const result = filterXSSLINQExpression('test\\<a onmouseover=\'alert(document.cookie)\'\\>xxs link\\</a\\>');
 
         expect(result).toEqual('test\\<a>xxs link\\</a>');
     });
 
-    test('XSS in LINQ expression', () => {
+    test('Sanitize XSS in LINQ expression', () => {
         const result = filterXSSLINQExpression('ExternalCalibration.NextRecommendedDate < \"2024-10-29T02:53:47.647Z\" && ExternalCalibration.NextRecommendedDate > \"2025-10-29T08:53:47.647Z\" && Location.MinionId = \"e2etest-1730102822793-365e021a-d0c5-496c-87f8-8e4e5fa5090f\" && ExternalCalibration.NextRecommendedDate > \"2024-10-29T08:53:43.995Z\" && ExternalCalibration.NextRecommendedDate < \"\\<a onmouseover=\'alert(document.cookie)\'\\>xxs link\\</a\\>\"');
 
         expect(result).toEqual('ExternalCalibration.NextRecommendedDate < \"2024-10-29T02:53:47.647Z\" && ExternalCalibration.NextRecommendedDate > \"2025-10-29T08:53:47.647Z\" && Location.MinionId = \"e2etest-1730102822793-365e021a-d0c5-496c-87f8-8e4e5fa5090f\" && ExternalCalibration.NextRecommendedDate > \"2024-10-29T08:53:43.995Z\" && ExternalCalibration.NextRecommendedDate < \"\\<a>xxs link\\\"</a>');
+    });
+
+    test('LINQ Sanitization test conditions', () => {
+        const result = filterXSSLINQExpression('(Example.Field <> \"EXAMPLE_VALUE_1\") && Example.Field < \"EXAMPLE_VALUE_2\" && Example.Field > \"EXAMPLE_VALUE_3\" && Example.Field <= \"EXAMPLE_VALUE_4\" && Example.Field >= \"EXAMPLE_VALUE_5\" && Example.Field != \"EXAMPLE_VALUE_6\"');
+
+        expect(result).toEqual('(Example.Field <> \"EXAMPLE_VALUE_1\") && Example.Field < \"EXAMPLE_VALUE_2\" && Example.Field > \"EXAMPLE_VALUE_3\" && Example.Field <= \"EXAMPLE_VALUE_4\" && Example.Field >= \"EXAMPLE_VALUE_5\" && Example.Field != \"EXAMPLE_VALUE_6\"');
     });
 });
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -107,5 +107,6 @@ export function filterXSSLINQExpression(value: string | null | undefined): strin
     .replace(/ &lt;= /g, " <= ")
     .replace(/ &gt; /g, " > ")
     .replace(/ &gt;= /g, " >= ")
-    .replace(/ &amp;&amp; /g, " && ");
+    .replace(/ &amp;&amp; /g, " && ")
+    .replace(/ &lt;&gt; /g, " <> ");
 }

--- a/src/datasources/notebook/QueryBuilder.test.ts
+++ b/src/datasources/notebook/QueryBuilder.test.ts
@@ -1,0 +1,43 @@
+import React, { ReactNode } from "react";
+import { TestResultsQueryBuilder } from "./QueryBuilder";
+import { render } from "@testing-library/react";
+
+describe('QueryBuilder', () => {
+  describe('useEffects', () => {
+    let reactNode: ReactNode
+
+    const containerClass = 'smart-filter-group-condition-container';
+
+    function renderElement(filter?: string) {
+      reactNode = React.createElement(TestResultsQueryBuilder, { defaultValue: filter, autoComplete: () => Promise.resolve([]), onChange: jest.fn()});
+      const renderResult = render(reactNode);
+      return {
+        renderResult,
+        conditionsContainer: renderResult.container.getElementsByClassName(`${containerClass}`)
+      };
+    }
+
+    it('should render empty query builder', () => {
+      const { renderResult, conditionsContainer } = renderElement("");
+
+      expect(conditionsContainer.length).toBe(1);
+      expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
+    })
+
+    it('should select partNumber and seralNumber in query builder', () => {
+      const { conditionsContainer } = renderElement('partNumber = "P_number" && serialNumber = "SomeRandomModelName"');
+
+      expect(conditionsContainer?.length).toBe(2);
+      expect(conditionsContainer.item(0)?.textContent).toContain("P_number");
+      expect(conditionsContainer.item(1)?.textContent).toContain("SomeRandomModelName");
+    })
+
+    it('should select a sanitized PartNumber in query builder', () => {
+      const { conditionsContainer } = renderElement('partNumber = "<script>alert(\'PartNumber\')</script>"');
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.innerHTML).not.toContain('alert(\'PartNumber\')');
+      expect(conditionsContainer.item(0)?.innerHTML).not.toContain('<script>');
+    })
+  });
+});

--- a/src/datasources/notebook/QueryBuilder.tsx
+++ b/src/datasources/notebook/QueryBuilder.tsx
@@ -8,6 +8,7 @@ import 'smart-webcomponents-react/source/styles/smart.orange.css';
 import 'smart-webcomponents-react/source/styles/components/smart.base.css';
 import 'smart-webcomponents-react/source/styles/components/smart.common.css';
 import 'smart-webcomponents-react/source/styles/components/smart.querybuilder.css';
+import { filterXSSLINQExpression } from 'core/utils';
 
 type TestResultsQueryBuilderProps = Omit<QueryBuilderProps, 'customOperations' | 'fields' | 'messages' | 'showIcons'> &
   React.HTMLAttributes<Element> & {
@@ -162,8 +163,9 @@ export const TestResultsQueryBuilder: React.FC<TestResultsQueryBuilderProps> = (
       messages={queryBuilderMessages}
       showIcons
       // Only set value on first render
-      {...(initialize.current && { value: props.defaultValue })}
+      {...(initialize.current && { value: filterXSSLINQExpression(props.defaultValue) })}
       {...props}
+      value={filterXSSLINQExpression(props.defaultValue)}
     />
   );
 };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Since the query builder is vulnerable to XSS, we need to ensure that the customers are safe using this feature.

## 👩‍💻 Implementation

Added sanitization to the filter

## 🧪 Testing

- Unit testing
- Manual testing

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).