### PR TITLE
feat(results): Add rate limiting to query steps

### DIFF
--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -1,6 +1,7 @@
 import { DataSourceBase } from "core/DataSourceBase";
 import { DataQueryRequest, DataFrameDTO, TestDataSourceResponse } from "@grafana/data";
 import { ResultsQuery } from "./types/types";
+import { BatchFetchConfig, BatchQueryResponse } from "./types/QuerySteps.types";
 
 export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery> {
   baseUrl = this.instanceSettings.url + '/nitestmonitor';
@@ -26,6 +27,62 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
     const timeRangeFilter = `(${timeRangeField} > "${this.fromDateString}" && ${timeRangeField} < "${this.toDateString}")`;
 
     return this.templateSrv.replace(timeRangeFilter, options.scopedVars);
+  }
+
+  async fetchInBatches<T>(
+    fetchRecord: (take: number, continuationToken?: string) => Promise<BatchQueryResponse<T>>,
+    config: BatchFetchConfig,
+    take?: number,
+  ): Promise<BatchQueryResponse<T>> {
+    let responseItems: T[] = [];
+    let continuationToken: string | undefined = undefined;
+
+    if (take === undefined || take <= config.maxTakePerRequest) {
+      return await fetchRecord(take || config.maxTakePerRequest, continuationToken);
+    }
+
+    const requestCount = Math.ceil(take / config.maxTakePerRequest);
+    const batchCount = Math.ceil(requestCount / config.requestsPerSecond);
+
+    for (let batch = 0; batch < batchCount; batch++) {
+      const requestsThisBatch = Math.min(
+        config.requestsPerSecond, 
+        Math.ceil((take - responseItems.length) / config.maxTakePerRequest)
+      );
+
+      for (let request = 0; request < requestsThisBatch; request++) {
+        if (responseItems.length >= take) {
+          break;
+        }
+
+        const currentTake = Math.min(config.maxTakePerRequest, take - responseItems.length);
+
+        const response: BatchQueryResponse<T> = await fetchRecord(currentTake, continuationToken);
+
+        responseItems = [...responseItems, ...response.items];
+        continuationToken = response.continuationToken;
+
+        if (!continuationToken) {
+          return {
+            items: responseItems,
+            totalCount: responseItems.length,
+          };
+        }
+      }
+
+      if (batch < batchCount - 1) {
+        await this.delay(1000);
+      }
+    }
+
+    return {
+      items: responseItems,
+      totalCount: responseItems.length,
+    };
+  }
+
+  private async delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   testDatasource(): Promise<TestDataSourceResponse> {

--- a/src/datasources/results/constants/QuerySteps.constants.ts
+++ b/src/datasources/results/constants/QuerySteps.constants.ts
@@ -1,0 +1,2 @@
+export const QUERY_STEPS_REQUEST_PER_SECOND = 6;
+export const MAX_TAKE_PER_REQUEST = 500;

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -221,6 +221,127 @@ describe('QueryStepsDataSource', () => {
     });
   });
 
+  describe('fetch Steps with rate limiting', () => {
+    it('should make a single request when take is less than MAX_TAKE_PER_REQUEST', async () => {
+      const mockResponses = [
+        createFetchResponse({
+          steps: Array(100).fill({ stepId: '1', name: 'Step 1' }),
+          continuationToken: null,
+          totalCount: 100,
+      })]
+
+      backendServer.fetch
+        .mockImplementationOnce(() => mockResponses[0])
+
+
+        const responsePromise = datastore.fetchStepsInBatch(
+          undefined,
+          undefined,
+          undefined,
+          100,
+          undefined,
+          true
+        );
+
+        const response = await responsePromise;
+
+      expect(response.steps).toHaveLength(100);
+      expect(backendServer.fetch).toHaveBeenCalledTimes(1);
+      expect(backendServer.fetch).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          data: expect.objectContaining({ take: 100, continuationToken: undefined }),
+        })
+      );
+    });
+
+    test('should batch requests with a maximum of 6 requests per second', async () => {
+      const mockResponses = [
+        createFetchResponse({
+          steps: Array(500).fill({ stepId: '1', name: 'Step 1' }),
+          continuationToken: 'token1',
+          totalCount: 1500,
+        }),
+        createFetchResponse({
+          steps: Array(500).fill({ stepId: '2', name: 'Step 2' }),
+          continuationToken: 'token2',
+          totalCount: 1500,
+        }),
+        createFetchResponse({
+          steps: Array(500).fill({ stepId: '3', name: 'Step 3' }),
+          continuationToken: null,
+          totalCount: 1500,
+        }),
+      ];
+
+      backendServer.fetch
+        .mockImplementationOnce(() => mockResponses[0])
+        .mockImplementationOnce(() => mockResponses[1])
+        .mockImplementationOnce(() => mockResponses[2]);
+
+      const responsePromise = datastore.fetchStepsInBatch(
+        undefined,
+        undefined,
+        undefined,
+        1500,
+        undefined,
+        true
+      );
+
+      const response = await responsePromise;
+
+      expect(response.steps).toHaveLength(1500);
+      expect(backendServer.fetch).toHaveBeenCalledTimes(3);
+      expect(backendServer.fetch).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          data: expect.objectContaining({ take: 500, continuationToken: undefined }),
+        })
+      );
+      expect(backendServer.fetch).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          data: expect.objectContaining({ take: 500, continuationToken: 'token1' }),
+        })
+      );
+      expect(backendServer.fetch).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          data: expect.objectContaining({ take: 500, continuationToken: 'token2' }),
+        })
+      );
+    });
+
+    test('should stop fetching when continuationToken is null', async () => {
+      const mockResponses = [
+        createFetchResponse({
+          steps: Array(500).fill({ stepId: '1', name: 'Step 1' }),
+          continuationToken: null,
+          totalCount: 500,
+        }),
+      ];
+
+      backendServer.fetch.mockImplementationOnce(() => mockResponses[0]);
+
+      const response = await datastore.fetchStepsInBatch(
+        undefined,
+        undefined,
+        undefined,
+        3000,
+        undefined,
+        true
+      );
+
+      expect(response.steps).toHaveLength(500);
+      expect(backendServer.fetch).toHaveBeenCalledTimes(1);
+      expect(backendServer.fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ take: 500, continuationToken: undefined }),
+        })
+      );
+    });
+  });
+
   const buildQuery = getQueryBuilder<QuerySteps>()({
     refId: 'A',
     queryType: QueryType.Steps,

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -1,6 +1,7 @@
 import { DataQueryRequest, DataFrameDTO, FieldType } from '@grafana/data';
 import { OutputType } from 'datasources/results/types/types';
 import {
+  BatchQueryResponse,
   QuerySteps,
   QueryStepsResponse,
   StepsProperties,
@@ -9,6 +10,7 @@ import {
 } from 'datasources/results/types/QuerySteps.types';
 import { ResultsDataSourceBase } from 'datasources/results/ResultsDataSourceBase';
 import { defaultStepsQuery } from 'datasources/results/defaultQueries';
+import { MAX_TAKE_PER_REQUEST, QUERY_STEPS_REQUEST_PER_SECOND } from 'datasources/results/constants/QuerySteps.constants';
 
 export class QueryStepsDataSource extends ResultsDataSourceBase {
   queryStepsUrl = this.baseUrl + '/v2/query-steps';
@@ -21,6 +23,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
     projection?: StepsProperties[],
     take?: number,
     descending?: boolean,
+    continuationToken?: string,
     returnCount = false
   ): Promise<QueryStepsResponse> {
     try {
@@ -30,6 +33,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
         descending,
         projection,
         take,
+        continuationToken,
         returnCount,
       });
     } catch (error) {
@@ -37,12 +41,52 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
     }
   }
 
+  async fetchStepsInBatch(
+    filter?: string,
+    orderBy?: string,
+    projection?: StepsProperties[],
+    take?: number,
+    descending?: boolean,
+    returnCount = false
+  ): Promise<QueryStepsResponse> {
+    const fetchRecord = async (currentTake: number, token?: string): Promise<BatchQueryResponse<StepsResponseProperties>> => {
+      const response = await this.querySteps(
+        filter,
+        orderBy,
+        projection,
+        currentTake,
+        descending,
+        token,
+        returnCount
+      );
+
+      return {
+        items: response.steps,
+        continuationToken: response.continuationToken,
+        totalCount: response.totalCount
+      };
+    };
+
+    const config = {
+      maxTakePerRequest: MAX_TAKE_PER_REQUEST,
+      requestsPerSecond: QUERY_STEPS_REQUEST_PER_SECOND
+    };
+
+    const result = await this.fetchInBatches(fetchRecord, config, take);
+
+    return {
+      steps: result.items,
+      continuationToken: result.continuationToken,
+      totalCount: result.totalCount
+    };
+  }
+
   async runQuery(query: QuerySteps, options: DataQueryRequest): Promise<DataFrameDTO> {
     const projection = query.showMeasurements
       ? [...new Set([...(query.properties || []), StepsPropertiesOptions.DATA])]
       : query.properties;
 
-    const responseData = await this.querySteps(
+    const responseData = await this.fetchStepsInBatch(
       this.getTimeRangeFilter(options, query.useTimeRange, query.useTimeRangeFor),
       query.orderBy,
       projection as StepsProperties[],

--- a/src/datasources/results/types/QuerySteps.types.ts
+++ b/src/datasources/results/types/QuerySteps.types.ts
@@ -136,3 +136,14 @@ export interface QueryStepsResponse {
   continuationToken?: string;
   totalCount?: number;
 };
+
+export interface BatchQueryResponse<T> {
+  items: T[];
+  continuationToken?: string;
+  totalCount?: number;
+};
+
+export interface BatchFetchConfig {
+  maxTakePerRequest: number;
+  requestsPerSecond: number;
+};


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
As a part of this [User Story 2980051](https://ni.visualstudio.com/DevCentral/_workitems/edit/2980051): Add Results Query editors to the Results Datasource,

This PR introduces rate-limiting logic to efficiently batch query steps, to handle large data request.

## 👩‍💻 Implementation
- Created a constant file to store the `MAX_TAKE_PER_REQUEST` and `QUERY_STEPS_REQUEST_PER_SECOND` values.
- Created a rate-limiting method `fetchInBatches` to batch the requests. It is placed in `ResultsDataSourceBase` so that if future data sources require rate limiting, it can be easily moved to a shared folder and reused without requiring major changes to the `QueryStepsDataSource`.

## 🧪 Testing

- Added unit test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).