### PR TITLE
fix(assets): fix display for assets in global variable

### DIFF
--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -105,7 +105,7 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
     const model = asset.modelName ? asset.modelName : asset.modelNumber;
     const serial = asset.serialNumber;
 
-    const assetName = !asset.name ? `${model}` : `${asset.name} (${model})`;
+    const assetName = !asset.name ? `${serial}` : `${asset.name} (${serial})`;
     const assetValue = `Assets.${vendor}.${model}.${serial}`
 
     return { text: assetName, value: assetValue };

--- a/src/datasources/asset/__snapshots__/AssetDataSource.test.ts.snap
+++ b/src/datasources/asset/__snapshots__/AssetDataSource.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`queries metricFindQuery returns default identifiers when asset name is not present 1`] = `
 [
   {
-    "text": "sbRIO-9629",
+    "text": "01FE20D1",
     "value": "Assets.National Instruments.sbRIO-9629.01FE20D1",
   },
   {
-    "text": "1111",
+    "text": "2222",
     "value": "Assets.3333.1111.2222",
   },
 ]
@@ -16,19 +16,19 @@ exports[`queries metricFindQuery returns default identifiers when asset name is 
 exports[`queries metricFindQuery returns name/alias when asset name field is present 1`] = `
 [
   {
-    "text": "NI-sbRIO-9629-01FE20D1 (sbRIO-9629)",
+    "text": "NI-sbRIO-9629-01FE20D1 (01FE20D1)",
     "value": "Assets.National Instruments.sbRIO-9629.01FE20D1",
   },
   {
-    "text": "Conn0_AI (AI 0-15)",
+    "text": "Conn0_AI (01FE20D1)",
     "value": "Assets.National Instruments.AI 0-15.01FE20D1",
   },
   {
-    "text": "Conn0_AO (AO 0-3)",
+    "text": "Conn0_AO (01FE20D1)",
     "value": "Assets.National Instruments.AO 0-3.01FE20D1",
   },
   {
-    "text": "Conn0_DIO0-3 (DIO 0-3)",
+    "text": "Conn0_DIO0-3 (01FE20D1)",
     "value": "Assets.National Instruments.DIO 0-3.01FE20D1",
   },
 ]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Due to difficulty in readability, we are changing the display for the assets from 

`Vendor: ${vendor} - Model: ${model} - Serial: ${serialNumber}`;

To only `$(serialNumber)`

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/f98730ea-efd6-4237-88bc-ee28616616e2" />


## 👩‍💻 Implementation

Changing the display builder to show only the serial number

## 🧪 Testing

Unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).