### PR TITLE
feat(results): Add steps query editor component

### DIFF
--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -4,6 +4,8 @@ import { ResultsDataSource } from '../ResultsDataSource';
 import { ResultsQuery } from '../types/types';
 import { QueryResultsEditor } from './editors/query-results/QueryResultsEditor';
 import { QueryResults } from '../types/QueryResults.types';
+import { QueryStepsEditor } from './editors/query-steps/QueryStepsEditor';
+import { QuerySteps } from '../types/QuerySteps.types';
 
 type Props = QueryEditorProps<ResultsDataSource, ResultsQuery>;
 
@@ -20,9 +22,15 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
   );
 
   return (
+    <>
     <QueryResultsEditor
       query={query as QueryResults} 
       handleQueryChange={handleQueryChange}
     />
+    <QueryStepsEditor
+      query={query as QuerySteps} 
+      handleQueryChange={handleQueryChange}
+    />
+    </>
   );
 }

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -4,8 +4,6 @@ import { ResultsDataSource } from '../ResultsDataSource';
 import { ResultsQuery } from '../types/types';
 import { QueryResultsEditor } from './editors/query-results/QueryResultsEditor';
 import { QueryResults } from '../types/QueryResults.types';
-import { QueryStepsEditor } from './editors/query-steps/QueryStepsEditor';
-import { QuerySteps } from '../types/QuerySteps.types';
 
 type Props = QueryEditorProps<ResultsDataSource, ResultsQuery>;
 
@@ -22,15 +20,9 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
   );
 
   return (
-    <>
     <QueryResultsEditor
       query={query as QueryResults} 
       handleQueryChange={handleQueryChange}
     />
-    <QueryStepsEditor
-      query={query as QuerySteps} 
-      handleQueryChange={handleQueryChange}
-    />
-    </>
   );
 }

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
@@ -1,0 +1,137 @@
+import { setupRenderer } from 'test/fixtures';
+import { ResultsDataSource } from '../../../ResultsDataSource';
+import { screen, waitFor } from '@testing-library/react';
+import { QueryType } from '../../../types/types';
+import { select } from 'react-select-event';
+import userEvent from '@testing-library/user-event';
+import { ResultsQueryEditor } from '../../ResultsQueryEditor';
+import { QuerySteps } from 'datasources/results/types/QuerySteps.types';
+
+const render = setupRenderer(ResultsQueryEditor, ResultsDataSource);
+
+let onChange: jest.Mock<any, any>;
+let properties: HTMLElement;
+let orderBy: HTMLElement;
+let descending: HTMLElement;
+let recordCount: HTMLElement;
+let dataOutput: HTMLElement;
+let totalCountOutput: HTMLElement;
+
+describe('QueryStepsEditor', () => {
+  beforeEach(() => {
+    [onChange] = render({
+      refId: '',
+      queryType: QueryType.Steps,
+      outputType: 'Data',
+      properties: [],
+      orderBy: undefined,
+      descending: false,
+      recordCount: 1000,
+      showMeasurements: false,
+      useTimeRange: true,
+      useTimeRangeFor: undefined,
+    } as QuerySteps);
+    properties = screen.getAllByRole('combobox')[0];
+    orderBy = screen.getAllByRole('combobox')[1];
+    descending = screen.getAllByRole('checkbox')[0];
+    dataOutput = screen.getByRole('radio', { name: 'Data' });
+    totalCountOutput = screen.getByRole('radio', { name: 'Total Count' });
+    recordCount = screen.getByDisplayValue(1000);
+  });
+
+  describe('Data outputType', () => {
+    let useTimeRange: HTMLElement;
+    let useTimeRangeFor: HTMLElement;
+
+    beforeEach(() => {
+      useTimeRange = screen.getAllByRole('checkbox')[1];
+      useTimeRangeFor = screen.getAllByRole('combobox')[2];
+    });
+
+    test('renders with default query', async () => {
+      expect(properties).toBeInTheDocument();
+      expect(properties).toHaveDisplayValue('');
+      expect(dataOutput).toBeInTheDocument();
+      expect(dataOutput).toBeChecked();
+      expect(orderBy).toBeInTheDocument();
+      expect(orderBy).toHaveAccessibleDescription('Select field to order by');
+      expect(descending).toBeInTheDocument();
+      expect(descending).not.toBeChecked();
+      expect(recordCount).toBeInTheDocument();
+      expect(recordCount).toHaveValue(1000);
+      expect(useTimeRange).toBeInTheDocument();
+      expect(useTimeRange).toBeChecked();
+      expect(useTimeRangeFor).toBeInTheDocument();
+      expect(useTimeRangeFor).toHaveAccessibleDescription('Choose');
+    });
+
+    test('updates when user makes changes', async () => {
+      //User adds a properties
+      await select(properties, 'properties', { container: document.body });
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ properties: ['properties'] }));
+      });
+
+      //User changes order by
+      await select(orderBy, 'Started At', { container: document.body });
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ orderBy: 'STARTED_AT' }));
+      });
+
+      //User changes descending checkbox
+      await userEvent.click(descending);
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ descending: true }));
+      });
+
+      //User enters numeric value for record count
+      await userEvent.clear(recordCount);
+      await userEvent.type(recordCount, '500');
+      await waitFor(() => {
+        expect(recordCount).toHaveValue(500);
+      });
+
+      //User enters non-numeric value for record count
+      await userEvent.clear(recordCount);
+      await userEvent.type(recordCount, 'Test');
+      await waitFor(() => {
+        expect(recordCount).toHaveValue(null);
+      });
+
+      //User changes useTimeRange checkbox
+      await userEvent.click(useTimeRange);
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ useTimeRange: false }));
+      });
+
+      //User changes useTimeRangeFor
+      await userEvent.click(useTimeRange); //To enable useTimeRangeFor
+      await select(useTimeRangeFor, 'Updated', { container: document.body });
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ useTimeRangeFor: 'Updated' }));
+      });
+
+      //User changes output type to Total Count
+      await userEvent.click(totalCountOutput);
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ outputType: 'Total Count' }));
+      });
+    });
+  });
+
+  describe('Total Count outputType', () => {
+    test('renders correctly when outputType is Total Count', async () => {
+      await userEvent.click(totalCountOutput);
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ outputType: 'Total Count' }));
+      });
+      expect(properties).not.toBeInTheDocument();
+      expect(orderBy).not.toBeInTheDocument();
+      expect(descending).not.toBeInTheDocument();
+      expect(recordCount).not.toBeInTheDocument();
+      expect(screen.getAllByRole('checkbox')[0]).toBeInTheDocument(); //useTimeRange
+      expect(screen.getAllByRole('combobox')[0]).toBeInTheDocument(); //useTimeRangeFor
+    });
+  });
+});

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -1,0 +1,122 @@
+import { SelectableValue } from '@grafana/data';
+import {
+  AutoSizeInput,
+  InlineField,
+  InlineSwitch,
+  MultiSelect,
+  RadioButtonGroup,
+  Select,
+  VerticalGroup,
+} from '@grafana/ui';
+import { enumToOptions, validateNumericInput } from 'core/utils';
+import React from 'react';
+import '../../ResultsQueryEditor.scss';
+import { OutputType } from 'datasources/results/types/types';
+import { TimeRangeControls } from '../time-range/TimeRangeControls';
+import { OrderBy, QuerySteps, StepsProperties } from 'datasources/results/types/QuerySteps.types';
+
+type Props = {
+  query: QuerySteps;
+  handleQueryChange: (query: QuerySteps, runQuery?: boolean) => void;
+};
+
+export function QueryStepsEditor({ query, handleQueryChange }: Props) {
+  const onOutputChange = (value: OutputType) => {
+    handleQueryChange({ ...query, outputType: value });
+  };
+
+  const onPropertiesChange = (items: Array<SelectableValue<string>>) => {
+    if (items !== undefined) {
+      handleQueryChange({ ...query, properties: items.map(i => i.value as StepsProperties) });
+    }
+  };
+
+  const onOrderByChange = (item: SelectableValue<string>) => {
+    handleQueryChange({ ...query, orderBy: item.value });
+  };
+
+  const onDescendingChange = (isDescendingChecked: boolean) => {
+    handleQueryChange({ ...query, descending: isDescendingChecked });
+  };
+
+  const recordCountChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = parseInt((event.target as HTMLInputElement).value, 10);
+    handleQueryChange({ ...query, recordCount: value });
+  };
+
+  return (
+    <>
+      <VerticalGroup>
+        <InlineField label="Output" labelWidth={25}>
+          <RadioButtonGroup
+            options={Object.values(OutputType).map(value => ({ label: value, value })) as SelectableValue[]}
+            value={query.outputType}
+            onChange={onOutputChange}
+          />
+        </InlineField>
+        {query.outputType === OutputType.Data && (
+          <VerticalGroup>
+            <InlineField label="Properties" labelWidth={25}>
+              <MultiSelect
+                placeholder="Select properties to fetch"
+                options={enumToOptions(StepsProperties)}
+                onChange={onPropertiesChange}
+                value={query.properties}
+                defaultValue={query.properties!}
+                noMultiValueWrap={true}
+                maxVisibleValues={5}
+                width={60}
+                allowCustomValue={false}
+                closeMenuOnSelect={false}
+              />
+            </InlineField>
+            <div>
+              <div className="horizontal-control-group">
+                <InlineField label="OrderBy" labelWidth={25}>
+                  <Select
+                    options={OrderBy as SelectableValue[]}
+                    placeholder="Select field to order by"
+                    onChange={onOrderByChange}
+                    value={query.orderBy}
+                    defaultValue={query.orderBy}
+                  />
+                </InlineField>
+                <InlineField label="Descending">
+                  <InlineSwitch
+                    onChange={event => onDescendingChange(event.currentTarget.checked)}
+                    value={query.descending}
+                  />
+                </InlineField>
+              </div>
+              <InlineField label="Take" labelWidth={25}>
+                <AutoSizeInput
+                  minWidth={20}
+                  maxWidth={40}
+                  type="number"
+                  defaultValue={query.recordCount}
+                  onCommitChange={recordCountChange}
+                  placeholder="Enter record count"
+                  onKeyDown={(event) => {validateNumericInput(event)}}
+                />
+              </InlineField>
+              <TimeRangeControls
+                query={query}
+                handleQueryChange={(updatedQuery, runQuery) => {
+                  handleQueryChange(updatedQuery as QuerySteps, runQuery);
+                }}
+              />
+            </div>
+          </VerticalGroup>
+        )}
+        {query.outputType === OutputType.TotalCount && (
+          <TimeRangeControls
+            query={query}
+            handleQueryChange={(updatedQuery, runQuery) => {
+              handleQueryChange(updatedQuery as QuerySteps, runQuery);
+            }}
+          />
+        )}
+      </VerticalGroup>
+    </>
+  );
+}

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -96,7 +96,9 @@ export function QueryStepsEditor({ query, handleQueryChange }: Props) {
                   defaultValue={query.recordCount}
                   onCommitChange={recordCountChange}
                   placeholder="Enter record count"
-                  onKeyDown={(event) => {validateNumericInput(event)}}
+                  onKeyDown={event => {
+                    validateNumericInput(event);
+                  }}
                 />
               </InlineField>
               <TimeRangeControls

--- a/src/datasources/results/components/editors/time-range/TimeRangeControls.tsx
+++ b/src/datasources/results/components/editors/time-range/TimeRangeControls.tsx
@@ -2,12 +2,13 @@ import { SelectableValue } from '@grafana/data';
 import { InlineField, InlineSwitch, Select } from '@grafana/ui';
 import { enumToOptions } from 'core/utils';
 import { QueryResults } from 'datasources/results/types/QueryResults.types';
+import { QuerySteps } from 'datasources/results/types/QuerySteps.types';
 import { UseTimeRangeFor } from 'datasources/results/types/types';
 import React from 'react';
 
 type Props = {
-  query: QueryResults;
-  handleQueryChange: (query: QueryResults, runQuery?: boolean) => void;
+  query: QueryResults | QuerySteps;
+  handleQueryChange: (query: QueryResults | QuerySteps, runQuery?: boolean) => void;
 };
 
 export function TimeRangeControls({query, handleQueryChange}: Props) {

--- a/src/datasources/results/types/QuerySteps.types.ts
+++ b/src/datasources/results/types/QuerySteps.types.ts
@@ -1,0 +1,97 @@
+import { OutputType, ResultsQuery } from "./types";
+
+export interface QuerySteps extends ResultsQuery {
+  outputType: OutputType;
+  properties?: StepsProperties[];
+  orderBy?: string;
+  descending?: boolean;
+  useTimeRange?: boolean;
+  useTimeRangeFor?: string;
+  recordCount?: number;
+};
+
+export const OrderBy = [
+  {
+    value: 'NAME',
+    label: 'Step Name',
+    description: 'Name of the step',
+  },
+  {
+    value: 'STEP_TYPE',
+    label: 'Step Type',
+    description: 'Type of the step',
+  },
+  {
+    value: 'STEP_ID',
+    label: 'Step ID',
+    description: 'ID of the step',
+  },
+  {
+    value: 'PARENT_ID',
+    label: 'Parent ID',
+    description: 'ID of the parent step',
+  },
+  {
+    value: 'RESULT_ID',
+    label: 'Result ID',
+    description: 'ID of the associated result',
+  },
+  {
+    value: 'TOTAL_TIME_IN_SECONDS',
+    label: 'Total Time in seconds',
+    description: 'Total time taken to run the step in seconds',
+  },
+  {
+    value: 'STARTED_AT',
+    label: 'Started At',
+    description: 'Timestamp when the step started',
+  },
+  {
+    value: 'UPDATED_AT',
+    label: 'Updated At',
+    description: 'Timestamp when the step was last updated',
+  },
+  {
+    value: 'DATA_MODEL',
+    label: 'Data Model',
+    description: 'Data model of the step',
+  }
+];
+
+export const StepsPropertiesOptions = {
+  STEP_ID: 'stepId',
+  NAME: 'name',
+  STEP_TYPE: 'stepType',
+  PARENT_ID: 'parentId',
+  RESULT_ID: 'resultId',
+  STATUS: 'status',
+  TOTAL_TIME_IN_SECONDS: 'totalTimeInSeconds',
+  STARTED_AT: 'startedAt',
+  UPDATED_AT: 'updatedAt',
+  INPUTS: 'inputs',
+  OUTPUTS: 'outputs',
+  DATA_MODEL: 'dataModel',
+  DATA: 'data',
+  WORKSPACE: 'workspace',
+  KEYWORDS: 'keywords',
+  PROPERTIES: 'properties',
+};
+
+export enum StepsProperties {
+  name = 'name',
+  stepType = 'stepType',
+  stepId = 'stepId',
+  parentId = 'parentId',
+  resultId = 'resultId',
+  status = 'status',
+  totalTimeInSeconds = 'totalTimeInSeconds',
+  startedAt = 'startedAt',
+  updatedAt = 'updatedAt',
+  inputs = 'inputs',
+  outputs = 'outputs',
+  dataModel = 'dataModel',
+  data = 'data',
+  workspace = 'workspace',
+  keywords = 'keywords',
+  properties = 'properties',
+};

--- a/src/datasources/results/types/QuerySteps.types.ts
+++ b/src/datasources/results/types/QuerySteps.types.ts
@@ -1,4 +1,4 @@
-import { OutputType, ResultsQuery } from "./types";
+import { OutputType, ResultsQuery } from './types';
 
 export interface QuerySteps extends ResultsQuery {
   outputType: OutputType;
@@ -8,7 +8,7 @@ export interface QuerySteps extends ResultsQuery {
   useTimeRange?: boolean;
   useTimeRangeFor?: string;
   recordCount?: number;
-};
+}
 
 export const OrderBy = [
   {
@@ -55,7 +55,7 @@ export const OrderBy = [
     value: 'DATA_MODEL',
     label: 'Data Model',
     description: 'Data model of the step',
-  }
+  },
 ];
 
 export const StepsPropertiesOptions = {
@@ -94,4 +94,4 @@ export enum StepsProperties {
   workspace = 'workspace',
   keywords = 'keywords',
   properties = 'properties',
-};
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As a part of this 
[User Story 2980051](https://ni.visualstudio.com/DevCentral/_workitems/edit/2980051): Add Results Query editors to the Results Datasource,

This PR introduces changes to add controls for the steps query editor. 

Note: 
- The component does not make any API calls, as it is not yet linked to the data source.
- This PR focuses solely on adding the controls and updating the input query object based on user interactions. No external functionality or API integration is included at this stage.

The following will be addressed in subsequent PRs:
- Implementing the functionality for these controls.
- Adding the "Show Measurements" feature and its functionality.
- Linking the query steps editor with the data source.

## 👩‍💻 Implementation
- Defined types and interfaces for step queries and responses in `QuerySteps.types.ts`.
- Implemented the `QueryStepsEditor` component, which includes controls.
- The Props for QueryStepsEditor is defined with `query` as an input to populate the controls and `handleQueryChange` method is used to update the query object whenever a user interacts with the controls.
- Added the `QuerySteps` type to the `TimeRangeControls` input query to support step queries.
- Ensured the controls in `QueryStepsEditor` update the input query object. 

## 🧪 Testing

- Added Unit Test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).