### PR TITLE
fix(asset): calibration forecast timezone issues on datalinks

### DIFF
--- a/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.test.ts
+++ b/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.test.ts
@@ -24,204 +24,225 @@ beforeEach(() => {
     .mockReturnValue(createFetchResponse({ data: fakeSystems }));
 });
 
-const monthGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
-      { name: "", values: [1, 0, 3], columnDescriptors: [{ value: "Assets", type: ColumnDescriptorType.Count }] }
-    ]
-  }
-}
-
-const dayGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: AssetCalibrationForecastKey.Day, values: ["2022-01-01T00:00:00.0000000Z", "2022-01-02T00:00:00.0000000Z", "2022-01-03T00:00:00.0000000Z"], columnDescriptors: [{ value: AssetCalibrationForecastKey.Day, type: ColumnDescriptorType.Time }] },
-      { name: "", values: [1, 2, 2], columnDescriptors: [{ value: "Assets", type: ColumnDescriptorType.Count }] }
-    ]
-  }
-}
-
-const weekGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: AssetCalibrationForecastKey.Week, values: ["2022-01-03T00:00:00.0000000Z", "2022-01-10T00:00:00.0000000Z", "2022-01-17T00:00:00.0000000Z"], columnDescriptors: [{ value: AssetCalibrationForecastKey.Week, type: ColumnDescriptorType.Time }] },
-      { name: "", values: [1, 2, 2], columnDescriptors: [{ value: "Assets", type: ColumnDescriptorType.Count }] }
-    ]
-  }
-}
-
-const weekGroupCalibrationForecastDataLinkResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: AssetCalibrationForecastKey.Week, values: ["2022-01-01T00:00:00.0000000Z", "2022-01-08T00:00:00.0000000Z", "2022-01-15T00:00:00.0000000Z"], columnDescriptors: [{ value: AssetCalibrationForecastKey.Week, type: ColumnDescriptorType.Time }] },
-      { name: "", values: [3, 2, 2], columnDescriptors: [{ value: "Assets", type: ColumnDescriptorType.Count }] }
-    ]
-  }
-}
-
-const locationGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: [1], columnDescriptors: [{ value: "Location1", type: ColumnDescriptorType.StringValue }] },
-      { name: "", values: [2], columnDescriptors: [{ value: "Location2", type: ColumnDescriptorType.StringValue }] },
-      { name: "", values: [3], columnDescriptors: [{ value: "Location3", type: ColumnDescriptorType.StringValue }] }
-    ]
-  }
-}
-
-const minionIdLocationGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: [1], columnDescriptors: [{ value: "Minion1", type: ColumnDescriptorType.MinionId }] },
-      { name: "", values: [2], columnDescriptors: [{ value: "Minion2", type: ColumnDescriptorType.MinionId }] },
-      { name: "", values: [3], columnDescriptors: [{ value: "Minion3", type: ColumnDescriptorType.MinionId }] }
-    ]
+const monthGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: AssetCalibrationForecastKey.Month, values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
+        { name: "", values: [1, 0, 3], columnDescriptors: [{ value: "Assets", type: ColumnDescriptorType.Count }] }
+      ]
+    }
   }
 }
 
 
-const modelGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: [1], columnDescriptors: [{ value: "Model1", type: ColumnDescriptorType.StringValue }] },
-      { name: "", values: [2], columnDescriptors: [{ value: "Model2", type: ColumnDescriptorType.StringValue }] }
-    ]
+const dayGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: AssetCalibrationForecastKey.Day, values: ["2022-01-01T00:00:00.0000000Z", "2022-01-02T00:00:00.0000000Z", "2022-01-03T00:00:00.0000000Z"], columnDescriptors: [{ value: AssetCalibrationForecastKey.Day, type: ColumnDescriptorType.Time }] },
+        { name: "", values: [1, 2, 2], columnDescriptors: [{ value: "Assets", type: ColumnDescriptorType.Count }] }
+      ]
+    }
   }
 }
 
-const emptyGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-    ]
+const weekGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: AssetCalibrationForecastKey.Week, values: ["2022-01-03T00:00:00.0000000Z", "2022-01-10T00:00:00.0000000Z", "2022-01-17T00:00:00.0000000Z"], columnDescriptors: [{ value: AssetCalibrationForecastKey.Week, type: ColumnDescriptorType.Time }] },
+        { name: "", values: [1, 2, 2], columnDescriptors: [{ value: "Assets", type: ColumnDescriptorType.Count }] }
+      ]
+    }
   }
 }
 
-const modelLocationGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: [1], columnDescriptors: [{ value: "Model1", type: ColumnDescriptorType.StringValue }, { value: "Location1", type: ColumnDescriptorType.StringValue }] },
-      { name: "", values: [2], columnDescriptors: [{ value: "Model2", type: ColumnDescriptorType.StringValue }, { value: "Location1", type: ColumnDescriptorType.StringValue }] }
-    ]
+const weekGroupCalibrationForecastDataLinkResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: AssetCalibrationForecastKey.Week, values: ["2022-01-01T00:00:00.0000000Z", "2022-01-08T00:00:00.0000000Z", "2022-01-15T00:00:00.0000000Z"], columnDescriptors: [{ value: AssetCalibrationForecastKey.Week, type: ColumnDescriptorType.Time }] },
+        { name: "", values: [3, 2, 2], columnDescriptors: [{ value: "Assets", type: ColumnDescriptorType.Count }] }
+      ]
+    }
   }
 }
 
-const monthLocationGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
-      { name: "", values: [1, 2, 3], columnDescriptors: [{ value: "Location1", type: ColumnDescriptorType.StringValue }] },
-      { name: "", values: [2, 4, 1], columnDescriptors: [{ value: "Location2", type: ColumnDescriptorType.StringValue }] },
-      { name: "", values: [4, 3, 1], columnDescriptors: [{ value: "Location3", type: ColumnDescriptorType.StringValue }] }
-    ]
+
+const locationGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: [1], columnDescriptors: [{ value: "Location1", type: ColumnDescriptorType.StringValue }] },
+        { name: "", values: [2], columnDescriptors: [{ value: "Location2", type: ColumnDescriptorType.StringValue }] },
+        { name: "", values: [3], columnDescriptors: [{ value: "Location3", type: ColumnDescriptorType.StringValue }] }
+      ]
+    }
   }
 }
 
-const workspaceGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: [1], columnDescriptors: [{ value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] },
-      { name: "", values: [2], columnDescriptors: [{ value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] }
-    ]
+const minionIdLocationGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: [1], columnDescriptors: [{ value: "Minion1", type: ColumnDescriptorType.MinionId }] },
+        { name: "", values: [2], columnDescriptors: [{ value: "Minion2", type: ColumnDescriptorType.MinionId }] },
+        { name: "", values: [3], columnDescriptors: [{ value: "Minion3", type: ColumnDescriptorType.MinionId }] }
+      ]
+    }
   }
 }
 
-const vendorGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: [1], columnDescriptors: [{ value: "Vendor1", type: ColumnDescriptorType.StringValue }] },
-      { name: "", values: [2], columnDescriptors: [{ value: "Vendor2", type: ColumnDescriptorType.StringValue }] }
-    ]
+
+const modelGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: [1], columnDescriptors: [{ value: "Model1", type: ColumnDescriptorType.StringValue }] },
+        { name: "", values: [2], columnDescriptors: [{ value: "Model2", type: ColumnDescriptorType.StringValue }] }
+      ]
+    }
   }
 }
 
-const assetTypeGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: [1], columnDescriptors: [{ value: AssetType.GENERIC, type: ColumnDescriptorType.AssetType }] },
-      { name: "", values: [2], columnDescriptors: [{ value: AssetType.DEVICE_UNDER_TEST, type: ColumnDescriptorType.AssetType }] }
-    ]
+const emptyGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+      ]
+    }
   }
 }
 
-const busTypeGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: [1], columnDescriptors: [{ value: BusType.BUILT_IN_SYSTEM, type: ColumnDescriptorType.BusType }] },
-      { name: "", values: [2], columnDescriptors: [{ value: BusType.FIRE_WIRE, type: ColumnDescriptorType.BusType }] }
-    ]
+const modelLocationGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: [1], columnDescriptors: [{ value: "Model1", type: ColumnDescriptorType.StringValue }, { value: "Location1", type: ColumnDescriptorType.StringValue }] },
+        { name: "", values: [2], columnDescriptors: [{ value: "Model2", type: ColumnDescriptorType.StringValue }, { value: "Location1", type: ColumnDescriptorType.StringValue }] }
+      ]
+    }
   }
 }
 
-const modelWorkspaceGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: [1], columnDescriptors: [{ value: "Model1", type: ColumnDescriptorType.StringValue }, { value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] },
-      { name: "", values: [2], columnDescriptors: [{ value: "Model2", type: ColumnDescriptorType.StringValue }, { value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] }
-    ]
+const monthLocationGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
+        { name: "", values: [1, 2, 3], columnDescriptors: [{ value: "Location1", type: ColumnDescriptorType.StringValue }] },
+        { name: "", values: [2, 4, 1], columnDescriptors: [{ value: "Location2", type: ColumnDescriptorType.StringValue }] },
+        { name: "", values: [4, 3, 1], columnDescriptors: [{ value: "Location3", type: ColumnDescriptorType.StringValue }] }
+      ]
+    }
   }
 }
 
-const monthWorkspaceGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
-      { name: "", values: [1, 2, 3], columnDescriptors: [{ value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] },
-      { name: "", values: [2, 4, 1], columnDescriptors: [{ value: "Workspace2", type: ColumnDescriptorType.WorkspaceId }] },
-      { name: "", values: [4, 3, 1], columnDescriptors: [{ value: "Workspace3", type: ColumnDescriptorType.WorkspaceId }] }
-    ]
+const workspaceGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: [1], columnDescriptors: [{ value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] },
+        { name: "", values: [2], columnDescriptors: [{ value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] }
+      ]
+    }
   }
 }
 
-const monthVendorGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
-      { name: "", values: [1, 2, 3], columnDescriptors: [{ value: "Vendor1", type: ColumnDescriptorType.StringValue }] },
-      { name: "", values: [2, 4, 1], columnDescriptors: [{ value: "Vendor2", type: ColumnDescriptorType.StringValue }] },
-      { name: "", values: [4, 3, 1], columnDescriptors: [{ value: "Vendor3", type: ColumnDescriptorType.StringValue }] }
-    ]
+const vendorGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: [1], columnDescriptors: [{ value: "Vendor1", type: ColumnDescriptorType.StringValue }] },
+        { name: "", values: [2], columnDescriptors: [{ value: "Vendor2", type: ColumnDescriptorType.StringValue }] }
+      ]
+    }
   }
 }
 
-const monthAssetTypeGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
-      { name: "", values: [1, 2, 3], columnDescriptors: [{ value: AssetType.DEVICE_UNDER_TEST, type: ColumnDescriptorType.AssetType }] },
-      { name: "", values: [2, 4, 1], columnDescriptors: [{ value: AssetType.FIXTURE, type: ColumnDescriptorType.AssetType }] },
-      { name: "", values: [4, 3, 1], columnDescriptors: [{ value: AssetType.GENERIC, type: ColumnDescriptorType.AssetType }] }
-    ]
+const assetTypeGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: [1], columnDescriptors: [{ value: AssetType.GENERIC, type: ColumnDescriptorType.AssetType }] },
+        { name: "", values: [2], columnDescriptors: [{ value: AssetType.DEVICE_UNDER_TEST, type: ColumnDescriptorType.AssetType }] }
+      ]
+    }
   }
 }
 
-const monthBusTypeGroupCalibrationForecastResponseMock: CalibrationForecastResponse =
-{
-  calibrationForecast: {
-    columns: [
-      { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
-      { name: "", values: [1, 2, 3], columnDescriptors: [{ value: BusType.BUILT_IN_SYSTEM, type: ColumnDescriptorType.BusType }] },
-      { name: "", values: [2, 4, 1], columnDescriptors: [{ value: BusType.ACCESSORY, type: ColumnDescriptorType.BusType }] },
-      { name: "", values: [4, 3, 1], columnDescriptors: [{ value: BusType.SERIAL, type: ColumnDescriptorType.BusType }] }
-    ]
+const busTypeGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: [1], columnDescriptors: [{ value: BusType.BUILT_IN_SYSTEM, type: ColumnDescriptorType.BusType }] },
+        { name: "", values: [2], columnDescriptors: [{ value: BusType.FIRE_WIRE, type: ColumnDescriptorType.BusType }] }
+      ]
+    }
+  }
+}
+
+const modelWorkspaceGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: [1], columnDescriptors: [{ value: "Model1", type: ColumnDescriptorType.StringValue }, { value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] },
+        { name: "", values: [2], columnDescriptors: [{ value: "Model2", type: ColumnDescriptorType.StringValue }, { value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] }
+      ]
+    }
+  }
+}
+
+const monthWorkspaceGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
+        { name: "", values: [1, 2, 3], columnDescriptors: [{ value: "Workspace1", type: ColumnDescriptorType.WorkspaceId }] },
+        { name: "", values: [2, 4, 1], columnDescriptors: [{ value: "Workspace2", type: ColumnDescriptorType.WorkspaceId }] },
+        { name: "", values: [4, 3, 1], columnDescriptors: [{ value: "Workspace3", type: ColumnDescriptorType.WorkspaceId }] }
+      ]
+    }
+  }
+}
+
+const monthVendorGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
+        { name: "", values: [1, 2, 3], columnDescriptors: [{ value: "Vendor1", type: ColumnDescriptorType.StringValue }] },
+        { name: "", values: [2, 4, 1], columnDescriptors: [{ value: "Vendor2", type: ColumnDescriptorType.StringValue }] },
+        { name: "", values: [4, 3, 1], columnDescriptors: [{ value: "Vendor3", type: ColumnDescriptorType.StringValue }] }
+      ]
+    }
+  }
+}
+
+const monthAssetTypeGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
+        { name: "", values: [1, 2, 3], columnDescriptors: [{ value: AssetType.DEVICE_UNDER_TEST, type: ColumnDescriptorType.AssetType }] },
+        { name: "", values: [2, 4, 1], columnDescriptors: [{ value: AssetType.FIXTURE, type: ColumnDescriptorType.AssetType }] },
+        { name: "", values: [4, 3, 1], columnDescriptors: [{ value: AssetType.GENERIC, type: ColumnDescriptorType.AssetType }] }
+      ]
+    }
+  }
+}
+
+const monthBusTypeGroupCalibrationForecastResponseMock = (): CalibrationForecastResponse => {
+  return {
+    calibrationForecast: {
+      columns: [
+        { name: "", values: ["2022-01-01T00:00:00.0000000Z", "2022-02-01T00:00:00.0000000Z", "2022-03-01T00:00:00.0000000Z"], columnDescriptors: [{ value: "Month", type: ColumnDescriptorType.Time }] },
+        { name: "", values: [1, 2, 3], columnDescriptors: [{ value: BusType.BUILT_IN_SYSTEM, type: ColumnDescriptorType.BusType }] },
+        { name: "", values: [2, 4, 1], columnDescriptors: [{ value: BusType.ACCESSORY, type: ColumnDescriptorType.BusType }] },
+        { name: "", values: [4, 3, 1], columnDescriptors: [{ value: BusType.SERIAL, type: ColumnDescriptorType.BusType }] }
+      ]
+    }
   }
 }
 
@@ -329,7 +350,7 @@ describe('queries', () => {
   test('asset calibration forecast with month groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(monthGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(monthGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(monthBasedCalibrationForecastQueryMock))
 
@@ -339,7 +360,7 @@ describe('queries', () => {
   test('asset calibration forecast with week groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(weekGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(weekGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(weekBasedCalibrationForecastQueryMock))
 
@@ -349,7 +370,7 @@ describe('queries', () => {
   test('asset calibration forecast with day groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(dayGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(dayGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(dayBasedCalibrationForecastQueryMock))
 
@@ -359,7 +380,7 @@ describe('queries', () => {
   test('calibration forecast with location groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(locationGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(locationGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(locationBasedCalibrationForecastQueryMock))
 
@@ -369,7 +390,7 @@ describe('queries', () => {
   test('calibration forecast with minion ID location groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(minionIdLocationGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(minionIdLocationGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(locationBasedCalibrationForecastQueryMock))
 
@@ -379,7 +400,7 @@ describe('queries', () => {
   test('calibration forecast with model groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(modelGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(modelGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(modelBasedCalibrationForecastQueryMock))
 
@@ -389,7 +410,7 @@ describe('queries', () => {
   test('calibration forecast with model and location groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(modelLocationGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(modelLocationGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(modelLocationBasedCalibrationForecastQueryMock))
 
@@ -399,7 +420,7 @@ describe('queries', () => {
   test('calibration forecast with month and location groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(monthLocationGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(monthLocationGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(monthLocationBasedCalibrationForecastQueryMock))
 
@@ -409,7 +430,7 @@ describe('queries', () => {
   test('calibration forecast with workspace groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(workspaceGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(workspaceGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(workspaceBasedCalibrationForecastQueryMock))
 
@@ -419,7 +440,7 @@ describe('queries', () => {
   test('calibration forecast with model and workspace groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(modelWorkspaceGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(modelWorkspaceGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(modelWorkspaceBasedCalibrationForecastQueryMock))
 
@@ -429,7 +450,7 @@ describe('queries', () => {
   test('calibration forecast with month and workspace groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(monthWorkspaceGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(monthWorkspaceGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(monthWorkspaceBasedCalibrationForecastQueryMock))
 
@@ -439,7 +460,7 @@ describe('queries', () => {
   test('calibration forecast with vendor groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(vendorGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(vendorGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery({ type: AssetQueryType.CalibrationForecast, groupBy: [AssetCalibrationPropertyGroupByType.Vendor] }))
 
@@ -449,7 +470,7 @@ describe('queries', () => {
   test('calibration forecast with month and vendor groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(monthVendorGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(monthVendorGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery({
       type: AssetQueryType.CalibrationForecast,
@@ -462,7 +483,7 @@ describe('queries', () => {
   test('calibration forecast with assetType groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(assetTypeGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(assetTypeGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery({ type: AssetQueryType.CalibrationForecast, groupBy: [AssetCalibrationPropertyGroupByType.AssetType] }))
 
@@ -472,7 +493,7 @@ describe('queries', () => {
   test('calibration forecast with month and assetType groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(monthAssetTypeGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(monthAssetTypeGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery({
       type: AssetQueryType.CalibrationForecast,
@@ -485,7 +506,7 @@ describe('queries', () => {
   test('calibration forecast with busType groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(busTypeGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(busTypeGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery({ type: AssetQueryType.CalibrationForecast, groupBy: [AssetCalibrationPropertyGroupByType.BusType] }))
 
@@ -495,7 +516,7 @@ describe('queries', () => {
   test('calibration forecast with month and busType groupBy', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(monthBusTypeGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(monthBusTypeGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery({
       type: AssetQueryType.CalibrationForecast,
@@ -508,7 +529,7 @@ describe('queries', () => {
   test('calibration forecast with month groupBy returns empty results', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(emptyGroupCalibrationForecastResponseMock as CalibrationForecastResponse))
+      .mockReturnValue(createFetchResponse(emptyGroupCalibrationForecastResponseMock() as CalibrationForecastResponse))
 
     const result = await datastore.query(buildCalibrationForecastQuery(monthBasedCalibrationForecastQueryMock))
 
@@ -621,9 +642,12 @@ describe('Asset calibration location queries', () => {
 describe('Time based data links', () => {
   test('creates data links for Day grouping', async () => {
     const query = buildCalibrationForecastQuery(dayBasedCalibrationForecastQueryMock);
+    query.range = { from: dateTime("2022-01-01T00:00:00.0000000Z"), to: dateTime("2022-03-01T00:00:00.0000000Z"), raw: { from: 'now', to: 'now+3M' } };
+    query.timezone = 'UTC';
+
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(dayGroupCalibrationForecastResponseMock as CalibrationForecastResponse));
+      .mockReturnValue(createFetchResponse(dayGroupCalibrationForecastResponseMock() as CalibrationForecastResponse));
 
     const result = await datastore.query(query);
     const [_day, assets] = result.data[0].fields;
@@ -635,7 +659,7 @@ describe('Time based data links', () => {
     expect(dataLink.targetBlank).toBe(false);
 
     const builtUrl = dataLink.onBuildUrl({
-      replaceVariables: (value: string) => value.replace('${__data.fields.Day}', from.toISOString())
+      replaceVariables: (value: string) => value.replace('${__data.fields.Day}', from.toISOString().split('T')[0])
     });
 
     expect(builtUrl).toMatchSnapshot();
@@ -644,42 +668,46 @@ describe('Time based data links', () => {
   test('creates data links for Week grouping', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(weekGroupCalibrationForecastDataLinkResponseMock as CalibrationForecastResponse));
+      .mockReturnValue(createFetchResponse(weekGroupCalibrationForecastDataLinkResponseMock() as CalibrationForecastResponse));
 
-    const result = await datastore.query(buildCalibrationForecastQuery(weekBasedCalibrationForecastQueryMock));
+    const query = buildCalibrationForecastQuery(weekBasedCalibrationForecastQueryMock);
+    query.range = { from: dateTime("2022-01-01T00:00:00.0000000Z"), to: dateTime("2022-03-01T00:00:00.0000000Z"), raw: { from: 'now', to: 'now+3M' } };
+    query.timezone = 'UTC';
+
+    const result = await datastore.query(query);
     const [_week, assets] = result.data[0].fields;
     const [dataLink] = assets.config.links;
 
-    const weekStartDate = new Date('2022-01-03T00:00:00.0000000Z');
-    const weekEndDate = new Date('2022-01-09T23:59:59.999Z');
+    const weekStartDate = new Date('2022-01-01T00:00:00.0000000Z');
+    const weekEndDate = new Date('2022-01-07T23:59:59.999Z');
 
     expect(dataLink.title).toBe(`View ${AssetCalibrationForecastKey.Week}`);
     expect(dataLink.targetBlank).toBe(false);
 
     const builtUrl = dataLink.onBuildUrl({
-      replaceVariables: (value: string) => value.replace('${__data.fields.Week}', `${weekStartDate.toISOString()} : ${weekEndDate.toISOString()}`)
+      replaceVariables: (value: string) => value.replace('${__data.fields.Week}', `${weekStartDate.toISOString().split('T')[0]} : ${weekEndDate.toISOString().split('T')[0]}`)
     });
 
     expect(builtUrl).toMatchSnapshot();
   });
 
   test('creates data links for Month grouping', async () => {
-    const query = buildCalibrationForecastQuery(monthBasedCalibrationForecastQueryMock);
+    const query = buildCalibrationForecastQuery(monthBasedCalibrationForecastQueryMock)
+    query.range = { from: dateTime("2022-01-01T00:00:00.0000000Z"), to: dateTime("2022-03-01T00:00:00.0000000Z"), raw: { from: 'now', to: 'now+3M' } };
+    query.timezone = 'UTC';
     backendServer.fetch
       .calledWith(requestMatching({ url: '/niapm/v1/assets/calibration-forecast' }))
-      .mockReturnValue(createFetchResponse(monthGroupCalibrationForecastResponseMock as CalibrationForecastResponse));
+      .mockReturnValue(createFetchResponse(monthGroupCalibrationForecastResponseMock() as CalibrationForecastResponse));
 
     const result = await datastore.query(query);
     const [_month, assets] = result.data[0].fields;
     const [dataLink] = assets.config.links;
 
-    const monthDate = new Date('2022-01-01T00:00:00.0000000Z');
-
     expect(dataLink.title).toBe(`View ${AssetCalibrationForecastKey.Month}`);
     expect(dataLink.targetBlank).toBe(false);
 
     const builtUrl = dataLink.onBuildUrl({
-      replaceVariables: (value: string) => value.replace('${__data.fields.Month}', monthDate.toISOString())
+      replaceVariables: (value: string) => value.replace('${__data.fields.Month}', "January 2022")
     });
 
     expect(builtUrl).toMatchSnapshot();

--- a/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.ts
+++ b/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.ts
@@ -66,8 +66,8 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
 
     async processCalibrationForecastQuery(query: CalibrationForecastQuery, options: DataQueryRequest) {
         const result: DataFrameDTO = { refId: query.refId, fields: [] };
-        const from = options.range!.from.toISOString();
-        const to = options.range!.to.toISOString();
+        const from = options.range!.from.utc().toISOString();
+        const to = options.range!.to.utc().toISOString();
 
         const calibrationForecastResponse: CalibrationForecastResponse = await this.queryCalibrationForecast(
             query.groupBy,
@@ -102,6 +102,19 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
     }
 
     processResultsGroupedByTime(result: DataFrameDTO, timeGrouping: AssetCalibrationForecastKey) {
+        const originalValuesMap = new Map<string, string>();
+        if (result.fields.length > 0) {
+            const field = result.fields[0];
+            const originalValues = field.values as string[] ?? [];
+            const formatter = this.forecastDateFormatterMap.get(field.name as AssetCalibrationForecastKey);
+            if (formatter) {
+                const formattedValues: string[] = field.values!.map(formatter);
+                for (let i = 0; i < originalValues!.length; i++) {
+                    originalValuesMap.set(formattedValues![i], originalValues![i]);
+                }
+            }
+        }
+
         result.fields.forEach(field => {
             field.name = this.createColumnNameFromDescriptor(field as FieldDTOWithDescriptor);
             const formatter = this.forecastDateFormatterMap.get(field.name as AssetCalibrationForecastKey);
@@ -111,17 +124,17 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
             }
 
             if (!formatter) {
-                field.config = { links: this.createDataLinks(timeGrouping) };
+                field.config = { links: this.createDataLinks(timeGrouping, originalValuesMap) };
             }
         });
     }
 
-    private constructDataLinkBaseUrl(){
+    private constructDataLinkBaseUrl() {
         const pathname = locationService.getLocation().pathname;
-        return  pathname + '?orgId=${__org.id}&${__all_variables}';
+        return pathname + '?orgId=${__org.id}&${__all_variables}';
     }
 
-    private createDataLinks(timeGrouping: AssetCalibrationForecastKey): DataLink[] {
+    private createDataLinks(timeGrouping: AssetCalibrationForecastKey, originalValuesMap: Map<string, string>): DataLink[] {
         const url = this.constructDataLinkBaseUrl();
         return [
             {
@@ -130,32 +143,22 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
                     if (!options.replaceVariables) {
                         return url;
                     }
-
                     const value = options.replaceVariables(`\${__data.fields.${timeGrouping}}`);
+                    const valueAsDate = new Date(originalValuesMap.get(value)!);
+
                     let from, to;
-
-                    const parseDate = (dateStr: string) => {
-                        const date = new Date(dateStr);
-                        date.setUTCHours(0);
-                        return date;
-                    };
-
                     switch (timeGrouping) {
                         case AssetCalibrationForecastKey.Day:
-                            const dayDate = parseDate(value);
-                            from = dayDate.valueOf();
-                            dayDate.setUTCDate(dayDate.getUTCDate() + 1);
-                            to = dayDate.valueOf();
+                            from = valueAsDate.valueOf();
+                            to = valueAsDate.setUTCDate(valueAsDate.getUTCDate() + 1).valueOf();
                             break;
                         case AssetCalibrationForecastKey.Week:
-                            [from, to] = value.split(' : ').map(dateStr => parseDate(dateStr).valueOf());
+                            from = valueAsDate.valueOf();
+                            to = valueAsDate.setUTCDate(valueAsDate.getUTCDate() + 6).valueOf();
                             break;
                         case AssetCalibrationForecastKey.Month:
-                            const monthDate = parseDate(value);
-                            monthDate.setUTCDate(monthDate.getUTCDate() + 1);
-                            from = monthDate.valueOf();
-                            monthDate.setUTCMonth(monthDate.getUTCMonth() + 1);
-                            to = monthDate.valueOf();
+                            from = valueAsDate.valueOf();
+                            to = valueAsDate.setUTCMonth(valueAsDate.getUTCMonth() + 1).valueOf();
                             break;
                     }
 
@@ -209,7 +212,7 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
     }
 
     formatDateForMonth(date: string): string {
-        return new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'long' });
+        return new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', timeZone: 'UTC' });
     }
 
     async queryAssets(filter = '', take = -1): Promise<AssetModel[]> {

--- a/src/datasources/asset/data-sources/calibration-forecast/__snapshots__/CalibrationForecastDataSource.test.ts.snap
+++ b/src/datasources/asset/data-sources/calibration-forecast/__snapshots__/CalibrationForecastDataSource.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`Time based data links creates data links for Day grouping 1`] = `"/?orgId=\${__org.id}&\${__all_variables}&from=1640995200000&to=1641081600000"`;
 
-exports[`Time based data links creates data links for Month grouping 1`] = `"/?orgId=\${__org.id}&\${__all_variables}&from=1641081600000&to=1643760000000"`;
+exports[`Time based data links creates data links for Month grouping 1`] = `"/?orgId=\${__org.id}&\${__all_variables}&from=1640995200000&to=1643673600000"`;
 
-exports[`Time based data links creates data links for Week grouping 1`] = `"/?orgId=\${__org.id}&\${__all_variables}&from=1641168000000&to=1641689999999"`;
+exports[`Time based data links creates data links for Week grouping 1`] = `"/?orgId=\${__org.id}&\${__all_variables}&from=1640995200000&to=1641600000000"`;
 
 exports[`queries asset calibration forecast with day groupBy 1`] = `
 [


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- Due to a reported issue in the CST time zone, it seems that the calibration forecast dashboard doesn't build the datalinks properly
- The bucket label was also built in local time instead of UTC

## 👩‍💻 Implementation

- The datalink time building algorithm was adjusted to account for the actual values from the backend when building the links
- The Buckets labels respect the UTC values now

## 🧪 Testing

- Unit testing
- Manual testing on different time zones

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).