### PR TITLE
fix(products): Enhance metricFindQuery to support multiple values

### DIFF
--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -348,7 +348,7 @@ describe('query', () => {
         .mockReturnValue(
           createFetchResponse<QueryProductResponse>(mockVariableQueryProductResponse));
       options = {
-        scopedVars: {}
+        scopedVars: { partNumber: { value : '123' } }
       }
     });
 
@@ -396,7 +396,6 @@ describe('query', () => {
     });
 
     it('should replace variables with values', async () => {
-      datastore.templateSrv.replace = jest.fn().mockImplementation((value) => {"partNumber = \"123\""});
       const query: ProductVariableQuery = {
         refId: '',
         queryBy: 'partNumber = "$partNumber"',

--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -429,6 +429,27 @@ describe('query', () => {
 
       expect(results).toEqual([]);
     })
+
+    it('should handle multiple values in queryBy', async () => {
+      const query: ProductVariableQuery = {
+        refId: '',
+        queryBy: `${ProductsQueryBuilderFieldNames.PART_NUMBER} = "{partNumber1,partNumber2}"`,
+      };
+
+      await datastore.metricFindQuery(query, options);
+
+      expect(backendServer.fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            descending: false,
+            filter:"PartNumber = \"partNumber1\" || PartNumber = \"partNumber2\"",
+            orderBy: "partNumber",
+            projection: ["PART_NUMBER", "NAME"],
+            returnCount: false,
+          }
+        })
+      );
+    });
   });
 });
 

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -163,9 +163,14 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
   }
 
   async metricFindQuery(query: ProductVariableQuery, options: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
-    let metadata: ProductResponseProperties[];
-    const filter = query.queryBy ? this.templateSrv.replace(query.queryBy, options.scopedVars) : undefined;
-    metadata = (await this.queryProducts(
+    const filter = query.queryBy
+      ? transformComputedFieldsQuery(
+        this.templateSrv.replace(query.queryBy, options.scopedVars),
+        this.productsComputedDataFields
+      )
+      : undefined;
+
+    const metadata = (await this.queryProducts(
       PropertiesOptions.PART_NUMBER,
       [Properties.partNumber, Properties.name],
       filter


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
As part of [Bug 3025905](https://dev.azure.com/ni/DevCentral/_workitems/edit/3025905): Products data source query builder doesn't support multi value variables, This PR contains the fix to support multiple values in the variable query builder

## 👩‍💻 Implementation

- Added logic to transform the queryBy with multiple values into the expected format

## 🧪 Testing

- Added tests to check if multi value is supported

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).