### PR TITLE
fix(products): Fix query builder css rendering and minor UI improvements

### DIFF
--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -14,23 +14,23 @@ let descending: HTMLElement
 let recordCount: HTMLElement
 
 describe('ProductsQueryEditor', () => {
-  beforeEach(async() => {
-    [onChange] = render({ refId: '', properties: [], orderBy: undefined} as ProductQuery);
+  beforeEach(async () => {
+    [onChange] = render({ refId: '', properties: [] } as ProductQuery);
     await waitFor(() => properties = screen.getAllByRole('combobox')[0]);
     orderBy = screen.getAllByRole('combobox')[1];
     descending = screen.getByRole('checkbox');
-    recordCount = screen.getByRole('textbox');
+    recordCount = screen.getByDisplayValue('1000');
   });
 
   it('renders with default query', async () => {
     expect(properties).toBeInTheDocument();
-    expect(properties).toHaveDisplayValue('');  
+    expect(properties).toHaveDisplayValue('');
     expect(orderBy).toBeInTheDocument();
-    expect(orderBy).toHaveAccessibleDescription('Select field to order by');  
+    expect(orderBy).toHaveAccessibleDescription('Select field to order by');
     expect(descending).toBeInTheDocument();
-    expect(descending).not.toBeChecked();  
+    expect(descending).not.toBeChecked();
     expect(recordCount).toBeInTheDocument();
-    expect(recordCount).toHaveValue('1000');
+    expect(recordCount).toHaveValue(1000);
   });
 
   it('renders the query builder', async () => {
@@ -46,24 +46,24 @@ describe('ProductsQueryEditor', () => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ properties: ["id"] })
       )
-    });  
+    });
     //User changes order by
     await select(orderBy, "ID", { container: document.body });
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ orderBy: "ID" })
       )
-    });  
+    });
     //User changes descending checkbox
     await userEvent.click(descending);
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ descending: true })
       )
-    });  
+    });
     //User changes record count
     await userEvent.clear(recordCount);
-    await userEvent.type(recordCount, '500{Enter}');
+    await userEvent.type(recordCount, '500A{Enter}'); //Should not enter 'A'
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ recordCount: 500 })

--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -15,7 +15,7 @@ let recordCount: HTMLElement
 
 describe('ProductsQueryEditor', () => {
   beforeEach(async () => {
-    [onChange] = render({ refId: '', properties: [] } as ProductQuery);
+    [onChange] = render({ refId: '', properties: [], orderBy: undefined} as ProductQuery);
     await waitFor(() => properties = screen.getAllByRole('combobox')[0]);
     orderBy = screen.getAllByRole('combobox')[1];
     descending = screen.getByRole('checkbox');
@@ -24,11 +24,11 @@ describe('ProductsQueryEditor', () => {
 
   it('renders with default query', async () => {
     expect(properties).toBeInTheDocument();
-    expect(properties).toHaveDisplayValue('');
+    expect(properties).toHaveDisplayValue(''); 
     expect(orderBy).toBeInTheDocument();
-    expect(orderBy).toHaveAccessibleDescription('Select field to order by');
+    expect(orderBy).toHaveAccessibleDescription('Select field to order by'); 
     expect(descending).toBeInTheDocument();
-    expect(descending).not.toBeChecked();
+    expect(descending).not.toBeChecked(); 
     expect(recordCount).toBeInTheDocument();
     expect(recordCount).toHaveValue(1000);
   });
@@ -46,21 +46,21 @@ describe('ProductsQueryEditor', () => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ properties: ["id"] })
       )
-    });
+    }); 
     //User changes order by
     await select(orderBy, "ID", { container: document.body });
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ orderBy: "ID" })
       )
-    });
+    }); 
     //User changes descending checkbox
     await userEvent.click(descending);
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ descending: true })
       )
-    });
+    }); 
     //User changes record count
     await userEvent.clear(recordCount);
     await userEvent.type(recordCount, '500A{Enter}'); //Should not enter 'A'

--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -15,7 +15,7 @@ let recordCount: HTMLElement
 
 describe('ProductsQueryEditor', () => {
   beforeEach(async () => {
-    [onChange] = render({ refId: '', properties: [], orderBy: undefined} as ProductQuery);
+    [onChange] = render({ refId: '', properties: [], orderBy: undefined } as ProductQuery);
     await waitFor(() => properties = screen.getAllByRole('combobox')[0]);
     orderBy = screen.getAllByRole('combobox')[1];
     descending = screen.getByRole('checkbox');
@@ -24,11 +24,11 @@ describe('ProductsQueryEditor', () => {
 
   it('renders with default query', async () => {
     expect(properties).toBeInTheDocument();
-    expect(properties).toHaveDisplayValue(''); 
+    expect(properties).toHaveDisplayValue('');
     expect(orderBy).toBeInTheDocument();
-    expect(orderBy).toHaveAccessibleDescription('Select field to order by'); 
+    expect(orderBy).toHaveAccessibleDescription('Select field to order by');
     expect(descending).toBeInTheDocument();
-    expect(descending).not.toBeChecked(); 
+    expect(descending).not.toBeChecked();
     expect(recordCount).toBeInTheDocument();
     expect(recordCount).toHaveValue(1000);
   });
@@ -46,21 +46,21 @@ describe('ProductsQueryEditor', () => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ properties: ["id"] })
       )
-    }); 
+    });
     //User changes order by
     await select(orderBy, "ID", { container: document.body });
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ orderBy: "ID" })
       )
-    }); 
+    });
     //User changes descending checkbox
     await userEvent.click(descending);
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ descending: true })
       )
-    }); 
+    });
     //User changes record count
     await userEvent.clear(recordCount);
     await userEvent.type(recordCount, '500A{Enter}'); //Should not enter 'A'

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -105,6 +105,7 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
                   onChange={onOrderByChange}
                   value={query.orderBy}
                   defaultValue={query.orderBy}
+                  width={26}
                 />
               </InlineField>
               <InlineField label="Descending" tooltip={tooltips.descending}>
@@ -116,8 +117,9 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
             </div>
             <InlineField label="Take" labelWidth={18} tooltip={tooltips.recordCount}>
               <AutoSizeInput
-                minWidth={20}
-                maxWidth={40}
+                minWidth={26}
+                maxWidth={26}
+                type='number'
                 defaultValue={query.recordCount}
                 onCommitChange={recordCountChange}
                 placeholder="Enter record count"

--- a/src/datasources/products/components/query-builder/ProductsQueryBuilder.tsx
+++ b/src/datasources/products/components/query-builder/ProductsQueryBuilder.tsx
@@ -8,6 +8,12 @@ import { QBField } from "datasources/products/types";
 import React, { useState, useEffect, useMemo } from "react";
 import QueryBuilder, { QueryBuilderCustomOperation, QueryBuilderProps } from "smart-webcomponents-react/querybuilder";
 
+import 'smart-webcomponents-react/source/styles/smart.dark-orange.css';
+import 'smart-webcomponents-react/source/styles/smart.orange.css';
+import 'smart-webcomponents-react/source/styles/components/smart.base.css';
+import 'smart-webcomponents-react/source/styles/components/smart.common.css';
+import 'smart-webcomponents-react/source/styles/components/smart.querybuilder.css';
+
 type ProductsQueryBuilderProps = QueryBuilderProps & React.HTMLAttributes<Element> & {
   filter?: string;
   workspaces: Workspace[];


### PR DESCRIPTION
## 🤨 Rationale
Inorder to fix the query builder rendering issue : 

![image](https://github.com/user-attachments/assets/21ad2c20-cb2d-4dfd-a1cc-fc75316ca17e)

This pull request includes updates to the `ProductsQueryBuilder.tsx` file to add new stylesheet imports for the `QueryBuilder` component. These changes ensure that the query builder component has the necessary styles applied.

###  UI Improvements
- The PR changes also include adjusting the input field widths, adding a numeric input type the `Order By` and `Take` elements.
![image](https://github.com/user-attachments/assets/461ea394-5dac-4137-b6d0-6068018ba8fa)

## 👩‍💻 Implementation

- Added imports for various `smart-webcomponents-react` stylesheets to ensure proper styling of the `QueryBuilder` component.
- Adjusted the width of the `orderBy` and `Take` input field to 26.
- Added type of the `Take` input field to 'number'

## 🧪 Testing
- Updated test for numeric value in Take input field

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x  ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).