### PR TITLE
feat(products): Add Family name lookup into the query builder 

### DIFF
--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -8,8 +8,6 @@ import { Workspace } from 'core/types';
 import { ProductsQueryBuilder } from 'datasources/products/components/query-builder/ProductsQueryBuilder';
 import { FloatingError } from 'core/errors';
 import './ProductsQueryEditor.scss';
-import { ProductsQueryBuilderStaticFields } from '../constants/ProductsQueryBuilder.constants';
-
 
 type Props = QueryEditorProps<ProductsDataSource, ProductQuery>;
 
@@ -18,6 +16,8 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
 
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [partNumbers, setPartNumbers] = useState<string[]>([]);
+  const [familyNames, setFamilyNames] = useState<string[]>([]);
+  
 
   useEffect(() => {
     const loadWorkspaces = async () => {
@@ -28,9 +28,14 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
       await datasource.arePartNumberLoaded$;
       setPartNumbers(Array.from(datasource.partNumbersCache.values()));
     };
+    const loadFamilyNames = async () => {
+      await datasource.getFamilyNames();
+      setFamilyNames(Array.from(datasource.familyNamesCache.values()));
+  };
 
     loadWorkspaces();
     loadPartNumbers();
+    loadFamilyNames();
   }, [datasource]);
 
   const handleQueryChange = useCallback((query: ProductQuery, runQuery = true): void => {
@@ -89,9 +94,9 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
               filter={query.queryBy}
               workspaces={workspaces}
               partNumbers={partNumbers}
+              familyNames={familyNames}
               globalVariableOptions={datasource.globalVariableOptions()}
               onChange={(event: any) => onParameterChange(event.detail.linq)}
-              staticFields={ProductsQueryBuilderStaticFields}
             ></ProductsQueryBuilder>
           </InlineField>
         </VerticalGroup>

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -18,7 +18,6 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
   const [partNumbers, setPartNumbers] = useState<string[]>([]);
   const [familyNames, setFamilyNames] = useState<string[]>([]);
   
-
   useEffect(() => {
     const loadWorkspaces = async () => {
       await datasource.areWorkspacesLoaded$;
@@ -31,7 +30,7 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
     const loadFamilyNames = async () => {
       await datasource.getFamilyNames();
       setFamilyNames(Array.from(datasource.familyNamesCache.values()));
-  };
+    };
 
     loadWorkspaces();
     loadPartNumbers();

--- a/src/datasources/products/components/ProductsVariableQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsVariableQueryEditor.tsx
@@ -1,11 +1,10 @@
 import { QueryEditorProps } from "@grafana/data";
 import { ProductsDataSource } from "../ProductsDataSource";
-import { ProductVariableQuery, QBField } from "../types";
+import { ProductVariableQuery } from "../types";
 import { InlineField } from 'core/components/InlineField';
 import { ProductsQueryBuilder } from "./query-builder/ProductsQueryBuilder";
 import { Workspace } from "core/types";
-import React, { useState, useEffect, useMemo } from "react";
-import { ProductsQueryBuilderFields } from "../constants/ProductsQueryBuilder.constants";
+import React, { useState, useEffect } from "react";
 import { FloatingError } from "core/errors";
 
 type Props = QueryEditorProps<ProductsDataSource, ProductVariableQuery>;
@@ -39,26 +38,6 @@ export function ProductsVariableQueryEditor({ query, onChange, datasource }: Pro
         onChange({ ...query, queryBy: value });
     };
 
-    const FamilyField = useMemo(() => {
-        const familyField = ProductsQueryBuilderFields.FAMILY;
-        return {
-            ...familyField,
-            lookup: {
-                ...familyField.lookup,
-                dataSource: [
-                    ...familyNames.map(family => ({ label: family, value: family }))
-                ],
-                minLength: 1
-            }
-        }
-    }, [familyNames]);
-
-    const productsVariableQueryStaticFields: QBField[] = [
-        FamilyField,
-        ProductsQueryBuilderFields.NAME,
-        ProductsQueryBuilderFields.PROPERTIES
-    ];
-
     return (
         <>
             <InlineField label="Query By" labelWidth={10}>
@@ -67,8 +46,8 @@ export function ProductsVariableQueryEditor({ query, onChange, datasource }: Pro
                     onChange={(event: any) => onQueryByChange(event.detail.linq)}
                     workspaces={workspaces}
                     partNumbers={partNumbers}
+                    familyNames={familyNames}
                     globalVariableOptions={datasource.globalVariableOptions()}
-                    staticFields={productsVariableQueryStaticFields}
                 ></ProductsQueryBuilder>
             </InlineField>
             <FloatingError message={datasource.error} />

--- a/src/datasources/products/components/query-builder/ProductsQueryBuilder.test.tsx
+++ b/src/datasources/products/components/query-builder/ProductsQueryBuilder.test.tsx
@@ -2,7 +2,6 @@ import { QueryBuilderOption, Workspace } from "core/types";
 import React, { ReactNode } from "react";
 import { ProductsQueryBuilder } from "./ProductsQueryBuilder";
 import { render } from "@testing-library/react";
-import { ProductsQueryBuilderStaticFields } from "datasources/products/constants/ProductsQueryBuilder.constants";
 
 describe('ProductsQueryBuilder', () => {
   describe('useEffects', () => {
@@ -11,10 +10,10 @@ describe('ProductsQueryBuilder', () => {
     const containerClass = 'smart-filter-group-condition-container';
     const workspace = { id: '1', name: 'Selected workspace' } as Workspace;
     const partNumber = ['partNumber1', 'partNumber2'];
-    const staticFields = ProductsQueryBuilderStaticFields;
+    const familyNames = ['familyName1', 'familyName2'];
 
-    function renderElement(workspaces: Workspace[], partNumbers: string[], filter?: string, globalVariableOptions: QueryBuilderOption[] = []) {
-      reactNode = React.createElement(ProductsQueryBuilder, { filter, workspaces, partNumbers, globalVariableOptions, staticFields, onChange: jest.fn(), });
+    function renderElement(workspaces: Workspace[], partNumbers: string[], familyNames: string[], filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
+      reactNode = React.createElement(ProductsQueryBuilder, { filter, workspaces, partNumbers, globalVariableOptions, familyNames, onChange: jest.fn(), });
       const renderResult = render(reactNode);
       return {
         renderResult,
@@ -23,14 +22,14 @@ describe('ProductsQueryBuilder', () => {
     }
 
     it('should render empty query builder', () => {
-      const { renderResult, conditionsContainer } = renderElement([], [], '');
+      const { renderResult, conditionsContainer } = renderElement([], [], [], '');
 
       expect(conditionsContainer.length).toBe(1);
       expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
     })
 
     it('should select workspace in query builder', () => {
-      const { conditionsContainer } = renderElement([workspace], partNumber, 'Workspace = "1" && PartNumber = "partNumber1"');
+      const { conditionsContainer } = renderElement([workspace], partNumber, familyNames, 'Workspace = "1" && PartNumber = "partNumber1"');
 
       expect(conditionsContainer?.length).toBe(2);
       expect(conditionsContainer.item(0)?.textContent).toContain(workspace.name);
@@ -38,15 +37,22 @@ describe('ProductsQueryBuilder', () => {
     })
 
     it('should select part number in query builder', () => {
-      const { conditionsContainer } = renderElement([workspace], partNumber, 'PartNumber = "partNumber1"');
+      const { conditionsContainer } = renderElement([workspace], partNumber, familyNames,  'PartNumber = "partNumber1"');
 
       expect(conditionsContainer?.length).toBe(1);
       expect(conditionsContainer.item(0)?.textContent).toContain("partNumber1");
     });
 
+    it('should select family names in query builder', () => {
+      const { conditionsContainer } = renderElement([workspace], partNumber, familyNames, 'Family = "familyName1"');
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain("familyName1");
+    });
+
     it('should select global variable option', () => {
       const globalVariableOption = { label: 'Global variable', value: 'global_variable' };
-      const { conditionsContainer } = renderElement([workspace], partNumber, 'PartNumber = \"global_variable\"', [globalVariableOption]);
+      const { conditionsContainer } = renderElement([workspace], partNumber, familyNames, 'PartNumber = \"global_variable\"', [globalVariableOption]);
 
       expect(conditionsContainer?.length).toBe(1);
       expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
@@ -54,7 +60,7 @@ describe('ProductsQueryBuilder', () => {
 
     [['${__from:date}', 'From'], ['${__to:date}', 'To'], ['${__now:date}', 'Now']].forEach(([value, label]) => {
       it(`should select user friendly value for updated date`, () => {
-        const { conditionsContainer } = renderElement([workspace], partNumber, `UpdatedAt > \"${value}\"`);
+        const { conditionsContainer } = renderElement([workspace], partNumber, familyNames, `UpdatedAt > \"${value}\"`);
 
         expect(conditionsContainer?.length).toBe(1);
         expect(conditionsContainer.item(0)?.textContent).toContain(label);
@@ -62,7 +68,7 @@ describe('ProductsQueryBuilder', () => {
     });
 
     it('should sanitize fields in query builder', () => {
-      const { conditionsContainer } = renderElement([workspace], partNumber, 'Family = "<script>alert(\'Family\')</script>"');
+      const { conditionsContainer } = renderElement([workspace], partNumber, familyNames, 'Family = "<script>alert(\'Family\')</script>"');
 
       expect(conditionsContainer?.length).toBe(1);
       expect(conditionsContainer.item(0)?.innerHTML).not.toContain('alert(\'Family\')');

--- a/src/datasources/products/components/query-builder/ProductsQueryBuilder.tsx
+++ b/src/datasources/products/components/query-builder/ProductsQueryBuilder.tsx
@@ -3,7 +3,7 @@ import { queryBuilderMessages, QueryBuilderOperations } from "core/query-builder
 import { expressionBuilderCallback, expressionReaderCallback } from "core/query-builder.utils";
 import { Workspace, QueryBuilderOption } from "core/types";
 import { filterXSSField, filterXSSLINQExpression } from "core/utils";
-import { ProductsQueryBuilderFields } from "datasources/products/constants/ProductsQueryBuilder.constants";
+import { ProductsQueryBuilderFields, ProductsQueryBuilderStaticFields } from "datasources/products/constants/ProductsQueryBuilder.constants";
 import { QBField } from "datasources/products/types";
 import React, { useState, useEffect, useMemo } from "react";
 import QueryBuilder, { QueryBuilderCustomOperation, QueryBuilderProps } from "smart-webcomponents-react/querybuilder";
@@ -18,8 +18,8 @@ type ProductsQueryBuilderProps = QueryBuilderProps & React.HTMLAttributes<Elemen
   filter?: string;
   workspaces: Workspace[];
   partNumbers: string[];
+  familyNames: string[];
   globalVariableOptions: QueryBuilderOption[];
-  staticFields?: QBField[];
 };
 
 export const ProductsQueryBuilder: React.FC<ProductsQueryBuilderProps> = ({
@@ -27,8 +27,8 @@ export const ProductsQueryBuilder: React.FC<ProductsQueryBuilderProps> = ({
   onChange,
   workspaces,
   partNumbers,
+  familyNames,
   globalVariableOptions,
-  staticFields
 }) => {
   const theme = useTheme2();
   document.body.setAttribute("theme", theme.isDark ? "dark-orange" : "orange");
@@ -86,9 +86,23 @@ export const ProductsQueryBuilder: React.FC<ProductsQueryBuilderProps> = ({
     }
   }, [partNumbers]);
 
+  const familyField = useMemo(() => {
+          const familyField = ProductsQueryBuilderFields.FAMILY;
+          return {
+              ...familyField,
+              lookup: {
+                  ...familyField.lookup,
+                  dataSource: [
+                      ...familyNames.map(family => ({ label: family, value: family }))
+                  ],
+                  minLength: 1
+              }
+          }
+      }, [familyNames]);
+
 
   useEffect(() => {
-    const updatedFields = [partNumberField, ...staticFields!, updatedAtField, workspaceField]
+    const updatedFields = [partNumberField, familyField, ...ProductsQueryBuilderStaticFields!, updatedAtField, workspaceField]
       .map((field) => {
         if (field.lookup?.dataSource) {
           return {
@@ -151,7 +165,7 @@ export const ProductsQueryBuilder: React.FC<ProductsQueryBuilderProps> = ({
 
     setOperations([...customOperations, ...keyValueOperations]);
 
-  }, [workspaceField, updatedAtField, partNumberField, staticFields, globalVariableOptions]);
+  }, [workspaceField, updatedAtField, partNumberField, familyField, globalVariableOptions]);
 
   return (
     <QueryBuilder

--- a/src/datasources/products/constants/ProductsQueryBuilder.constants.ts
+++ b/src/datasources/products/constants/ProductsQueryBuilder.constants.ts
@@ -98,7 +98,6 @@ export const ProductsQueryBuilderFields: Record<string, QBField> = {
 }
 
 export const ProductsQueryBuilderStaticFields = [
-    ProductsQueryBuilderFields.FAMILY,
     ProductsQueryBuilderFields.NAME,
     ProductsQueryBuilderFields.PROPERTIES,
 ];


### PR DESCRIPTION
 Pull Request

## 🤨 Rationale

With the recent discussions in the [AC change PR](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullRequest/899260#1739531352): we will be supporting `familyName` look up in the query builders of both the query editor and the variable query of Products DataSource , 

This Pull Request contains changes to the `ProductsQueryEditor` and the `ProductsQueryBuilder` to include the family Name lookup.

## 👩‍💻 Implementation

- Added a new state for `familyNames` in the `ProductsQueryEditor` component and updated the `useEffect` hook to load family names from the datasource.
- Added `familyNames` as a prop and created a new `familyField` using `useMemo` to map family names. 
- Updated the fields array to include `familyField` and removed the static `FAMILY` field from `ProductsQueryBuilderStaticFields`.

## 🧪 Testing

- Updated `ProductsQueryBuilder` tests to include `familyNames` in the test cases and added a new test case for selecting family names.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [  x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).