### PR TITLE
fix(products): Add query help and update label name in the products datasource

### DIFF
--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -112,7 +112,7 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
                 />
               </InlineField>
             </div>
-            <InlineField label="Records to Query" labelWidth={18} tooltip={tooltips.recordCount}>
+            <InlineField label="Take" labelWidth={18} tooltip={tooltips.recordCount}>
               <AutoSizeInput
                 minWidth={20}
                 maxWidth={40}

--- a/src/datasources/products/query_help.md
+++ b/src/datasources/products/query_help.md
@@ -1,0 +1,3 @@
+The _SystemLink Products_ data source allows you to display product metadata in dashboards.
+
+For more information, refer to [Analyzing and Interacting with Test Results - SystemLink Enterprise.](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/analyzing-test-data-jupyter.html)


### PR DESCRIPTION
## 🤨 Rationale

This PR contains changes to the label Name from `Records to query` to `Take` and add a Help doc for the datasource.

## 👩‍💻 Implementation

-  Updated the label "Records to Query" to "Take" for better clarity.
- Added a description of the `SystemLink Products` data source and a link to further information on analyzing and interacting with test results

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).