### PR TITLE
fix(core): Update numeric input validation method to support negative values

### DIFF
--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -62,6 +62,14 @@ describe('validateNumericInput', () => {
 
       expect(mockPreventDefault).not.toHaveBeenCalled();
     });
+
+    test('allows negative sign', () => {
+        const event = { key: '-', preventDefault: mockPreventDefault } as unknown as React.KeyboardEvent<HTMLInputElement>;
+        
+        validateNumericInput(event);
+  
+        expect(mockPreventDefault).not.toHaveBeenCalled();
+    });
   
     test('allows navigation keys', () => {
         const event = { key: 'Tab', preventDefault: mockPreventDefault } as unknown as React.KeyboardEvent<HTMLInputElement>;

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -112,7 +112,7 @@ export function filterXSSLINQExpression(value: string | null | undefined): strin
 }
 
 export function validateNumericInput(event: React.KeyboardEvent<HTMLInputElement>) {
-  if (isNaN(Number(event.key)) && !['Backspace', 'Tab', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
+  if (isNaN(Number(event.key)) && !['Backspace', 'Tab', 'Delete', 'ArrowLeft', 'ArrowRight', '-'].includes(event.key)) {
     event.preventDefault();
   }
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
As a part of this [User Story 2980051](https://ni.visualstudio.com/DevCentral/_workitems/edit/2980051): Add Results Query editors to the Results Datasource

This PR updates  `validateNumericInput` method to allow the `-` input, enabling for negative values.

## 👩‍💻 Implementation
- Modified the `validateNumericInput` method in the `utils.ts` file to include the `-` sign as a valid input.

## 🧪 Testing

- Added unit test. 

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).