### PR TITLE
fix(results): Prevent non-numeric input in record count(Take) field

### DIFF
--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
@@ -33,7 +33,7 @@ describe('QueryResultsEditor', () => {
     descending = screen.getAllByRole('checkbox')[0];
     dataOutput = screen.getByRole('radio', { name: 'Data' });
     totalCountOutput = screen.getByRole('radio', { name: 'Total Count' });
-    recordCount = screen.getByRole('textbox');
+    recordCount = screen.getByDisplayValue(1000);
   });
 
   describe('Data outputType', () => {
@@ -55,7 +55,7 @@ describe('QueryResultsEditor', () => {
       expect(descending).toBeInTheDocument();
       expect(descending).not.toBeChecked();
       expect(recordCount).toBeInTheDocument();
-      expect(recordCount).toHaveValue('1000');
+      expect(recordCount).toHaveValue(1000);
       expect(useTimeRange).toBeInTheDocument();
       expect(useTimeRange).toBeChecked();
       expect(useTimeRangeFor).toBeInTheDocument();
@@ -81,11 +81,18 @@ describe('QueryResultsEditor', () => {
         expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ descending: true }));
       });
 
-      //User changes record count
+      //User enters numeric value for record count
       await userEvent.clear(recordCount);
-      await userEvent.type(recordCount, '500{Enter}');
+      await userEvent.type(recordCount, '500');
       await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: 500 }));
+        expect(recordCount).toHaveValue(500);
+      });
+
+      //User enters non-numeric value for record count
+      await userEvent.clear(recordCount);
+      await userEvent.type(recordCount, 'Test');
+      await waitFor(() => {
+        expect(recordCount).toHaveValue(null);
       });
 
       //User changes useTimeRange checkbox

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -8,7 +8,7 @@ import {
   Select,
   VerticalGroup,
 } from '@grafana/ui';
-import { enumToOptions } from 'core/utils';
+import { enumToOptions, validateNumericInput } from 'core/utils';
 import { OrderBy, OutputType, ResultsProperties, ResultsQuery, UseTimeRangeFor } from 'datasources/results/types';
 import React from 'react';
 import './QueryResultsEditor.scss';
@@ -90,9 +90,11 @@ export function QueryResultsEditor({ query, handleQueryChange }: Props) {
                 <AutoSizeInput
                   minWidth={20}
                   maxWidth={40}
+                  type="number"
                   defaultValue={query.recordCount}
                   onCommitChange={recordCountChange}
                   placeholder="Enter record count"
+                  onKeyDown={(event) => {validateNumericInput(event)}}
                 />
               </InlineField>
               <UseTimeRangeControls

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -9,7 +9,6 @@ import {
   VerticalGroup,
 } from '@grafana/ui';
 import { enumToOptions, validateNumericInput } from 'core/utils';
-import { OrderBy, OutputType, ResultsProperties, ResultsQuery, UseTimeRangeFor } from 'datasources/results/types';
 import React from 'react';
 import './QueryResultsEditor.scss';
 import { OrderBy, QueryResults, ResultsProperties } from 'datasources/results/types/QueryResults.types';

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -39,7 +39,7 @@ export function QueryResultsEditor({ query, handleQueryChange }: Props) {
 
   const recordCountChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = parseInt((event.target as HTMLInputElement).value, 10);
-    handleQueryChange({ ...query, recordCount: isNaN(value) ? undefined : value });
+    handleQueryChange({ ...query, recordCount: value });
   };
 
   return (


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
Feature : [Feature 2605755 ](https://dev.azure.com/ni/DevCentral/_workitems/edit/2605755): Grafana support for results datasource

As part of [Add Results Query editors to the Results Datasource](https://dev.azure.com/ni/DevCentral/_workitems/edit/2980051) user story, this PR has the changes to enhance input validation for the Take field in all browsers.[`AutoSizeInput`](vscode-file://vscode-app/c:/Users/aradhakr/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) element with the `number` type, used for the "Take" field (which should only accept numeric input), behaves as expected in Edge but allows alphabets and symbols in Firefox and Chrome. 


## 👩‍💻 Implementation

- Added `validateNumericInput` function from `Utils` to handle numeric input validation in the `AutoSizeInput` component.

## 🧪 Testing

- Added unit test 
- Manually verified

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).