### PR TITLE
fix(products): Set defaults for OrderBy and Decending

### DIFF
--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -291,8 +291,8 @@ describe('query', () => {
           properties: [
             PropertiesOptions.PART_NUMBER
           ] as Properties[],
-          orderBy: undefined,
-          queryBy: `${PropertiesOptions.PART_NUMBER} = '123'`
+          queryBy: `${PropertiesOptions.PART_NUMBER} = '123'`,
+          descending: false
         },
       );
 
@@ -318,8 +318,8 @@ describe('query', () => {
           properties: [
             PropertiesOptions.PART_NUMBER
           ] as Properties[],
-          orderBy: undefined,
-          queryBy: `${ProductsQueryBuilderFieldNames.PART_NUMBER} = "{partNumber1,partNumber2}"`
+          queryBy: `${ProductsQueryBuilderFieldNames.PART_NUMBER} = "{partNumber1,partNumber2}"`,
+          descending: false
         },
       );
 

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -34,8 +34,8 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
       PropertiesOptions.FAMILY,
       PropertiesOptions.WORKSPACE
     ] as Properties[],
-    orderBy: undefined,
-    descending: false,
+    orderBy: Properties.updatedAt,
+    descending: true,
     recordCount: 1000,
     queryBy: ''
   };

--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -28,7 +28,7 @@ describe('ProductsQueryEditor', () => {
     expect(orderBy).toBeInTheDocument();
     expect(orderBy).toHaveAccessibleDescription('Select field to order by');
     expect(descending).toBeInTheDocument();
-    expect(descending).not.toBeChecked();
+    expect(descending).toBeChecked();
     expect(recordCount).toBeInTheDocument();
     expect(recordCount).toHaveValue(1000);
   });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
We need to set default values for `OrderBy` to `UpdatedAt` and `Decending` to `True`.

![image](https://github.com/user-attachments/assets/b1239bf0-f433-4e54-b5fc-7d035c3a2d9d)


## 👩‍💻 Implementation
Updated the default query

## 🧪 Testing
Altered the Test cases 

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).