### PR TITLE
fix(assets): updating visualization for the asset display name in global variable

### DIFF
--- a/src/datasources/asset/AssetDataSource.test.ts
+++ b/src/datasources/asset/AssetDataSource.test.ts
@@ -11,6 +11,7 @@ import { AssetDataSource } from "./AssetDataSource";
 import { AssetQueryType } from "./types/types";
 import { AssetPresenceWithSystemConnectionModel, AssetsResponse } from "datasources/asset-common/types";
 import { ListAssetsQuery } from "./types/ListAssets.types";
+import { AssetVariableQuery } from "./types/AssetVariableQuery.types";
 
 let ds: AssetDataSource, backendSrv: MockProxy<BackendSrv>
 let assetOptions = {
@@ -224,6 +225,87 @@ const assetsResponseMock: AssetsResponse =
   "totalCount": 4
 }
 
+const assetsWithoutNameResponseMock: AssetsResponse =
+{
+  "assets": [
+    {
+      "modelName": "sbRIO-9629",
+      "modelNumber": 0,
+      "serialNumber": "01FE20D1",
+      "vendorName": "National Instruments",
+      "vendorNumber": 0,
+      "busType": "BUILT_IN_SYSTEM",
+      "name": "",
+      "assetType": "SYSTEM",
+      "discoveryType": "AUTOMATIC",
+      "firmwareVersion": "8.8.0f0",
+      "hardwareVersion": "",
+      "visaResourceName": "",
+      "temperatureSensors": [],
+      "supportsSelfCalibration": false,
+      "supportsExternalCalibration": false,
+      "isNIAsset": true,
+      "id": "7f6d0d74-bc75-4d78-9edd-00c253b3a0de",
+      "location": {
+        "minionId": "NI_sbRIO-9629--SN-01FE20D1--MAC-00-80-2F-33-30-18",
+        "parent": "",
+        "resourceUri": "system",
+        "slotNumber": -1,
+        "state": {
+          "assetPresence": "PRESENT"
+        }
+      },
+      "calibrationStatus": "OK",
+      "isSystemController": true,
+      "workspace": "e73fcd94-649b-4d0a-b164-bf647a5d0946",
+      "properties": {},
+      "keywords": [],
+      "lastUpdatedTimestamp": "2024-02-21T12:54:20.069Z",
+      "fileIds": [],
+      "supportsSelfTest": false,
+      "supportsReset": false
+    },
+    {
+      "modelName": "",
+      "modelNumber": 1111,
+      "serialNumber": "2222",
+      "vendorName": "",
+      "vendorNumber": 3333,
+      "busType": "BUILT_IN_SYSTEM",
+      "name": "",
+      "assetType": "SYSTEM",
+      "discoveryType": "AUTOMATIC",
+      "firmwareVersion": "8.8.0f0",
+      "hardwareVersion": "",
+      "visaResourceName": "",
+      "temperatureSensors": [],
+      "supportsSelfCalibration": false,
+      "supportsExternalCalibration": false,
+      "isNIAsset": true,
+      "id": "7f6d0d74-bc75-4d78-9edd-00c253b3a0de",
+      "location": {
+        "minionId": "NI_sbRIO-9629--SN-01FE20D1--MAC-00-80-2F-33-30-18",
+        "parent": "",
+        "resourceUri": "system",
+        "slotNumber": -1,
+        "state": {
+          "assetPresence": "PRESENT"
+        }
+      },
+      "calibrationStatus": "OK",
+      "isSystemController": true,
+      "workspace": "e73fcd94-649b-4d0a-b164-bf647a5d0946",
+      "properties": {},
+      "keywords": [],
+      "lastUpdatedTimestamp": "2024-02-21T12:54:20.069Z",
+      "fileIds": [],
+      "supportsSelfTest": false,
+      "supportsReset": false
+    }
+  ],
+  "totalCount": 2
+}
+
 
 const assetMetadataQueryMock: ListAssetsQuery = {
   type: AssetQueryType.ListAssets,
@@ -273,5 +355,47 @@ describe('queries', () => {
       .mockReturnValue(createFetchError(418))
 
     await expect(ds.query(buildMetadataQuery(assetMetadataQueryMock))).rejects.toThrow()
+  })
+
+  describe('metricFindQuery', () => {
+    it('returns name/alias when asset name field is present', async () => {
+      const query: AssetVariableQuery = {
+        filter: '',
+        type: AssetQueryType.None,
+        refId: ""
+      }
+
+      backendSrv.fetch
+        .calledWith(requestMatching({ url: '/niapm/v1/query-assets' }))
+        .mockReturnValue(createFetchResponse(assetsResponseMock as AssetsResponse))
+
+      const options = {
+        scopedVars: {}
+      }
+
+      const result = await ds.metricFindQuery(query, options)
+
+      expect(result).toMatchSnapshot();
+    })
+
+    it('returns default identifiers when asset name is not present', async () => {
+      const query: AssetVariableQuery = {
+        filter: '',
+        type: AssetQueryType.None,
+        refId: ""
+      }
+
+      backendSrv.fetch
+        .calledWith(requestMatching({ url: '/niapm/v1/query-assets' }))
+        .mockReturnValue(createFetchResponse(assetsWithoutNameResponseMock as AssetsResponse))
+
+      const options = {
+        scopedVars: {}
+      }
+
+      const result = await ds.metricFindQuery(query, options)
+
+      expect(result).toMatchSnapshot();
+    })
   })
 })

--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -97,6 +97,22 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
       this.listAssetsDataSource.queryTransformationOptions
     );
     const assetsResponse: AssetModel[] = await this.listAssetsDataSource.queryAssets(assetFilter, QUERY_LIMIT);
-    return assetsResponse.map((asset: AssetModel) => ({ text: asset.name, value: `Assets.${asset.vendorName}.${asset.modelName}.${asset.serialNumber}` }));
+    return assetsResponse.map(this.getAssetNameForMetricQuery);
+  }
+
+  private getAssetNameForMetricQuery(asset: AssetModel): MetricFindValue {
+    let assetName = asset.name;
+    const vendor = asset.vendorName ? asset.vendorName : asset.vendorNumber;
+    const model = asset.modelName ? asset.modelName : asset.modelNumber;
+    const serial = asset.serialNumber;
+
+    if(!assetName) {
+      assetName = `Vendor: ${vendor} - Model: ${model} - Serial: ${serial}`;
+    }
+
+    return {
+      text: assetName,
+      value: `Assets.${vendor}.${model}.${asset.serialNumber}`,
+    };
   }
 }

--- a/src/datasources/asset/__snapshots__/AssetDataSource.test.ts.snap
+++ b/src/datasources/asset/__snapshots__/AssetDataSource.test.ts.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`queries metricFindQuery returns default identifiers when asset name is not present 1`] = `
+[
+  {
+    "text": "Vendor: National Instruments - Model: sbRIO-9629 - Serial: 01FE20D1",
+    "value": "Assets.National Instruments.sbRIO-9629.01FE20D1",
+  },
+  {
+    "text": "Vendor: 3333 - Model: 1111 - Serial: 2222",
+    "value": "Assets.3333.1111.2222",
+  },
+]
+`;
+
+exports[`queries metricFindQuery returns name/alias when asset name field is present 1`] = `
+[
+  {
+    "text": "NI-sbRIO-9629-01FE20D1",
+    "value": "Assets.National Instruments.sbRIO-9629.01FE20D1",
+  },
+  {
+    "text": "Conn0_AI",
+    "value": "Assets.National Instruments.AI 0-15.01FE20D1",
+  },
+  {
+    "text": "Conn0_AO",
+    "value": "Assets.National Instruments.AO 0-3.01FE20D1",
+  },
+  {
+    "text": "Conn0_DIO0-3",
+    "value": "Assets.National Instruments.DIO 0-3.01FE20D1",
+  },
+]
+`;
+
 exports[`queries run metadata query 1`] = `
 [
   {

--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
@@ -64,7 +64,7 @@ export class ListAssetsDataSource extends AssetDataSourceBase {
       { name: 'minionId', values: assets.map(a => a.location.minionId) },
       { name: 'parent name', values: assets.map(a => a.location.parent) },
       { name: 'workspace', values: assets.map( a => getWorkspaceName( workspaces, a.workspace ) ) },
-      { name: 'calibration due date', values: assets.map(a => a.externalCalibration?.resolvedDueDate) },
+      { name: 'calibration due date', values: assets.map(a => a.externalCalibration?.resolvedDueDate) }
     ];
     return result;
   }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

When there's not asset name in the dropdowns, the row renders an empty string which makes choosing an asset very difficult.

Improving the existing flow to render the asset identifier parameters when the name/alias is empty

<img width="654" alt="image" src="https://github.com/user-attachments/assets/27bd6d8b-354a-4e13-a998-ab760686f48b">

## 👩‍💻 Implementation

Implemented the logic to construct the identifier when the name attribute is missing

## 🧪 Testing

- Manual testing
- Unit testing

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).