### PR TITLE
feat(results): Add Constants for Results Query Builder

### DIFF
--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -18,7 +18,7 @@ export enum ResultsQueryBuilderFieldNames {
 
 export const ResultsQueryBuilderFields: Record<string, QBField> = {
   PARTNUMBER: {
-    label: 'Part Number',
+    label: 'Part number',
     dataField: ResultsQueryBuilderFieldNames.PART_NUMBER,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
@@ -35,7 +35,7 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
     },
   },
   PROGRAMNAME: {
-    label: 'Program Name',
+    label: 'Test Program',
     dataField: ResultsQueryBuilderFieldNames.PROGRAM_NAME,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
@@ -47,7 +47,7 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
     ],
   },
   SERIALNUMBER: {
-    label: 'Serial Number',
+    label: 'Serial number',
     dataField: ResultsQueryBuilderFieldNames.SERIAL_NUMBER,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
@@ -59,7 +59,7 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
     ],
   },
   KEYWORDS: {
-    label: 'Keywords',
+    label: 'Keyword',
     dataField: ResultsQueryBuilderFieldNames.KEYWORDS,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
@@ -98,7 +98,7 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
     ],
   },
   STARTEDAT: {
-    label: 'Started At',
+    label: 'Started',
     dataField: ResultsQueryBuilderFieldNames.STARTED_AT,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
@@ -113,7 +113,7 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
     },
   },
   UPDATEDAT: {
-    label: 'Updated At',
+    label: 'Updated',
     dataField: ResultsQueryBuilderFieldNames.UPDATED_AT,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
@@ -159,7 +159,7 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
     },
   },
   HOSTNAME: {
-    label: 'Host Name',
+    label: 'Host name',
     dataField: ResultsQueryBuilderFieldNames.HOSTNAME,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,

--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -1,0 +1,174 @@
+import { QueryBuilderOperations } from 'core/query-builder.constants';
+import { QBField } from '../types/QueryResults.types';
+
+export enum ResultsQueryBuilderFieldNames {
+  PART_NUMBER = 'PartNumber',
+  PROGRAM_NAME = 'ProgramName',
+  SERIAL_NUMBER = 'SerialNumber',
+  KEYWORDS = 'Keywords',
+  PROPERTIES = 'Properties',
+  OPERATOR = 'Operator',
+  STARTED_AT = 'StartedAt',
+  UPDATED_AT = 'UpdatedAt',
+  SYSTEM_ID = 'SystemId',
+  WORKSPACE = 'Workspace',
+  STATUS = 'Status',
+  HOSTNAME = 'HostName',
+}
+
+export const ResultsQueryBuilderFields: Record<string, QBField> = {
+  PARTNUMBER: {
+    label: 'Part Number',
+    dataField: ResultsQueryBuilderFieldNames.PART_NUMBER,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.STARTS_WITH.name,
+      QueryBuilderOperations.ENDS_WITH.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  PROGRAMNAME: {
+    label: 'Program Name',
+    dataField: ResultsQueryBuilderFieldNames.PROGRAM_NAME,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  SERIALNUMBER: {
+    label: 'Serial Number',
+    dataField: ResultsQueryBuilderFieldNames.SERIAL_NUMBER,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  KEYWORDS: {
+    label: 'Keywords',
+    dataField: ResultsQueryBuilderFieldNames.KEYWORDS,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+    ],
+  },
+  PROPERTIES: {
+    label: 'Properties',
+    dataField: ResultsQueryBuilderFieldNames.PROPERTIES,
+    dataType: 'object',
+    filterOperations: [
+      QueryBuilderOperations.KEY_VALUE_MATCH.name,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_MATCH.name,
+      QueryBuilderOperations.KEY_VALUE_CONTAINS.name,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_CONTAINS.name,
+      QueryBuilderOperations.KEY_VALUE_IS_GREATER_THAN.name,
+      QueryBuilderOperations.KEY_VALUE_IS_GREATER_THAN_OR_EQUAL.name,
+      QueryBuilderOperations.KEY_VALUE_IS_LESS_THAN.name,
+      QueryBuilderOperations.KEY_VALUE_IS_LESS_THAN_OR_EQUAL.name,
+      QueryBuilderOperations.KEY_VALUE_IS_NUMERICAL_EQUAL.name,
+      QueryBuilderOperations.KEY_VALUE_IS_NUMERICAL_NOT_EQUAL.name,
+    ],
+  },
+  OPERATOR: {
+    label: 'Operator',
+    dataField: ResultsQueryBuilderFieldNames.OPERATOR,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  STARTEDAT: {
+    label: 'Started At',
+    dataField: ResultsQueryBuilderFieldNames.STARTED_AT,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.GREATER_THAN.name,
+      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
+      QueryBuilderOperations.LESS_THAN.name,
+      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  UPDATEDAT: {
+    label: 'Updated At',
+    dataField: ResultsQueryBuilderFieldNames.UPDATED_AT,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.GREATER_THAN.name,
+      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
+      QueryBuilderOperations.LESS_THAN.name,
+      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  SYSTEMID: {
+    label: 'System ID',
+    dataField: ResultsQueryBuilderFieldNames.SYSTEM_ID,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  WORKSPACE: {
+    label: 'Workspace',
+    dataField: ResultsQueryBuilderFieldNames.WORKSPACE,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  STATUS: {
+    label: 'Status',
+    dataField: ResultsQueryBuilderFieldNames.STATUS,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+    ],
+  },
+  HOSTNAME: {
+    label: 'Host Name',
+    dataField: ResultsQueryBuilderFieldNames.HOSTNAME,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+};
+
+// export const ResultsQueryBuilderStaticFields = [
+//   ResultsQueryBuilderFields.PROPERTIES,
+// ];

--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -2,53 +2,24 @@ import { QueryBuilderOperations } from 'core/query-builder.constants';
 import { QBField } from '../types/QueryResults.types';
 
 export enum ResultsQueryBuilderFieldNames {
-  PART_NUMBER = 'PartNumber',
-  PROGRAM_NAME = 'ProgramName',
-  SERIAL_NUMBER = 'SerialNumber',
-  KEYWORDS = 'Keywords',
-  PROPERTIES = 'Properties',
-  OPERATOR = 'Operator',
-  STARTED_AT = 'StartedAt',
-  UPDATED_AT = 'UpdatedAt',
-  SYSTEM_ID = 'SystemId',
-  WORKSPACE = 'Workspace',
-  STATUS = 'Status',
   HOSTNAME = 'HostName',
+  KEYWORDS = 'Keywords',
+  OPERATOR = 'Operator',
+  PART_NUMBER = 'PartNumber',
+  PROPERTIES = 'Properties',
+  SERIAL_NUMBER = 'SerialNumber',
+  STARTED_AT = 'StartedAt',
+  STATUS = 'Status',
+  SYSTEM_ID = 'SystemId',
+  PROGRAM_NAME = 'ProgramName',
+  UPDATED_AT = 'UpdatedAt',
+  WORKSPACE = 'Workspace',
 }
 
 export const ResultsQueryBuilderFields: Record<string, QBField> = {
-  PARTNUMBER: {
-    label: 'Part number',
-    dataField: ResultsQueryBuilderFieldNames.PART_NUMBER,
-    filterOperations: [
-      QueryBuilderOperations.EQUALS.name,
-      QueryBuilderOperations.DOES_NOT_EQUAL.name,
-      QueryBuilderOperations.STARTS_WITH.name,
-      QueryBuilderOperations.ENDS_WITH.name,
-      QueryBuilderOperations.CONTAINS.name,
-      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
-      QueryBuilderOperations.IS_BLANK.name,
-      QueryBuilderOperations.IS_NOT_BLANK.name,
-    ],
-    lookup: {
-      dataSource: [],
-    },
-  },
-  PROGRAMNAME: {
-    label: 'Test Program',
-    dataField: ResultsQueryBuilderFieldNames.PROGRAM_NAME,
-    filterOperations: [
-      QueryBuilderOperations.EQUALS.name,
-      QueryBuilderOperations.DOES_NOT_EQUAL.name,
-      QueryBuilderOperations.CONTAINS.name,
-      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
-      QueryBuilderOperations.IS_BLANK.name,
-      QueryBuilderOperations.IS_NOT_BLANK.name,
-    ],
-  },
-  SERIALNUMBER: {
-    label: 'Serial number',
-    dataField: ResultsQueryBuilderFieldNames.SERIAL_NUMBER,
+  HOSTNAME: {
+    label: 'Host name',
+    dataField: ResultsQueryBuilderFieldNames.HOSTNAME,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
       QueryBuilderOperations.DOES_NOT_EQUAL.name,
@@ -68,6 +39,35 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
       QueryBuilderOperations.DOES_NOT_CONTAIN.name,
     ],
   },
+  OPERATOR: {
+    label: 'Operator',
+    dataField: ResultsQueryBuilderFieldNames.OPERATOR,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  PARTNUMBER: {
+    label: 'Part number',
+    dataField: ResultsQueryBuilderFieldNames.PART_NUMBER,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.STARTS_WITH.name,
+      QueryBuilderOperations.ENDS_WITH.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
   PROPERTIES: {
     label: 'Properties',
     dataField: ResultsQueryBuilderFieldNames.PROPERTIES,
@@ -85,9 +85,9 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
       QueryBuilderOperations.KEY_VALUE_IS_NUMERICAL_NOT_EQUAL.name,
     ],
   },
-  OPERATOR: {
-    label: 'Operator',
-    dataField: ResultsQueryBuilderFieldNames.OPERATOR,
+  SERIALNUMBER: {
+    label: 'Serial number',
+    dataField: ResultsQueryBuilderFieldNames.SERIAL_NUMBER,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
       QueryBuilderOperations.DOES_NOT_EQUAL.name,
@@ -112,16 +112,12 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
       dataSource: [],
     },
   },
-  UPDATEDAT: {
-    label: 'Updated',
-    dataField: ResultsQueryBuilderFieldNames.UPDATED_AT,
+  STATUS: {
+    label: 'Status',
+    dataField: ResultsQueryBuilderFieldNames.STATUS,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
       QueryBuilderOperations.DOES_NOT_EQUAL.name,
-      QueryBuilderOperations.GREATER_THAN.name,
-      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
-      QueryBuilderOperations.LESS_THAN.name,
-      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
     ],
     lookup: {
       dataSource: [],
@@ -139,28 +135,9 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
       QueryBuilderOperations.IS_NOT_BLANK.name,
     ],
   },
-  WORKSPACE: {
-    label: 'Workspace',
-    dataField: ResultsQueryBuilderFieldNames.WORKSPACE,
-    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
-    lookup: {
-      dataSource: [],
-    },
-  },
-  STATUS: {
-    label: 'Status',
-    dataField: ResultsQueryBuilderFieldNames.STATUS,
-    filterOperations: [
-      QueryBuilderOperations.EQUALS.name,
-      QueryBuilderOperations.DOES_NOT_EQUAL.name,
-    ],
-    lookup: {
-      dataSource: [],
-    },
-  },
-  HOSTNAME: {
-    label: 'Host name',
-    dataField: ResultsQueryBuilderFieldNames.HOSTNAME,
+  PROGRAMNAME: {
+    label: 'Test program',
+    dataField: ResultsQueryBuilderFieldNames.PROGRAM_NAME,
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
       QueryBuilderOperations.DOES_NOT_EQUAL.name,
@@ -169,6 +146,29 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
       QueryBuilderOperations.IS_BLANK.name,
       QueryBuilderOperations.IS_NOT_BLANK.name,
     ],
+  },
+  UPDATEDAT: {
+    label: 'Updated',
+    dataField: ResultsQueryBuilderFieldNames.UPDATED_AT,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.GREATER_THAN.name,
+      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
+      QueryBuilderOperations.LESS_THAN.name,
+      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  WORKSPACE: {
+    label: 'Workspace',
+    dataField: ResultsQueryBuilderFieldNames.WORKSPACE,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [],
+    },
   },
 };
 

--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -154,6 +154,9 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
       QueryBuilderOperations.EQUALS.name,
       QueryBuilderOperations.DOES_NOT_EQUAL.name,
     ],
+    lookup: {
+      dataSource: [],
+    },
   },
   HOSTNAME: {
     label: 'Host Name',
@@ -169,6 +172,12 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
   },
 };
 
-// export const ResultsQueryBuilderStaticFields = [
-//   ResultsQueryBuilderFields.PROPERTIES,
-// ];
+export const ResultsQueryBuilderStaticFields = [
+  ResultsQueryBuilderFields.PROGRAMNAME,
+  ResultsQueryBuilderFields.PROPERTIES,
+  ResultsQueryBuilderFields.SYSTEMID,
+  ResultsQueryBuilderFields.KEYWORDS,
+  ResultsQueryBuilderFields.OPERATOR,
+  ResultsQueryBuilderFields.SERIALNUMBER,
+  ResultsQueryBuilderFields.HOSTNAME,
+];

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -9,7 +9,6 @@ export interface QueryResults extends ResultsQuery {
   useTimeRange?: boolean;
   useTimeRangeFor?: string;
   recordCount?: number;
-  queryBy?: string;
 }
 
 export const OrderBy = [

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -1,3 +1,4 @@
+import { QueryBuilderField } from 'smart-webcomponents-react';
 import { OutputType, ResultsQuery } from './types';
 
 export interface QueryResults extends ResultsQuery {
@@ -8,6 +9,7 @@ export interface QueryResults extends ResultsQuery {
   useTimeRange?: boolean;
   useTimeRangeFor?: string;
   recordCount?: number;
+  queryBy?: string;
 }
 
 export const OrderBy = [
@@ -136,4 +138,14 @@ export interface QueryResultsResponse {
   results: ResultsResponseProperties[];
   continuationToken?: string;
   totalCount?: number;
+}
+
+export interface QBField extends QueryBuilderField {
+  lookup?: {
+    readonly?: boolean;
+    dataSource: Array<{
+      label: string,
+      value: string
+    }>;
+  },
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
As a part of this [User Story 2798322](https://ni.visualstudio.com/DevCentral/_workitems/edit/2798322): FE | Add Query Builder for Results Datasource

this PR introduces constants and types required for implementing the query builder functionality for the Results datasource.

## 👩‍💻 Implementation
In `ResultsQueryBuilder.constants.ts`: 

- Added `ResultsQueryBuilderFieldNames` to define the field names used in the query builder.
- Added `ResultsQueryBuilderFields` to configure field metadata, including labels, filter operations, and lookup values.
- Added `ResultsQueryBuilderStaticFields` to define static fields for the query builder.

In `QueryResults.types.ts`:

- Added `QBField` type to represent the structure of query builder fields.
- Added `queryBy` property in the `QueryResults` type to support query transformations in the Results datasource.


## 🧪 Testing

NA

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).