### PR TITLE
fix(assets): addressing feedback for naming the assets

### DIFF
--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -101,18 +101,15 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
   }
 
   private getAssetNameForMetricQuery(asset: AssetModel): MetricFindValue {
-    let assetName = asset.name;
+
     const vendor = asset.vendorName ? asset.vendorName : asset.vendorNumber;
     const model = asset.modelName ? asset.modelName : asset.modelNumber;
     const serial = asset.serialNumber;
+    const assetIdentifier = `Vendor: ${vendor} - Model: ${model} - Serial: ${serial}`;
 
-    if(!assetName) {
-      assetName = `Vendor: ${vendor} - Model: ${model} - Serial: ${serial}`;
-    }
+    const assetName = !asset.name ? assetIdentifier : `${asset.name} (${assetIdentifier})`;
+    const assetValue = `Assets.${vendor}.${model}.${asset.serialNumber}`
 
-    return {
-      text: assetName,
-      value: `Assets.${vendor}.${model}.${asset.serialNumber}`,
-    };
+    return { text: assetName, value: assetValue };
   }
 }

--- a/src/datasources/asset/__snapshots__/AssetDataSource.test.ts.snap
+++ b/src/datasources/asset/__snapshots__/AssetDataSource.test.ts.snap
@@ -16,19 +16,19 @@ exports[`queries metricFindQuery returns default identifiers when asset name is 
 exports[`queries metricFindQuery returns name/alias when asset name field is present 1`] = `
 [
   {
-    "text": "NI-sbRIO-9629-01FE20D1",
+    "text": "NI-sbRIO-9629-01FE20D1 (Vendor: National Instruments - Model: sbRIO-9629 - Serial: 01FE20D1)",
     "value": "Assets.National Instruments.sbRIO-9629.01FE20D1",
   },
   {
-    "text": "Conn0_AI",
+    "text": "Conn0_AI (Vendor: National Instruments - Model: AI 0-15 - Serial: 01FE20D1)",
     "value": "Assets.National Instruments.AI 0-15.01FE20D1",
   },
   {
-    "text": "Conn0_AO",
+    "text": "Conn0_AO (Vendor: National Instruments - Model: AO 0-3 - Serial: 01FE20D1)",
     "value": "Assets.National Instruments.AO 0-3.01FE20D1",
   },
   {
-    "text": "Conn0_DIO0-3",
+    "text": "Conn0_DIO0-3 (Vendor: National Instruments - Model: DIO 0-3 - Serial: 01FE20D1)",
     "value": "Assets.National Instruments.DIO 0-3.01FE20D1",
   },
 ]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Based on @joshuaprewitt feedback, I've added the identifier on the default asset names as well.

This will enable the customers to search more easily between their assets by any of the following:

Name, Vendor, Model, Serial Number

![image](https://github.com/user-attachments/assets/869329b9-67ea-45d8-80a1-d70270eafc6f)

## 👩‍💻 Implementation

When constructing the name, I've included additional details (Name, Vendor, Model, Serial Number) in the asset name to make the search more rich

## 🧪 Testing

Manual / Unit tests


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).