### PR TITLE
fix(products): Enclose filter conditions in parentheses for grouping

### DIFF
--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -350,7 +350,7 @@ describe('query', () => {
         expect.objectContaining({
           data: {
             descending: false,
-            filter: "PartNumber = \"partNumber1\" || PartNumber = \"partNumber2\"",
+            filter: "(PartNumber = \"partNumber1\" || PartNumber = \"partNumber2\")",
             orderBy: undefined,
             projection: ["partNumber"],
             returnCount: false, take: 1000
@@ -462,7 +462,7 @@ describe('query', () => {
         expect.objectContaining({
           data: {
             descending: false,
-            filter:"PartNumber = \"partNumber1\" || PartNumber = \"partNumber2\"",
+            filter:"(PartNumber = \"partNumber1\" || PartNumber = \"partNumber2\")",
             orderBy: "partNumber",
             projection: ["PART_NUMBER", "NAME"],
             returnCount: false,

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -201,9 +201,9 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
       const valuesArray = this.getMultipleValuesArray(value);
       const logicalOperator = this.getLogicalOperator(operation);
 
-      return isMultiSelect ? valuesArray
+      return isMultiSelect ? `(${valuesArray
         .map(val => `${field} ${operation} "${val}"`)
-        .join(` ${logicalOperator} `) : `${field} ${operation} "${value}"`;
+        .join(` ${logicalOperator} `)})` : `${field} ${operation} "${value}"`;
     }
   }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
In order to solve : [Bug 3034280](https://dev.azure.com/ni/DevCentral/_workitems/edit/3034280): Grafana Product data source | Filters are not grouped together if a variable with multi value is used in the query builder, 

We need to enclose the filter within parenthesis for grouping of queries

## 👩‍💻 Implementation

- Added additional parentheses to MultiValueQuery forming logic

## 🧪 Testing

- Updated the existing test cases

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [  x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).