### PR TITLE
fix(products): Add workspace id to name conversion in query response

### DIFF
--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -5,6 +5,7 @@ import { Field, LegacyMetricFindQueryOptions } from '@grafana/data';
 import { createFetchError, createFetchResponse, getQueryBuilder, requestMatching, setupDataSource } from 'test/fixtures';
 import { MockProxy } from 'jest-mock-extended';
 import { ProductsQueryBuilderFieldNames } from './constants/ProductsQueryBuilder.constants';
+import { Workspace } from 'core/types';
 
 const mockQueryProductResponse: QueryProductResponse = {
   products: [
@@ -227,6 +228,26 @@ describe('query', () => {
       { name: 'workspace', values: ['Workspace 1'], type: 'string' },
       { name: 'updatedAt', values: ['2021-08-01T00:00:00Z'], type: 'time' },
       { name: 'properties', values: ['{"prop1":"value1"}'], type: 'string' },
+    ]);
+  });
+
+  it('should convert workspaceIds to workspace names for workspace field', async () => {
+    datastore.workspacesCache.set('Workspace 1', { id: 'Workspace 1', name: 'WorkspaceName'} as Workspace);
+
+    const query = buildQuery(
+      {
+        refId: 'A',
+        properties: [
+          PropertiesOptions.WORKSPACE
+        ] as Properties[], orderBy: undefined
+      },
+    );
+
+    const response = await datastore.query(query);
+
+    const fields = response.data[0].fields as Field[];
+    expect(fields).toEqual([
+      { name: 'workspace', values: ['WorkspaceName'], type: 'string' },
     ]);
   });
 

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -7,6 +7,7 @@ import { parseErrorMessage } from 'core/errors';
 import { ExpressionTransformFunction, transformComputedFieldsQuery } from 'core/query-builder.utils';
 import { QueryBuilderOperations } from 'core/query-builder.constants';
 import { ProductsQueryBuilderFieldNames } from './constants/ProductsQueryBuilder.constants';
+import { getWorkspaceName } from 'core/utils';
 
 export class ProductsDataSource extends DataSourceBase<ProductQuery> {
   constructor(
@@ -119,13 +120,21 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
         const values = products
           .map(data => data[field as unknown as keyof ProductResponseProperties]);
 
+        const fieldValues = values.map(value => {
+          switch (field) {
+            case PropertiesOptions.PROPERTIES:
+              return value == null ? '' : JSON.stringify(value);
+            case PropertiesOptions.WORKSPACE:
+              const workspace = this.workspacesCache.get(value);
+              return workspace ? getWorkspaceName([workspace], value) : value;
+            default:
+              return value == null ? '' : value;
+          }
+        });
+
         return {
           name: field,
-          values: values.map(value => value != null
-            ? (field === PropertiesOptions.PROPERTIES
-              ? JSON.stringify(value)
-              : value)
-            : ''),
+          values: fieldValues,
           type: fieldType
         };
       });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
As part of fixing the [Bug 3025909](https://dev.azure.com/ni/DevCentral/_workitems/edit/3025909): Products data source - Workspace name should be displayed and not just the workspace UUID, This PR contains the conversion of the workspace Id to workspace names.

## 👩‍💻 Implementation
- Refactored the conditioning using a switch case 
- Used the `getWorkspaceName` method from the Utils to convert the workspace Id to Workspace name

## 🧪 Testing

- Added Test case to check the workspace name to be displayed 

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).