### PR TITLE
feat(results): Introduce feature flag toggles for Results and Steps query builders

### DIFF
--- a/src/datasources/results/ResultsConfigEditor.test.tsx
+++ b/src/datasources/results/ResultsConfigEditor.test.tsx
@@ -33,16 +33,16 @@ describe('ResultsConfigEditor', () => {
     stepsQueryBuilder = screen.getAllByRole('checkbox')[1];
     jest.clearAllMocks();
   });
-  test('renders DataSourceHttpSettings component', () => {
+  test('should renders DataSourceHttpSettings component when ResultsConfigEditor is loaded', () => {
     expect(screen.getByText('Mock DataSourceHttpSettings')).toBeInTheDocument();
   });
 
-  test('renders the component with feature toggles', () => {
+  test('should render the component with feature toggles when loaded', () => {
     expect(resultsQueryBuilder).toBeInTheDocument();
     expect(stepsQueryBuilder).toBeInTheDocument();
   });
 
-  test('toggles Results Query Builder feature', async () => {
+  test('Should update the queryByResults feature toggle when it is toggled', async () => {
     expect(resultsQueryBuilder).not.toBeChecked();
 
     await userEvent.click(resultsQueryBuilder);
@@ -53,7 +53,7 @@ describe('ResultsConfigEditor', () => {
     });
   });
 
-  test('toggles Steps Query Builder feature', () => {
+  test('Should update the queryBySteps feature toggle when it is toggled', () => {
     expect(stepsQueryBuilder).not.toBeChecked();
 
     fireEvent.click(stepsQueryBuilder);

--- a/src/datasources/results/ResultsConfigEditor.test.tsx
+++ b/src/datasources/results/ResultsConfigEditor.test.tsx
@@ -22,30 +22,29 @@ const defaultProps: DataSourcePluginOptionsEditorProps<any> = {
   } as DataSourceSettings<any>,
   onOptionsChange: mockOnOptionsChange,
 };
-let resultsQueryBuilder: HTMLElement;
-let stepsQueryBuilder: HTMLElement;
+let resultsQueryBuilderToggle: HTMLElement;
+let stepsQueryBuilderToggle: HTMLElement;
 
 describe('ResultsConfigEditor', () => {
   beforeEach(() => {
     render(<ResultsConfigEditor {...defaultProps} />);
 
-    resultsQueryBuilder = screen.getAllByRole('checkbox')[0];
-    stepsQueryBuilder = screen.getAllByRole('checkbox')[1];
-    jest.clearAllMocks();
+    resultsQueryBuilderToggle = screen.getAllByRole('checkbox')[0];
+    stepsQueryBuilderToggle = screen.getAllByRole('checkbox')[1];
   });
-  test('should renders DataSourceHttpSettings component when ResultsConfigEditor is loaded', () => {
+  test('should render DataSourceHttpSettings component when ResultsConfigEditor is loaded', () => {
     expect(screen.getByText('Mock DataSourceHttpSettings')).toBeInTheDocument();
   });
 
   test('should render the component with feature toggles when loaded', () => {
-    expect(resultsQueryBuilder).toBeInTheDocument();
-    expect(stepsQueryBuilder).toBeInTheDocument();
+    expect(resultsQueryBuilderToggle).toBeInTheDocument();
+    expect(stepsQueryBuilderToggle).toBeInTheDocument();
   });
 
-  test('Should update the queryByResults feature toggle when it is toggled', async () => {
-    expect(resultsQueryBuilder).not.toBeChecked();
+  test('should update the queryByResults feature toggles option when it is toggled', async () => {
+    expect(resultsQueryBuilderToggle).not.toBeChecked();
 
-    await userEvent.click(resultsQueryBuilder);
+    await userEvent.click(resultsQueryBuilderToggle);
     await waitFor(() => {
       expect(mockOnOptionsChange).toHaveBeenCalledWith(
         expect.objectContaining({ "jsonData": {"featureToggles": {"queryByResults": true, "queryBySteps": false}}})
@@ -53,10 +52,10 @@ describe('ResultsConfigEditor', () => {
     });
   });
 
-  test('Should update the queryBySteps feature toggle when it is toggled', () => {
-    expect(stepsQueryBuilder).not.toBeChecked();
+  test('should update the queryBySteps feature toggles option when it is toggled', () => {
+    expect(stepsQueryBuilderToggle).not.toBeChecked();
 
-    fireEvent.click(stepsQueryBuilder);
+    fireEvent.click(stepsQueryBuilderToggle);
 
     expect(mockOnOptionsChange).toHaveBeenCalledWith(
       expect.objectContaining({ "jsonData": {"featureToggles": {"queryByResults": false, "queryBySteps": true}}})

--- a/src/datasources/results/ResultsConfigEditor.test.tsx
+++ b/src/datasources/results/ResultsConfigEditor.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ResultsConfigEditor } from './ResultsConfigEditor';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import userEvent from '@testing-library/user-event';
+
+const mockOnOptionsChange = jest.fn();
+
+const defaultProps: DataSourcePluginOptionsEditorProps<any> = {
+  options: {
+    jsonData: {
+      featureToggles: {
+        queryByResults: false,
+        queryBySteps: false,
+      },
+    },
+    id: 0,
+    uid: '',
+    orgId: 0,
+    name: '',
+    typeLogoUrl: '',
+    type: '',
+    typeName: '',
+    access: '',
+    url: '',
+    user: '',
+    database: '',
+    basicAuth: true,
+    basicAuthUser: '',
+    isDefault: false,
+    secureJsonFields: {},
+    readOnly: false,
+    withCredentials: false,
+  },
+  onOptionsChange: mockOnOptionsChange,
+};
+let resultsQueryBuilder: HTMLElement;
+let stepsQueryBuilder: HTMLElement;
+
+describe('ResultsConfigEditor', () => {
+  beforeEach(() => {
+    render(<ResultsConfigEditor {...defaultProps} />);
+    resultsQueryBuilder = screen.getAllByRole('checkbox')[3];
+    stepsQueryBuilder = screen.getAllByRole('checkbox')[7];
+  });
+
+  test('renders the component with feature toggles', () => {
+    expect(resultsQueryBuilder).toBeInTheDocument();
+    expect(stepsQueryBuilder).toBeInTheDocument();
+  });
+
+  test('toggles Results Query Builder feature', async () => {
+    render(<ResultsConfigEditor {...defaultProps} />);
+
+    expect(resultsQueryBuilder).not.toBeChecked();
+
+    await userEvent.click(resultsQueryBuilder);
+    await waitFor(() => {
+      expect(mockOnOptionsChange).toHaveBeenCalledWith(expect.objectContaining({ queryByResults: true }));
+    });
+  });
+
+  test('toggles Steps Query Builder feature', () => {
+    render(<ResultsConfigEditor {...defaultProps} />);
+
+    expect(stepsQueryBuilder).not.toBeChecked();
+
+    fireEvent.click(stepsQueryBuilder);
+
+    expect(mockOnOptionsChange).toHaveBeenCalledWith({
+      ...defaultProps.options,
+      jsonData: {
+        featureToggles: {
+          ...defaultProps.options.jsonData.featureToggles,
+          queryBySteps: true,
+        },
+      },
+    });
+  });
+
+  test('renders DataSourceHttpSettings component', () => {
+    render(<ResultsConfigEditor {...defaultProps} />);
+
+    expect(screen.getByText('URL')).toBeInTheDocument();
+  });
+});

--- a/src/datasources/results/ResultsConfigEditor.tsx
+++ b/src/datasources/results/ResultsConfigEditor.tsx
@@ -6,7 +6,7 @@ import { ResultsDataSourceOptions, ResultsFeatureTogglesDefaults } from './types
 interface Props extends DataSourcePluginOptionsEditorProps<ResultsDataSourceOptions> {}
 
 export const ResultsConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
-  const handleFeatureChange = useCallback(
+    const handleFeatureChange = useCallback(
     (featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
       const jsonData = {
         ...options.jsonData,

--- a/src/datasources/results/ResultsConfigEditor.tsx
+++ b/src/datasources/results/ResultsConfigEditor.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, useCallback } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { DataSourceHttpSettings, InlineField, InlineSegmentGroup, InlineSwitch, Tag, Text } from '@grafana/ui';
+import { DataSourceHttpSettings, InlineField, InlineSegmentGroup, InlineSwitch, Text } from '@grafana/ui';
 import { ResultsDataSourceOptions, ResultsFeatureTogglesDefaults } from './types/types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<ResultsDataSourceOptions> {}

--- a/src/datasources/results/ResultsConfigEditor.tsx
+++ b/src/datasources/results/ResultsConfigEditor.tsx
@@ -36,7 +36,6 @@ export const ResultsConfigEditor: React.FC<Props> = ({ options, onOptionsChange 
               onChange={handleFeatureChange('queryByResults')}
             />
           </InlineField>
-          <Tag name="Beta" colorIndex={5} />
         </InlineSegmentGroup>
         <InlineSegmentGroup>
           <InlineField label="Steps Query Builder" labelWidth={25}>
@@ -45,7 +44,6 @@ export const ResultsConfigEditor: React.FC<Props> = ({ options, onOptionsChange 
               onChange={handleFeatureChange('queryBySteps')}
             />
           </InlineField>
-          <Tag name="Beta" colorIndex={5} />
         </InlineSegmentGroup>
       </>
     </>

--- a/src/datasources/results/ResultsConfigEditor.tsx
+++ b/src/datasources/results/ResultsConfigEditor.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback } from 'react';
+import React, { ChangeEvent } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { DataSourceHttpSettings, InlineField, InlineSegmentGroup, InlineSwitch, Text } from '@grafana/ui';
 import { ResultsDataSourceOptions, ResultsFeatureTogglesDefaults } from './types/types';

--- a/src/datasources/results/ResultsConfigEditor.tsx
+++ b/src/datasources/results/ResultsConfigEditor.tsx
@@ -6,16 +6,13 @@ import { ResultsDataSourceOptions, ResultsFeatureTogglesDefaults } from './types
 interface Props extends DataSourcePluginOptionsEditorProps<ResultsDataSourceOptions> {}
 
 export const ResultsConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
-    const handleFeatureChange = useCallback(
-    (featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
-      const jsonData = {
-        ...options.jsonData,
-        ...{ featureToggles: { ...options.jsonData.featureToggles, [featureKey]: event.target.checked } },
-      };
-      onOptionsChange({ ...options, jsonData });
-    },
-    [options, onOptionsChange]
-  );
+  const handleFeatureChange = (featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
+    const jsonData = {
+      ...options.jsonData,
+      featureToggles: { ...options.jsonData.featureToggles, [featureKey]: event.target.checked },
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
 
   return (
     <>

--- a/src/datasources/results/ResultsConfigEditor.tsx
+++ b/src/datasources/results/ResultsConfigEditor.tsx
@@ -1,0 +1,53 @@
+import React, { ChangeEvent, useCallback } from 'react';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { DataSourceHttpSettings, InlineField, InlineSegmentGroup, InlineSwitch, Tag, Text } from '@grafana/ui';
+import { ResultsDataSourceOptions, ResultsFeatureTogglesDefaults } from './types/types';
+
+interface Props extends DataSourcePluginOptionsEditorProps<ResultsDataSourceOptions> {}
+
+export const ResultsConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
+  const handleFeatureChange = useCallback(
+    (featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
+      const jsonData = {
+        ...options.jsonData,
+        ...{ featureToggles: { ...options.jsonData.featureToggles, [featureKey]: event.target.checked } },
+      };
+      onOptionsChange({ ...options, jsonData });
+    },
+    [options, onOptionsChange]
+  );
+
+  return (
+    <>
+      <DataSourceHttpSettings
+        defaultUrl=""
+        dataSourceConfig={options}
+        showAccessOptions={false}
+        onChange={onOptionsChange}
+      />
+      <>
+        <div style={{ paddingBottom: '10px' }}>
+          <Text element="h6">Features</Text>
+        </div>
+        <InlineSegmentGroup>
+          <InlineField label="Results Query Builder" labelWidth={25}>
+            <InlineSwitch
+              value={options.jsonData?.featureToggles?.queryByResults ?? ResultsFeatureTogglesDefaults.queryByResults}
+              onChange={handleFeatureChange('queryByResults')}
+            />
+          </InlineField>
+          <Tag name="Beta" colorIndex={5} />
+        </InlineSegmentGroup>
+        <InlineSegmentGroup>
+          <InlineField label="Steps Query Builder" labelWidth={25}>
+            <InlineSwitch
+              value={options.jsonData?.featureToggles?.queryBySteps ?? ResultsFeatureTogglesDefaults.queryBySteps}
+              onChange={handleFeatureChange('queryBySteps')}
+            />
+          </InlineField>
+          <Tag name="Beta" colorIndex={5} />
+        </InlineSegmentGroup>
+      </>
+    </>
+  );
+};

--- a/src/datasources/results/ResultsDataSource.ts
+++ b/src/datasources/results/ResultsDataSource.ts
@@ -1,20 +1,20 @@
 import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
-import { QueryType, ResultsQuery } from './types/types';
+import { QueryType, ResultsDataSourceOptions, ResultsQuery } from './types/types';
 import { QueryResultsDataSource } from './query-handlers/query-results/QueryResultsDataSource';
 import { QueryResults } from './types/QueryResults.types';
 import { QuerySteps } from './types/QuerySteps.types';
 import { QueryStepsDataSource } from './query-handlers/query-steps/QueryStepsDataSource';
 
-export class ResultsDataSource extends DataSourceBase<ResultsQuery> {
+export class ResultsDataSource extends DataSourceBase<ResultsQuery, ResultsDataSourceOptions> {
   public defaultQuery: Partial<ResultsQuery> & Omit<ResultsQuery, 'refId'>;
 
   private queryResultsDataSource: QueryResultsDataSource;
   private queryStepsDataSource: QueryStepsDataSource;
 
   constructor(
-    readonly instanceSettings: DataSourceInstanceSettings,
+    readonly instanceSettings: DataSourceInstanceSettings<ResultsDataSourceOptions>,
     readonly backendSrv: BackendSrv = getBackendSrv(),
     readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {

--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -3,7 +3,7 @@ import { render, waitFor } from '@testing-library/react';
 import { ResultsQueryEditor } from './ResultsQueryEditor';
 import { QueryEditorProps } from '@grafana/data';
 import { ResultsDataSource } from '../ResultsDataSource';
-import { QueryType, ResultsQuery } from '../types/types';
+import { QueryType, ResultsDataSourceOptions, ResultsQuery } from '../types/types';
 import userEvent from '@testing-library/user-event';
 import { defaultResultsQuery, defaultStepsQuery } from '../defaultQueries';
 
@@ -13,7 +13,7 @@ const mockDatasource = {
   prepareQuery: jest.fn((query: ResultsQuery) => query),
 } as unknown as ResultsDataSource;
 
-const defaultProps: QueryEditorProps<ResultsDataSource, ResultsQuery> = {
+const defaultProps: QueryEditorProps<ResultsDataSource, ResultsQuery, ResultsDataSourceOptions> = {
   query: {
     refId: 'A',
     queryType: QueryType.Results,

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { ResultsDataSource } from '../ResultsDataSource';
-import { QueryType, ResultsQuery } from '../types/types';
+import { QueryType, ResultsDataSourceOptions, ResultsQuery } from '../types/types';
 import { QueryResultsEditor } from './editors/query-results/QueryResultsEditor';
 import { QueryResults } from '../types/QueryResults.types';
 import { defaultResultsQuery, defaultStepsQuery } from '../defaultQueries';
@@ -9,7 +9,7 @@ import { InlineField, RadioButtonGroup, VerticalGroup } from '@grafana/ui';
 import { QueryStepsEditor } from './editors/query-steps/QueryStepsEditor';
 import { QuerySteps } from '../types/QuerySteps.types';
 
-type Props = QueryEditorProps<ResultsDataSource, ResultsQuery>;
+type Props = QueryEditorProps<ResultsDataSource, ResultsQuery, ResultsDataSourceOptions>;
 
 export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   query = datasource.prepareQuery(query);

--- a/src/datasources/results/module.ts
+++ b/src/datasources/results/module.ts
@@ -1,8 +1,9 @@
 import { DataSourcePlugin } from '@grafana/data';
 import { ResultsDataSource } from './ResultsDataSource';
 import { ResultsQueryEditor } from './components/ResultsQueryEditor';
-import { HttpConfigEditor } from 'core/components/HttpConfigEditor';
+import { ResultsConfigEditor } from './ResultsConfigEditor';
+import { ResultsDataSourceOptions, ResultsQuery } from './types/types';
 
-export const plugin = new DataSourcePlugin(ResultsDataSource)
-  .setConfigEditor(HttpConfigEditor)
+export const plugin = new DataSourcePlugin<ResultsDataSource, ResultsQuery, ResultsDataSourceOptions>(ResultsDataSource)
+  .setConfigEditor(ResultsConfigEditor)
   .setQueryEditor(ResultsQueryEditor);

--- a/src/datasources/results/types/types.ts
+++ b/src/datasources/results/types/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, DataSourceJsonData } from '@grafana/schema';
 
 export interface ResultsQuery extends DataQuery {
   queryType: QueryType;
@@ -17,4 +17,18 @@ export enum OutputType {
 export enum UseTimeRangeFor {
   Started = 'Started',
   Updated = 'Updated'
+}
+
+export interface ResultsFeatureToggles {
+  queryByResults: boolean;
+  queryBySteps: boolean;
+}
+
+export interface ResultsDataSourceOptions extends DataSourceJsonData {
+  featureToggles: ResultsFeatureToggles;
+}
+
+export const ResultsFeatureTogglesDefaults: ResultsFeatureToggles = {
+  queryByResults: true,
+  queryBySteps: true
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As a part of the [User Story 2798322](https://ni.visualstudio.com/DevCentral/_workitems/edit/2798322): FE | Add Query Builder for Results Datasource
this PR introduces the ResultsConfigEditor to  toggle feature flags `queryByResults` and `queryBySteps`, enabling or disabling the visibility of the respective query builders.

## 👩‍💻 Implementation

- Added `ResultsConfigEditor` to having `DatasourceHttpSettings` and toggle switches to control the visibility of the Results and Steps Query Builders based on feature flags.
- Updated `module.ts` to set `ResultsConfigEditor` using `setConfigEditor` method and `ResultsDataSourceOptions` to define the datasource configuration type 
- Created required interfaces and constant for the feature flag toggles.
- Updated the Results Editor and Datasource to include the `ResultsDataSourceOptions` type, to ensure type safety.

## 🧪 Testing

- Added unit test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).