### PR TITLE
fix(products): Prevent non-numeric input in record count field

### DIFF
--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -61,13 +61,21 @@ describe('ProductsQueryEditor', () => {
         expect.objectContaining({ descending: true })
       )
     });
-    //User changes record count
+  });
+
+  it('only allows numbers in Take field', async () => {
+    // User tries to enter a non-numeric value
     await userEvent.clear(recordCount);
-    await userEvent.type(recordCount, '500A{Enter}'); //Should not enter 'A'
+    await userEvent.type(recordCount, 'abc');
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({ recordCount: 500 })
-      )
+      expect(recordCount).toHaveValue(null);
+    });
+
+    // User enters a valid numeric value
+    await userEvent.clear(recordCount);
+    await userEvent.type(recordCount, '500');
+    await waitFor(() => {
+      expect(recordCount).toHaveValue(500);
     });
   });
 });

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -69,6 +69,11 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
     }
   }
 
+  function checkIfNumber(event: React.KeyboardEvent<HTMLInputElement>) {
+    const regex = new RegExp(/(^-?\d*$)|(Backspace|Tab|Delete|ArrowLeft|ArrowRight)/);
+    return !event.key.match(regex) && event.preventDefault();
+ }
+
   return (
     <>
       <HorizontalGroup align="flex-start">
@@ -127,6 +132,7 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
                 defaultValue={query.recordCount}
                 onCommitChange={recordCountChange}
                 placeholder="Enter record count"
+                onKeyDown={(event) => {checkIfNumber(event)}}
               />
             </InlineField>
           </div>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
On testing the Products Datasource on different browsers, we noticed that the `autoSizeInput` element with Number type used for `Take` field which should allow only Numbers, works properly in `Edge` but allows Alphabets and symbols in `Firefox` and `Chrome` . 

![image](https://github.com/user-attachments/assets/97703f46-a56f-49f5-9d77-3f8cdefdc281)

This PR has the changes to enhance input validation for the Take field in all browsers.

## 👩‍💻 Implementation
-   Added a `checkIfNumber` function to ensure that only numeric values or specific control keys (Backspace, Tab, Delete, ArrowLeft, ArrowRight) are allowed in the record count input field.

- Integrated the `checkIfNumber` function with the `onKeyDown` event of the record count input field to enforce the validation.

## 🧪 Testing
Tested manually in all browsers
Added unit tests to verify the same

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).