### PR TITLE
fix(data-frame): Replace Variable support for $__all variable

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -70,14 +70,13 @@ export function sleep(timeout: number) {
  */
 export function replaceVariables(values: string[], templateSrv: TemplateSrv) {
   const replaced: string[] = [];
-  values.forEach((col: string, index) => {
-    let value = col;
-    if (templateSrv.containsTemplate(col)) {
-      const variables = templateSrv.getVariables() as any[];
-      const variable = variables.find(v => v.name === col.split('$')[1]);
-      value = variable.current.value;
+  values.forEach(value => {
+    if (templateSrv.containsTemplate(value)) {
+      const variableReplacedValues = templateSrv.replace(value).replace(/[{}]/g, '').split(',');
+      replaced.push(...variableReplacedValues.filter(v => v.trim() !== ''));
+    } else {
+      replaced.push(value);
     }
-    replaced.push(value);
   });
   // Dedupe and flatten
   return [...new Set(replaced.flat())];

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -72,7 +72,9 @@ export function replaceVariables(values: string[], templateSrv: TemplateSrv) {
   const replaced: string[] = [];
   values.forEach(value => {
     if (templateSrv.containsTemplate(value)) {
-      const variableReplacedValues = templateSrv.replace(value).replace(/[{}]/g, '').split(',');
+      const variableReplacedValues = templateSrv.replace(value) // Replace variable with their values
+        .replace(/[{}]/g, '') // return values without curly braces for multi-value variables which are returned as {value1,value2}
+        .split(',');
       replaced.push(...variableReplacedValues.filter(v => v.trim() !== ''));
     } else {
       replaced.push(value);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
To fix : [Bug 3107967](https://dev.azure.com/ni/DevCentral/_workitems/edit/3107967): Dataframe data source doesn't handle Grafana variables when 'All' is selected as an option from the variable dropdown

We need to refactor the `replaceVariables` method to properly handle the `All` selection in the variables, as the `variable.current.value` of the `All` selection of variables is `$__all`, which is currently causing failures : 
![image](https://github.com/user-attachments/assets/84a0e967-1872-4ce6-a830-60339ec6511f)

## 👩‍💻 Implementation
- Refactored the logic of replacing the variables using `templateSrv.replace` instead of `template.Srv.getVariables` which does not list the proper value under `$__all` variable.
- Removed curly braces from multi-value variables as they return strings enclosed within curly braces

## 🧪 Testing

- Added unit test cases.
- Manually verified in Local env

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).