### PR TITLE
feat(testplans): Set base for testplans

### DIFF
--- a/src/datasources/test-plans/README.md
+++ b/src/datasources/test-plans/README.md
@@ -1,0 +1,5 @@
+# Systemlink Test Plans data source
+
+This is a plugin for the Test Plans from the Work order service. It allows you to:
+
+- Visualize test plans metadata and its count on a dashboard

--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -1,0 +1,33 @@
+import { MockProxy } from "jest-mock-extended";
+import { TestPlansDataSource } from "./TestPlansDataSource";
+import { BackendSrv } from "@grafana/runtime";
+import { createFetchError, createFetchResponse, requestMatching, setupDataSource } from "test/fixtures";
+
+
+let datastore: TestPlansDataSource, backendServer: MockProxy<BackendSrv>
+
+beforeEach(() => {
+  [datastore, backendServer] = setupDataSource(TestPlansDataSource);
+});
+
+describe('testDatasource', () => {
+  test('returns success', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/niworkorder/v1/query-testplans', data: { take: 1 } }))
+      .mockReturnValue(createFetchResponse(25));
+
+    const result = await datastore.testDatasource();
+
+    expect(result.status).toEqual('success');
+  });
+
+  test('bubbles up exception', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/niworkorder/v1/query-testplans', data: { take: 1 } }))
+      .mockReturnValue(createFetchError(400));
+
+    await expect(datastore.testDatasource())
+      .rejects
+      .toThrow('Request to url "/niworkorder/v1/query-testplans" failed with status code: 400. Error message: "Error"');
+  });
+});

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -12,8 +12,8 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
     super(instanceSettings, backendSrv, templateSrv);
   }
 
-  baseUrl = this.instanceSettings.url + '/niworkorder/v1';
-  queryTestPlansUrl = this.baseUrl + '/query-testplans';
+  baseUrl = `${this.instanceSettings.url}/niworkorder/v1`;
+  queryTestPlansUrl = `${this.baseUrl}/query-testplans`;
 
   defaultQuery = {};
 
@@ -29,7 +29,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   }
 
   async testDatasource(): Promise<TestDataSourceResponse> {
-    await this.post(`${this.queryTestPlansUrl}`, { take: 1 });
+    await this.post(this.queryTestPlansUrl, { take: 1 });
     return { status: 'success', message: 'Data source connected and authentication successful!' };
   }
 }

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -1,0 +1,35 @@
+import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, TestDataSourceResponse } from '@grafana/data';
+import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
+import { DataSourceBase } from 'core/DataSourceBase';
+import { TestPlansQuery } from './types';
+
+export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
+  constructor(
+    readonly instanceSettings: DataSourceInstanceSettings,
+    readonly backendSrv: BackendSrv = getBackendSrv(),
+    readonly templateSrv: TemplateSrv = getTemplateSrv()
+  ) {
+    super(instanceSettings, backendSrv, templateSrv);
+  }
+
+  baseUrl = this.instanceSettings.url + '/niworkorder/v1';
+  queryTestPlansUrl = this.baseUrl + '/query-testplans';
+
+  defaultQuery = {};
+
+  async runQuery(query: TestPlansQuery, { range }: DataQueryRequest): Promise<DataFrameDTO> {
+    return {
+      refId: query.refId,
+      fields: [],
+    };
+  }
+
+  shouldRunQuery(query: TestPlansQuery): boolean {
+    return true;
+  }
+
+  async testDatasource(): Promise<TestDataSourceResponse> {
+    await this.post(`${this.queryTestPlansUrl}`, { take: 1 });
+    return { status: 'success', message: 'Data source connected and authentication successful!' };
+  }
+}

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TestPlansQueryEditor } from './TestPlansQueryEditor';
+import { QueryEditorProps } from '@grafana/data';
+import { TestPlansDataSource } from '../TestPlansDataSource';
+import { TestPlansQuery } from '../types';
+
+const mockDatasource = {
+    prepareQuery: jest.fn((query: TestPlansQuery) => query),
+} as unknown as TestPlansDataSource;
+
+const defaultProps: QueryEditorProps<TestPlansDataSource, TestPlansQuery> = {
+    query: {} as TestPlansQuery,
+    onChange: jest.fn(),
+    onRunQuery: jest.fn(),
+    datasource: mockDatasource,
+};
+
+describe('TestPlansQueryEditor', () => {
+    it('should render without crashing', () => {
+        const { container } = render(<TestPlansQueryEditor {...defaultProps} />);
+        expect(container).toBeInTheDocument(); // Ensure the component renders
+    });
+
+    it('should render an empty fragment', () => {
+        render(<TestPlansQueryEditor {...defaultProps} />);
+        expect(screen.queryByText(/./)).not.toBeInTheDocument(); // Ensure no text content is rendered
+    });
+});

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { QueryEditorProps } from '@grafana/data';
+import { TestPlansDataSource } from '../TestPlansDataSource';
+import { TestPlansQuery } from '../types';
+
+type Props = QueryEditorProps<TestPlansDataSource, TestPlansQuery>;
+
+export function TestPlansQueryEditor({ query, onChange, onRunQuery }: Props) {
+  return (
+    <>
+    </>
+  );
+}

--- a/src/datasources/test-plans/img/logo-ni.svg
+++ b/src/datasources/test-plans/img/logo-ni.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="43px" height="29px" viewBox="0 0 43 29" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>9B441361-9BF9-4E57-A772-8A5F7846467E</title>
+    <g id="Login" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Logging-In-Loader" transform="translate(-864.000000, -139.000000)" fill="#00B383">
+            <g id="NI-logo" transform="translate(864.000000, 139.000000)">
+                <path d="M9.98214286,9.92105263 L9.98214286,29 L0,29 L0,9.92105263 L9.98214286,9.92105263 Z M43,0 L43,29 C37.4870147,29 33.0178571,24.5308424 33.0178571,19.0178571 L33.0178571,0 L43,0 Z M18.4107143,0 C23.9335618,-1.01453063e-15 28.4107143,4.4771525 28.4107143,10 L28.4107143,29 L18.4293773,29 L18.4293773,10.9210526 C18.4293439,10.3687809 17.981649,9.92107107 17.4293773,9.92101925 L9.98214286,9.92077061 L9.98214286,0 L18.4107143,0 Z"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/datasources/test-plans/module.ts
+++ b/src/datasources/test-plans/module.ts
@@ -1,0 +1,8 @@
+import { DataSourcePlugin } from '@grafana/data';
+import { TestPlansDataSource } from './TestPlansDataSource';
+import { TestPlansQueryEditor } from './components/TestPlansQueryEditor';
+import { HttpConfigEditor } from 'core/components/HttpConfigEditor';
+
+export const plugin = new DataSourcePlugin(TestPlansDataSource)
+  .setConfigEditor(HttpConfigEditor)
+  .setQueryEditor(TestPlansQueryEditor);

--- a/src/datasources/test-plans/plugin.json
+++ b/src/datasources/test-plans/plugin.json
@@ -1,0 +1,15 @@
+{
+  "type": "datasource",
+  "name": "SystemLink Test Plans",
+  "id": "ni-sltestplans-datasource",
+  "metrics": true,
+  "info": {
+    "author": {
+      "name": "NI"
+    },
+    "logos": {
+      "small": "img/logo-ni.svg",
+      "large": "img/logo-ni.svg"
+    }
+  }
+}

--- a/src/datasources/test-plans/types.ts
+++ b/src/datasources/test-plans/types.ts
@@ -1,0 +1,4 @@
+import { DataQuery } from '@grafana/schema'
+
+export interface TestPlansQuery extends DataQuery {
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

[User Story 3108772](https://ni.visualstudio.com/DevCentral/_workitems/edit/3108772): FE | Set base
To set base for Test plans data source

## 👩‍💻 Implementation
- Generated a new data source test-plans following the [Getting started - Grafana Plugin Development for SLE](https://dev.azure.com/ni/DevCentral/_wiki/wikis/AppCentral.wiki/108813/Getting-started-Grafana-Plugin-Development-for-SLE).
- Removed unnecessary code generated

## 🧪 Testing

Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).