### PR TITLE
feat(results): Add Test Results datasource and its query editor

### DIFF
--- a/provisioning/example.yaml
+++ b/provisioning/example.yaml
@@ -41,3 +41,7 @@ datasources:
     type: ni-slassetcalibration-datasource
     uid: assetcalibration
     <<: *config
+  - name: SystemLink Test Results
+    type: ni-sltestresults-datasource
+    uid: testresults
+    <<: *config

--- a/src/datasources/results/README.md
+++ b/src/datasources/results/README.md
@@ -1,0 +1,5 @@
+# Systemlink Results data source
+
+This is a plugin for the Test Results from the testmonitor service. It allows you to:
+
+- Visualize results metadata on a dashboard

--- a/src/datasources/results/ResultsDataSource.ts
+++ b/src/datasources/results/ResultsDataSource.ts
@@ -1,0 +1,80 @@
+import {
+    DataFrameDTO,
+    DataQueryRequest,
+    DataSourceInstanceSettings,
+    FieldType,
+    TestDataSourceResponse,
+} from '@grafana/data';
+import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
+import { DataSourceBase } from 'core/DataSourceBase';
+import {
+    OutputType,
+    QueryResultsResponse,
+    ResultsProperties,
+    ResultsPropertiesOptions,
+    ResultsQuery,
+    ResultsResponseProperties,
+} from './types';
+
+export class ResultsDataSource extends DataSourceBase<ResultsQuery> {
+  constructor(
+    readonly instanceSettings: DataSourceInstanceSettings,
+    readonly backendSrv: BackendSrv = getBackendSrv(),
+    readonly templateSrv: TemplateSrv = getTemplateSrv()
+  ) {
+    super(instanceSettings, backendSrv, templateSrv);
+  }
+
+  baseUrl = this.instanceSettings.url + '/nitestmonitor';
+  queryResultsUrl = this.baseUrl + '/v2/query-results';
+
+  defaultQuery = {
+    outputType: OutputType.Data,
+    useTimeRange: false,
+  };
+
+  async queryResults(
+    orderBy: string,
+    projection: ResultsProperties[],
+    recordCount = 1000,
+    descending = false,
+    returnCount = false
+  ): Promise<QueryResultsResponse> {
+    return await this.post<QueryResultsResponse>(`${this.queryResultsUrl}`, {
+      orderBy: orderBy,
+      descending: descending,
+      projection: projection,
+      take: recordCount,
+      returnCount: returnCount,
+    }).then(response => response);
+  }
+
+  async runQuery(query: ResultsQuery, { range }: DataQueryRequest): Promise<DataFrameDTO> {
+    const responseData = (await this.queryResults(query.orderBy!, query.properties!, query.recordCount, query.descending)).results;
+    const selectedFields = query.properties?.filter((field: ResultsProperties) => Object.keys(responseData[0]).includes(field)) || [];
+    const fields = selectedFields.map(field => {
+      const fieldType = (field === ResultsPropertiesOptions.UPDATED_AT || field === ResultsPropertiesOptions.STARTED_AT) ? FieldType.time : FieldType.string;
+      const values = responseData.map(data => data[field as unknown as keyof ResultsResponseProperties]);
+
+      if (field === ResultsPropertiesOptions.PROPERTIES || field === ResultsPropertiesOptions.STATUS || field === ResultsPropertiesOptions.STATUS_SUMMARY) {
+        return { name: field, values: values.map(value => JSON.stringify(value)), type: fieldType };
+      }
+      return { name: field, values, type: fieldType };
+    });
+
+    return {
+      refId: query.refId,
+      fields: fields,
+    };
+  }
+
+  shouldRunQuery(query: ResultsQuery): boolean {
+    return true;
+  }
+
+  async testDatasource(): Promise<TestDataSourceResponse> {
+    // TODO: Implement a health and authentication check
+    await this.backendSrv.get(this.baseUrl + '/');
+    return { status: 'success', message: 'Data source connected and authentication successful!' };
+  }
+}

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -1,0 +1,140 @@
+import React, { useCallback } from 'react';
+import { AutoSizeInput, InlineSwitch, MultiSelect, RadioButtonGroup, Select, VerticalGroup } from '@grafana/ui';
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { InlineField } from 'core/components/InlineField';
+import { ResultsDataSource } from '../ResultsDataSource';
+import { OrderBy, OutputType, ResultsProperties, ResultsQuery, UseTimeRange } from '../types';
+
+type Props = QueryEditorProps<ResultsDataSource, ResultsQuery>;
+
+export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+  query = datasource.prepareQuery(query);
+
+  const handleQueryChange = useCallback(
+    (query: ResultsQuery, runQuery = true): void => {
+      onChange(query);
+      if (runQuery) {
+        onRunQuery();
+      }
+    },
+    [onChange, onRunQuery]
+  );
+
+  const onOutputChange = (value: OutputType) => {
+    handleQueryChange({ ...query, outputType: value });
+  };
+
+  const onPropertiesChange = (items: Array<SelectableValue<string>>) => {
+    if (items !== undefined) {
+      handleQueryChange({ ...query, properties: items.map(i => i.value as ResultsProperties) });
+    }
+  };
+
+  const onOrderByChange = (item: SelectableValue<string>) => {
+    handleQueryChange({ ...query, orderBy: item.value });
+  };
+
+  const onUseTimeRangeChecked = (value: boolean) => {
+    onChange({ ...query, useTimeRange: value });
+  };
+
+  const onUseTimeRangeChanged = (value: SelectableValue<string>) => {
+    handleQueryChange({ ...query, useTimeRangeFor: value.value! });
+  };
+
+  const onDescendingChange = (isDescendingChecked: boolean) => {
+    handleQueryChange({ ...query, descending: isDescendingChecked });
+  };
+
+  const recordCountChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = parseInt((event.target as HTMLInputElement).value, 10);
+    handleQueryChange({ ...query, recordCount: value });
+  };
+
+  return (
+    <>
+      <VerticalGroup>
+        <InlineField label="Output" labelWidth={18} tooltip={tooltips.output}>
+          <RadioButtonGroup
+            options={Object.values(OutputType).map(value => ({ label: value, value })) as SelectableValue[]}
+            value={query.outputType}
+            onChange={onOutputChange}
+          />
+        </InlineField>
+        {query.outputType === OutputType.Data && (
+          <InlineField label="Properties" labelWidth={18} tooltip={tooltips.properties}>
+            <MultiSelect
+              placeholder="Select properties to fetch"
+              options={Object.keys(ResultsProperties).map(value => ({ label: value, value })) as SelectableValue[]}
+              onChange={onPropertiesChange}
+              value={query.properties}
+              defaultValue={query.properties!}
+              maxVisibleValues={5}
+              width={40}
+              allowCustomValue={false}
+              closeMenuOnSelect={false}
+            />
+          </InlineField>
+        )}
+        <div>
+          {query.outputType === OutputType.Data && (
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+              <InlineField label="OrderBy" labelWidth={18} tooltip={tooltips.orderBy}>
+                <Select
+                  options={OrderBy as SelectableValue[]}
+                  placeholder="Select field to order by"
+                  onChange={onOrderByChange}
+                  value={query.orderBy}
+                  defaultValue={query.orderBy}
+                />
+              </InlineField>
+              <InlineField label="Descending" tooltip={tooltips.descending}>
+                <InlineSwitch
+                  onChange={event => onDescendingChange(event.currentTarget.checked)}
+                  value={query.descending}
+                />
+              </InlineField>
+            </div>
+          )}
+          {query.outputType === OutputType.Data && (
+            <InlineField label="Take" labelWidth={18} tooltip={tooltips.recordCount}>
+              <AutoSizeInput
+                minWidth={20}
+                maxWidth={40}
+                defaultValue={query.recordCount}
+                onCommitChange={recordCountChange}
+                placeholder="Enter record count"
+              />
+            </InlineField>
+          )}
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <InlineField label="Use time range" tooltip={tooltips.useTimeRange} labelWidth={18}>
+              <InlineSwitch
+                onChange={event => onUseTimeRangeChecked(event.currentTarget.checked)}
+                value={query.useTimeRange}
+              />
+            </InlineField>
+            <InlineField label="to filter by" disabled={!query.useTimeRange}>
+              <Select
+                options={Object.keys(UseTimeRange).map(value => ({ label: value, value })) as SelectableValue[]}
+                onChange={onUseTimeRangeChanged}
+                value={query.useTimeRangeFor}
+                width={25}
+              />
+            </InlineField>
+          </div>
+        </div>
+      </VerticalGroup>
+    </>
+  );
+}
+
+const tooltips = {
+  queryType: 'Select the type of query to run',
+  output: 'Select the output type for the query',
+  properties: 'Select the properties fields to query',
+  recordCount: 'Enter the number of records to query',
+  orderBy: 'Select the field to order the results by',
+  descending: 'Select to order the results in descending order',
+  useTimeRange: 'Use the time range instead for the selected field',
+};

--- a/src/datasources/results/img/logo-ni.svg
+++ b/src/datasources/results/img/logo-ni.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="43px" height="29px" viewBox="0 0 43 29" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>9B441361-9BF9-4E57-A772-8A5F7846467E</title>
+    <g id="Login" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Logging-In-Loader" transform="translate(-864.000000, -139.000000)" fill="#00B383">
+            <g id="NI-logo" transform="translate(864.000000, 139.000000)">
+                <path d="M9.98214286,9.92105263 L9.98214286,29 L0,29 L0,9.92105263 L9.98214286,9.92105263 Z M43,0 L43,29 C37.4870147,29 33.0178571,24.5308424 33.0178571,19.0178571 L33.0178571,0 L43,0 Z M18.4107143,0 C23.9335618,-1.01453063e-15 28.4107143,4.4771525 28.4107143,10 L28.4107143,29 L18.4293773,29 L18.4293773,10.9210526 C18.4293439,10.3687809 17.981649,9.92107107 17.4293773,9.92101925 L9.98214286,9.92077061 L9.98214286,0 L18.4107143,0 Z"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/datasources/results/module.ts
+++ b/src/datasources/results/module.ts
@@ -1,0 +1,8 @@
+import { DataSourcePlugin } from '@grafana/data';
+import { ResultsDataSource } from './ResultsDataSource';
+import { ResultsQueryEditor } from './components/ResultsQueryEditor';
+import { HttpConfigEditor } from 'core/components/HttpConfigEditor';
+
+export const plugin = new DataSourcePlugin(ResultsDataSource)
+  .setConfigEditor(HttpConfigEditor)
+  .setQueryEditor(ResultsQueryEditor);

--- a/src/datasources/results/plugin.json
+++ b/src/datasources/results/plugin.json
@@ -1,0 +1,15 @@
+{
+  "type": "datasource",
+  "name": "SystemLink Results",
+  "id": "ni-sltestresults-datasource",
+  "metrics": true,
+  "info": {
+    "author": {
+      "name": "NI"
+    },
+    "logos": {
+      "small": "img/logo-ni.svg",
+      "large": "img/logo-ni.svg"
+    }
+  }
+}

--- a/src/datasources/results/types.ts
+++ b/src/datasources/results/types.ts
@@ -1,0 +1,116 @@
+import { DataQuery } from '@grafana/schema';
+
+export interface ResultsQuery extends DataQuery {
+  outputType: OutputType;
+  properties?: ResultsProperties[];
+  orderBy?: string;
+  descending?: boolean;
+  useTimeRange?: boolean;
+  useTimeRangeFor?: string;
+  recordCount?: number;
+}
+
+export enum OutputType {
+  Data = 'Data',
+  TotalCount = 'Total Count',
+}
+
+export enum UseTimeRange {
+  Started = 'Started',
+  Updated = 'Updated',
+}
+
+export enum ResultsProperties {
+    id = 'ID',
+    programName = 'PROGRAM_NAME',
+    serialNumber = 'SERIAL_NUMBER',
+    systemId = 'SYSTEM_ID',
+    status = 'STATUS',
+    totalTimeInSeconds = 'TOTAL_TIME_IN_SECONDS',
+    startedAt= 'STARTED_AT',
+    updatedAt = 'UPDATED_AT',
+    partNumber = 'PART_NUMBER',
+    dataTableIds= 'DATA_TABLE_IDS',
+    fileIds = 'FILE_IDS',
+    hostName = 'HOST_NAME',
+    operator = 'OPERATOR',
+    keywords = 'KEYWORDS',
+    properties = 'PROPERTIES',
+    statusSummary = 'STATUS_SUMMARY',
+    workspace = 'WORKSPACE',
+}
+
+
+export const OrderBy = [
+  {
+    value: 'ID',
+    label: 'ID',
+    description: `ID of the result`,
+  }
+];
+
+export const ResultsPropertiesOptions = {
+    ID: 'id',
+    PROGRAM_NAME: 'programName',
+    SERIAL_NUMBER: 'serialNumber',
+    SYSTEM_ID: 'systemId',
+    STATUS: 'status',
+    TOTAL_TIME_IN_SECONDS: 'totalTimeInSeconds',
+    STARTED_AT: 'startedAt',
+    UPDATED_AT: 'updatedAt',
+    PART_NUMBER: 'partNumber',
+    DATA_TABLE_IDS: 'dataTableIds',
+    FILE_IDS: 'fileIds',
+    HOST_NAME: 'hostName',
+    OPERATOR: 'operator',
+    KEYWORDS: 'keywords',
+    PROPERTIES: 'properties',
+    STATUS_SUMMARY: 'statusSummary',
+    WORKSPACE: 'workspace',
+}
+
+export interface StatusHttp {
+  statusType: string;
+  statusName: string;
+}
+
+export interface StatusTypeSummaryHttp {
+  [status: string]: number;
+}
+
+export interface ResultsResponseProperties {
+  status?: StatusHttp;
+  startedAt?: string;
+  updatedAt?: string;
+  programName: string;
+  id: string;
+  systemId: string;
+  hostName: string;
+  operator: string;
+  partNumber: string;
+  serialNumber: string;
+  totalTimeInSeconds: number;
+  keywords: string[];
+  properties: { [key: string]: string };
+  fileIds: string[];
+  statusTypeSummary?: StatusTypeSummaryHttp;
+  workspace: string;
+  dataTableIds: string[];
+}
+
+export interface QueryResultsResponse {
+  results: ResultsResponseProperties[];
+  continuationToken: string;
+  totalCount: number;
+  // error?: ErrorBody;
+}
+
+// export interface ErrorBody {
+//   resourceType?: string;
+//   resourceId?: string;
+//   name?: string;
+//   code?: number;
+//   message?: string;
+//   args?: string[];
+//   innerErrors?: ErrorBody[];
+// }

--- a/src/datasources/results/types.ts
+++ b/src/datasources/results/types.ts
@@ -46,6 +46,56 @@ export const OrderBy = [
     value: 'ID',
     label: 'ID',
     description: `ID of the result`,
+  },
+  {
+    value: 'STARTED_AT',
+    label: 'Started At',
+    description: `Started At of the result`,
+  },
+  {
+    value: 'UPDATED_AT',
+    label: 'Updated At',
+    description: `Updated At of the result`,
+  },
+  {
+    value: 'PROGRAM_NAME',
+    label: 'Program Name',
+    description: `Program Name of the result`,
+  },
+  {
+    value: 'SYSTEM_ID',
+    label: 'System ID',
+    description: `System ID of the result`,
+  },
+  {
+    value: 'HOST_NAME',
+    label: 'Host Name',
+    description: `Host Name of the result`,
+  },
+  {
+    value: 'OPERATOR',
+    label: 'Operator',
+    description: `Operator of the result`,
+  },
+  {
+    value: 'SERIAL_NUMBER',
+    label: 'Serial Number',
+    description: `Serial Number of the result`,
+  },
+   {
+    value: 'PART_NUMBER',
+    label: 'Part Number',
+    description: `Part Number of the result`,
+  },
+  {
+    value: 'PROPERTIES',
+    label: 'Properties',
+    description: `Properties of the result`,
+  },
+  {
+    value: 'TOTAL_TIME_IN_SECONDS ',
+    label: 'Total Time In Seconds',
+    description: `Total Time In Seconds of the result`,
   }
 ];
 
@@ -102,15 +152,4 @@ export interface QueryResultsResponse {
   results: ResultsResponseProperties[];
   continuationToken: string;
   totalCount: number;
-  // error?: ErrorBody;
 }
-
-// export interface ErrorBody {
-//   resourceType?: string;
-//   resourceId?: string;
-//   name?: string;
-//   code?: number;
-//   message?: string;
-//   args?: string[];
-//   innerErrors?: ErrorBody[];
-// }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
Feature : [Feature 2605755 ](https://dev.azure.com/ni/DevCentral/_workitems/edit/2605755): Grafana support for results datasource

As part of [Add Results Query editors to the Results Datasource](https://dev.azure.com/ni/DevCentral/_workitems/edit/2980051) user story, this PR contains the addition of the Results Datasource along with basic controls in the query editor to fetch results details.

## 👩‍💻 Implementation

- Created `ResultsDataSource` class with methods to query results and run queries.
- Defined types and interfaces for result queries and responses.
![image](https://github.com/user-attachments/assets/070f72d5-590b-45d0-89ea-4cdd0a9caf21)
![image](https://github.com/user-attachments/assets/d9d5f31f-a6be-4356-928b-1a9f16c67357)

## 🧪 Testing

- [x] Yet to update

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).