### PR TITLE
fix(products): Change the variable query output format

### DIFF
--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -27,12 +27,12 @@ const mockVariableQueryProductResponse: QueryProductResponse = {
     {
       id: '1',
       partNumber: '123',
-      family: 'Family 1',
+      name: 'product 1',
     },
     {
       id: '2',
       partNumber: '456',
-      family: 'Family 2',
+      name: 'product 2',
     }
   ],
   continuationToken: '',
@@ -366,7 +366,7 @@ describe('query', () => {
           data: {
             descending: false,
             orderBy: "partNumber",
-            projection: ["PART_NUMBER", "FAMILY"],
+            projection: ["PART_NUMBER", "NAME"],
             returnCount: false,
           }
         })
@@ -388,7 +388,7 @@ describe('query', () => {
             descending: false,
             filter: "partNumber = \"123\"",
             orderBy: "partNumber",
-            projection: ["PART_NUMBER", "FAMILY"],
+            projection: ["PART_NUMBER", "NAME"],
             returnCount: false,
           }
         })

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -170,7 +170,7 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
       [Properties.partNumber, Properties.name],
       filter
     )).products;
-    return metadata ? metadata.map(frame => ({ text: `${frame.name}(${frame.partNumber})`, value: frame.partNumber })) : [];
+    return metadata ? metadata.map(frame => ({ text: `${frame.name} (${frame.partNumber})`, value: frame.partNumber })) : [];
   }
 
   readonly productsComputedDataFields = new Map<string, ExpressionTransformFunction>(

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -164,20 +164,13 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
 
   async metricFindQuery(query: ProductVariableQuery, options: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
     let metadata: ProductResponseProperties[];
-    if (query.queryBy) {
-      const filter = this.templateSrv.replace(query.queryBy, options.scopedVars)
-      metadata = (await this.queryProducts(
-        PropertiesOptions.PART_NUMBER,
-        [Properties.partNumber, Properties.family],
-        filter
-      )).products;
-    } else {
-      metadata = (await this.queryProducts(
-        PropertiesOptions.PART_NUMBER,
-        [Properties.partNumber, Properties.family]
-      )).products;
-    }
-    return metadata ? metadata.map(frame => ({ text: `${frame.partNumber}(${frame.family})`, value: frame.partNumber })) : [];
+    const filter = query.queryBy ? this.templateSrv.replace(query.queryBy, options.scopedVars) : undefined;
+    metadata = (await this.queryProducts(
+      PropertiesOptions.PART_NUMBER,
+      [Properties.partNumber, Properties.name],
+      filter
+    )).products;
+    return metadata ? metadata.map(frame => ({ text: `${frame.name}(${frame.partNumber})`, value: frame.partNumber })) : [];
   }
 
   readonly productsComputedDataFields = new Map<string, ExpressionTransformFunction>(

--- a/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
+++ b/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`query metricFindQuery should replace variables with values 1`] = `
 [
   {
-    "text": "product 1(123)",
+    "text": "product 1 (123)",
     "value": "123",
   },
   {
-    "text": "product 2(456)",
+    "text": "product 2 (456)",
     "value": "456",
   },
 ]
@@ -16,11 +16,11 @@ exports[`query metricFindQuery should replace variables with values 1`] = `
 exports[`query metricFindQuery should return partNumber when queryBy is provided 1`] = `
 [
   {
-    "text": "product 1(123)",
+    "text": "product 1 (123)",
     "value": "123",
   },
   {
-    "text": "product 2(456)",
+    "text": "product 2 (456)",
     "value": "456",
   },
 ]
@@ -29,11 +29,11 @@ exports[`query metricFindQuery should return partNumber when queryBy is provided
 exports[`query metricFindQuery should return partNumber with family Name when queryBy is not provided 1`] = `
 [
   {
-    "text": "product 1(123)",
+    "text": "product 1 (123)",
     "value": "123",
   },
   {
-    "text": "product 2(456)",
+    "text": "product 2 (456)",
     "value": "456",
   },
 ]

--- a/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
+++ b/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`query metricFindQuery should replace variables with values 1`] = `
 [
   {
-    "text": "123(Family 1)",
+    "text": "product 1(123)",
     "value": "123",
   },
   {
-    "text": "456(Family 2)",
+    "text": "product 2(456)",
     "value": "456",
   },
 ]
@@ -16,11 +16,11 @@ exports[`query metricFindQuery should replace variables with values 1`] = `
 exports[`query metricFindQuery should return partNumber when queryBy is provided 1`] = `
 [
   {
-    "text": "123(Family 1)",
+    "text": "product 1(123)",
     "value": "123",
   },
   {
-    "text": "456(Family 2)",
+    "text": "product 2(456)",
     "value": "456",
   },
 ]
@@ -29,11 +29,11 @@ exports[`query metricFindQuery should return partNumber when queryBy is provided
 exports[`query metricFindQuery should return partNumber with family Name when queryBy is not provided 1`] = `
 [
   {
-    "text": "123(Family 1)",
+    "text": "product 1(123)",
     "value": "123",
   },
   {
-    "text": "456(Family 2)",
+    "text": "product 2(456)",
     "value": "456",
   },
 ]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As per the [ AC change discussion](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullRequest/899260#1739530845), the  variable output format needs to be changed from `Part Number(Family)` to `Product Name( Part Number`

This pull request includes changes to the products data source variable output as requested. 

## 👩‍💻 Implementation

- Refactored the `metricFindQuery` method to use `name` instead of `family` and adjusted the return mapping to reflect this change.

## 🧪 Testing

- Updated the test associated with the `metricFindQuery`

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).