### PR TITLE
feat(results): Add floating error in results query editor

### DIFF
--- a/src/datasources/results/ResultsDataSource.test.ts
+++ b/src/datasources/results/ResultsDataSource.test.ts
@@ -5,7 +5,7 @@ import { BackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { createFetchError, createFetchResponse, getQueryBuilder, requestMatching, setupDataSource } from 'test/fixtures';
 import { Field } from '@grafana/data';
 
-const mockQueryResulltsResponse: QueryResultsResponse = {
+const mockQueryResultsResponse: QueryResultsResponse = {
   results: [
     {
       id: '000007fb-aa87-4ab9-9757-6568e7893c33',
@@ -18,7 +18,8 @@ const mockQueryResulltsResponse: QueryResultsResponse = {
 };
 
 jest.mock('@grafana/runtime', () => ({
-  getTemplateSrv: jest.fn()
+  getTemplateSrv: jest.fn(),
+  isFetchError: jest.fn()
 }));
 
 let datastore: ResultsDataSource, backendServer: MockProxy<BackendSrv>
@@ -27,13 +28,14 @@ describe('ResultsDataSource', () => {
   beforeEach(() => {
     (getTemplateSrv as jest.Mock).mockReturnValue({
         replace: jest.fn((value) => value.replace('${__from:date}', 'replacedDate'))
-      });
+    });
+
     [datastore, backendServer] = setupDataSource(ResultsDataSource);
 
     backendServer.fetch
     .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
     .mockReturnValue(
-      createFetchResponse<QueryResultsResponse>(mockQueryResulltsResponse)
+      createFetchResponse<QueryResultsResponse>(mockQueryResultsResponse)
     );
   })
 

--- a/src/datasources/results/ResultsDataSource.ts
+++ b/src/datasources/results/ResultsDataSource.ts
@@ -2,6 +2,7 @@ import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, FieldType, 
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { OutputType, QueryResultsResponse, ResultsProperties, ResultsPropertiesOptions, ResultsQuery, ResultsResponseProperties } from './types';
+import { parseErrorMessage } from 'core/errors';
 
 export class ResultsDataSource extends DataSourceBase<ResultsQuery> {
   constructor(
@@ -14,6 +15,9 @@ export class ResultsDataSource extends DataSourceBase<ResultsQuery> {
 
   baseUrl = this.instanceSettings.url + '/nitestmonitor';
   queryResultsUrl = this.baseUrl + '/v2/query-results';
+
+  error = '';
+
   defaultQuery = {
     properties: [
       ResultsPropertiesOptions.PROGRAM_NAME,
@@ -54,7 +58,8 @@ export class ResultsDataSource extends DataSourceBase<ResultsQuery> {
         returnCount,
       });
     } catch (error) {
-      throw new Error(`An error occurred while querying results: ${error}`);
+      this.error = parseErrorMessage(error as Error)!;
+      throw new Error(`An error occurred while querying results ${this.error}`);
     }
   }
 

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -20,8 +20,9 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
 
   return (
     <QueryResultsEditor
-      query={query} 
+      query={query}
       handleQueryChange={handleQueryChange}
+      datasource={datasource}
     />
   );
 }

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -12,13 +12,16 @@ import { enumToOptions } from 'core/utils';
 import { OrderBy, OutputType, ResultsProperties, ResultsQuery, UseTimeRangeFor } from 'datasources/results/types';
 import React from 'react';
 import './QueryResultsEditor.scss';
+import { FloatingError } from 'core/errors';
+import { ResultsDataSource } from 'datasources/results/ResultsDataSource';
 
 type Props = {
   query: ResultsQuery;
   handleQueryChange: (query: ResultsQuery, runQuery?: boolean) => void;
+  datasource?: ResultsDataSource;
 };
 
-export function QueryResultsEditor({ query, handleQueryChange }: Props) {
+export function QueryResultsEditor({ query, datasource, handleQueryChange }: Props) {
   const onOutputChange = (value: OutputType) => {
     handleQueryChange({ ...query, outputType: value });
   };
@@ -109,6 +112,7 @@ export function QueryResultsEditor({ query, handleQueryChange }: Props) {
           />
         )}
       </VerticalGroup>
+      <FloatingError message={datasource?.error} />
     </>
   );
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
Feature : [Feature 2605755 ](https://dev.azure.com/ni/DevCentral/_workitems/edit/2605755): Grafana support for results datasource

As a part of [User Story 2980051](https://dev.azure.com/ni/DevCentral/_workitems/edit/2980051): Add Results Query editors to the Results Datasource, this PR contains the addition of `FloatingError` reusable for handling errors in Results Query Editor. 

## 👩‍💻 Implementation

- The errors are parsed using `parseErrorMessage` from `core/error`.
- The parsed error message is passed to the `FloatingError` component to be displayed in the Results Query Editor when errors occur.

## 🧪 Testing

Updated test

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).