### PR TITLE
feat(results): Add constants for Steps Query Builder

### DIFF
--- a/src/datasources/results/ResultsDataSource.ts
+++ b/src/datasources/results/ResultsDataSource.ts
@@ -44,6 +44,10 @@ export class ResultsDataSource extends DataSourceBase<ResultsQuery> {
     return false;
   }
 
+  getQueryResultsDataSource(): QueryResultsDataSource {
+    return this.queryResultsDataSource;
+  }
+
   async testDatasource(): Promise<TestDataSourceResponse> {
     await this.get(this.baseUrl + '/v2/results?take=1');
     return { status: 'success', message: 'Data source connected and authentication successful!' };

--- a/src/datasources/results/ResultsDataSource.ts
+++ b/src/datasources/results/ResultsDataSource.ts
@@ -44,10 +44,6 @@ export class ResultsDataSource extends DataSourceBase<ResultsQuery> {
     return false;
   }
 
-  getQueryResultsDataSource(): QueryResultsDataSource {
-    return this.queryResultsDataSource;
-  }
-
   async testDatasource(): Promise<TestDataSourceResponse> {
     await this.get(this.baseUrl + '/v2/results?take=1');
     return { status: 'success', message: 'Data source connected and authentication successful!' };

--- a/src/datasources/results/ResultsDataSource.ts
+++ b/src/datasources/results/ResultsDataSource.ts
@@ -28,7 +28,7 @@ export class ResultsDataSource extends DataSourceBase<ResultsQuery> {
 
   async runQuery(query: ResultsQuery, options: DataQueryRequest): Promise<DataFrameDTO> {
     if (query.queryType === QueryType.Results) {
-      return this.queryResultsDataSource.runQuery(query as QueryResults, options);
+      return this.getQueryResultsDataSource().runQuery(query as QueryResults, options);
     } else if (query.queryType === QueryType.Steps) {
       return this.queryStepsDataSource.runQuery(query as QuerySteps, options);
     }
@@ -37,11 +37,15 @@ export class ResultsDataSource extends DataSourceBase<ResultsQuery> {
 
   shouldRunQuery(query: ResultsQuery): boolean {
     if (query.queryType === QueryType.Results) {
-      return this.queryResultsDataSource.shouldRunQuery(query as QueryResults);
+      return this.getQueryResultsDataSource().shouldRunQuery(query as QueryResults);
     } else if (query.queryType === QueryType.Steps) {
       return this.queryStepsDataSource.shouldRunQuery(query as QuerySteps);
     }
     return false;
+  }
+
+  getQueryResultsDataSource(): QueryResultsDataSource {
+    return this.queryResultsDataSource;
   }
 
   async testDatasource(): Promise<TestDataSourceResponse> {

--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -2,7 +2,7 @@ import { DataSourceBase } from "core/DataSourceBase";
 import { DataQueryRequest, DataFrameDTO, TestDataSourceResponse } from "@grafana/data";
 import { ResultsQuery } from "./types/types";
 import { BatchQueryConfig, QueryResponse } from "./types/QuerySteps.types";
-import { QueryBuilderOption, Workspace } from "core/types";
+import { Workspace } from "core/types";
 
 export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery> {
   baseUrl = this.instanceSettings.url + '/nitestmonitor';
@@ -16,7 +16,6 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
   private toDateString = '${__to:date}';
 
   readonly workspacesCache = new Map<string, Workspace>([]);
-  readonly globalVariableOptions = (): QueryBuilderOption[] => this.getVariableOptions();
 
   abstract runQuery(query: ResultsQuery, options: DataQueryRequest): Promise<DataFrameDTO>;
 
@@ -89,12 +88,6 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
       data: queryResponse,
       totalCount,
     };
-  }
-
-  private getVariableOptions() {
-    return this.templateSrv
-      .getVariables()
-      .map(variable => ({ label: '$' + variable.name, value: '$' + variable.name }));
   }
 
   async loadWorkspaces(): Promise<void> {

--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -2,20 +2,21 @@ import { DataSourceBase } from "core/DataSourceBase";
 import { DataQueryRequest, DataFrameDTO, TestDataSourceResponse } from "@grafana/data";
 import { ResultsQuery } from "./types/types";
 import { BatchQueryConfig, QueryResponse } from "./types/QuerySteps.types";
-import { Workspace } from "core/types";
+import { QueryBuilderOption, Workspace } from "core/types";
 
 export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery> {
   baseUrl = this.instanceSettings.url + '/nitestmonitor';
-
+  
   private timeRange: { [key: string]: string } = {
     Started: 'startedAt',
     Updated: 'updatedAt',
   };
-
+  
   private fromDateString = '${__from:date}';
   private toDateString = '${__to:date}';
-
+  
   readonly workspacesCache = new Map<string, Workspace>([]);
+  readonly globalVariableOptions = (): QueryBuilderOption[] => this.getVariableOptions();
 
   abstract runQuery(query: ResultsQuery, options: DataQueryRequest): Promise<DataFrameDTO>;
 
@@ -101,6 +102,12 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
       });
 
     workspaces?.forEach(workspace => this.workspacesCache.set(workspace.id, workspace));
+  }
+
+  private getVariableOptions() {
+    return this.templateSrv
+      .getVariables()
+      .map(variable => ({ label: '$' + variable.name, value: '$' + variable.name }));
   }
 
   private async delay(timeout: number): Promise<void> {

--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -2,7 +2,7 @@ import { DataSourceBase } from "core/DataSourceBase";
 import { DataQueryRequest, DataFrameDTO, TestDataSourceResponse } from "@grafana/data";
 import { ResultsQuery } from "./types/types";
 import { BatchQueryConfig, QueryResponse } from "./types/QuerySteps.types";
-import { Workspace } from "core/types";
+import { QueryBuilderOption, Workspace } from "core/types";
 
 export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery> {
   baseUrl = this.instanceSettings.url + '/nitestmonitor';
@@ -16,6 +16,7 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
   private toDateString = '${__to:date}';
 
   readonly workspacesCache = new Map<string, Workspace>([]);
+  readonly globalVariableOptions = (): QueryBuilderOption[] => this.getVariableOptions();
 
   abstract runQuery(query: ResultsQuery, options: DataQueryRequest): Promise<DataFrameDTO>;
 
@@ -88,6 +89,12 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
       data: queryResponse,
       totalCount,
     };
+  }
+
+  private getVariableOptions() {
+    return this.templateSrv
+      .getVariables()
+      .map(variable => ({ label: '$' + variable.name, value: '$' + variable.name }));
   }
 
   async loadWorkspaces(): Promise<void> {

--- a/src/datasources/results/components/ResultsQueryEditor.scss
+++ b/src/datasources/results/components/ResultsQueryEditor.scss
@@ -1,4 +1,7 @@
 .horizontal-control-group {
   display: flex;
-  align-items: center;
+}
+
+.right-query-controls {
+  padding-left: 8px;
 }

--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -76,7 +76,6 @@ describe('ResultsQueryEditor', () => {
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining(defaultResultsQuery));
         expect(mockOnRunQuery).toHaveBeenCalled();
-        expect(mockDatasource.getQueryResultsDataSource).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -11,6 +11,7 @@ const mockOnChange = jest.fn();
 const mockOnRunQuery = jest.fn();
 const mockDatasource = {
   prepareQuery: jest.fn((query: ResultsQuery) => query),
+  getQueryResultsDataSource: jest.fn(() => ({}))
 } as unknown as ResultsDataSource;
 
 const defaultProps: QueryEditorProps<ResultsDataSource, ResultsQuery> = {
@@ -75,6 +76,7 @@ describe('ResultsQueryEditor', () => {
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining(defaultResultsQuery));
         expect(mockOnRunQuery).toHaveBeenCalled();
+        expect(mockDatasource.getQueryResultsDataSource).not.toHaveBeenCalled();
       });
     });
   });
@@ -97,6 +99,25 @@ describe('ResultsQueryEditor', () => {
 
       expect(renderResult.queryByTestId('query-steps-editor')).toBeInTheDocument();
       expect(renderResult.queryByTestId('query-results-editor')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Datasource', () => {
+    test('should call getQueryResultsDataSource when query type is results', () => {
+      renderElement();
+
+      expect(mockDatasource.getQueryResultsDataSource).toHaveBeenCalled();
+    });
+
+    test('should not call getQueryResultsDataSource when query type is steps', () => {
+      const query = {
+        refId: 'A',
+        queryType: QueryType.Steps,
+      };
+
+      renderElement(query);
+
+      expect(mockDatasource.getQueryResultsDataSource).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -53,7 +53,6 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
         <QueryResultsEditor
           query={query as QueryResults} 
           handleQueryChange={handleQueryChange}
-          datasource={datasource.getQueryResultsDataSource()}
         />
       )}
       {query.queryType === QueryType.Steps && (

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -53,6 +53,7 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
         <QueryResultsEditor
           query={query as QueryResults} 
           handleQueryChange={handleQueryChange}
+          datasource={datasource.getQueryResultsDataSource()}
         />
       )}
       {query.queryType === QueryType.Steps && (

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
@@ -1,169 +1,197 @@
-import { setupRenderer } from 'test/fixtures';
-import { act, screen, waitFor } from '@testing-library/react';
-import { QueryType } from '../../../types/types';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { OutputType, QueryType } from '../../../types/types';
 import { select } from 'react-select-event';
 import userEvent from '@testing-library/user-event';
-import { ResultsQueryEditor } from '../../ResultsQueryEditor';
-import { QueryResults } from 'datasources/results/types/QueryResults.types';
 import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
-import { ResultsDataSource } from '../../../ResultsDataSource';
+import { QueryResultsEditor } from './QueryResultsEditor';
+import React from 'react';
 
-class MockQueryResultsDataSource extends QueryResultsDataSource {
-  constructor() {
-    super({} as any, {} as any, {} as any);
-  }
+jest.mock('../../query-builders/query-results/ResultsQueryBuilder', () => ({
+  ResultsQueryBuilder: jest.fn(({ filter, workspaces, partNumbers, status, globalVariableOptions, onChange }) => {
+    return (
+      <div data-testid="results-query-builder">
+        <div data-testid="filter">{filter}</div>
+        <div data-testid="workspaces">{JSON.stringify(workspaces)}</div>
+        <div data-testid="part-numbers">{JSON.stringify(partNumbers)}</div>
+        <div data-testid="status">{JSON.stringify(status)}</div>
+        <div data-testid="global-vars">{JSON.stringify(globalVariableOptions)}</div>
+        <button data-testid="trigger-change" onClick={() => onChange({ detail: { linq: 'workspace = "Workspace1"' } })}>
+          Trigger Change
+        </button>
+      </div>
+    );
+  }),
+}));
 
-  // Override the methods that make HTTP requests
-  async loadWorkspaces() {
-    return Promise.resolve();
-  }
+jest.mock('../../../types/types', () => ({
+  ...jest.requireActual('../../../types/types'),
+  TestMeasurementStatus: {
+    Passed: 'PASSED',
+    Failed: 'FAILED',
+  },
+}));
 
-  async getResultsPartNumbers() {
-    return Promise.resolve();
-  }
+const mockWorkspaces = ['Workspace1', 'Workspace2'];
+const mockPartNumbers = ['PN1', 'PN2', 'PN3'];
+const mockGlobalVars = [{ label: '$var1', value: '$var1' }];
 
-  globalVariableOptions = () => {
-    return [];
-  };
-}
+const mockDatasource = {
+  loadWorkspaces: jest.fn().mockResolvedValue(undefined),
+  getResultsPartNumbers: jest.fn().mockResolvedValue(undefined),
+  workspacesCache: new Map(mockWorkspaces.map(workspace => [workspace, workspace])),
+  partNumbersCache: new Map(mockPartNumbers.map(partNumber => [partNumber, partNumber])),
+  globalVariableOptions: jest.fn(() => mockGlobalVars),
+} as unknown as QueryResultsDataSource;
 
-class MockResultsDataSource extends ResultsDataSource {
-  getQueryResultsDataSource() {
-    return new MockQueryResultsDataSource();
-  }
-}
-
-// Set up our renderer function that uses the mock data source
-const render = setupRenderer(ResultsQueryEditor, MockResultsDataSource);
-
-let onChange: jest.Mock<any, any>;
+const mockHandleQueryChange = jest.fn();
 let properties: HTMLElement;
 let orderBy: HTMLElement;
 let descending: HTMLElement;
 let recordCount: HTMLElement;
 let dataOutput: HTMLElement;
 let totalCountOutput: HTMLElement;
+let useTimeRange: HTMLElement;
+let useTimeRangeFor: HTMLElement;
 
 describe('QueryResultsEditor', () => {
   beforeEach(async () => {
-    // Clear all mocks before each test
-    jest.clearAllMocks();
-    
-    // Render the component
-    [onChange] = await act(async () => render({
-      refId: '',
-      queryType: QueryType.Results,
-      outputType: 'Data',
-      properties: [],
-      orderBy: undefined,
-      descending: false,
-      recordCount: 1000,
-      useTimeRange: true,
-      useTimeRangeFor: undefined,
-    } as QueryResults));
-    
-    // Get the elements from the screen
+    await act(async () => {
+      render(
+        <QueryResultsEditor
+          query={{
+            refId: 'A',
+            queryType: QueryType.Results,
+            outputType: OutputType.Data,
+            properties: [],
+            orderBy: 'STARTED_AT',
+            descending: true,
+            recordCount: 1000,
+            useTimeRange: true,
+            useTimeRangeFor: 'Updated',
+            queryBy: 'partNumber = "PN1"',
+          }}
+          handleQueryChange={mockHandleQueryChange}
+          datasource={mockDatasource}
+        />
+      );
+    });
     properties = screen.getAllByRole('combobox')[0];
-    orderBy = screen.getAllByRole('combobox')[1];
-    descending = screen.getAllByRole('checkbox')[0];
+    orderBy = screen.getAllByRole('combobox')[2];
+    descending = screen.getAllByRole('checkbox')[1];
     dataOutput = screen.getByRole('radio', { name: 'Data' });
     totalCountOutput = screen.getByRole('radio', { name: 'Total Count' });
     recordCount = screen.getByDisplayValue(1000);
+    useTimeRange = screen.getAllByRole('checkbox')[0];
+    useTimeRangeFor = screen.getAllByRole('combobox')[1];
   });
 
-  describe('Data outputType', () => {
-    let useTimeRange: HTMLElement;
-    let useTimeRangeFor: HTMLElement;
+  test('should render with default query when default values are provided', async () => {
+    expect(properties).toBeInTheDocument();
+    expect(properties).toHaveDisplayValue('');
+    expect(dataOutput).toBeInTheDocument();
+    expect(dataOutput).toBeChecked();
+    expect(orderBy).toBeInTheDocument();
+    expect(screen.getAllByText('Started At').length).toBe(1);
+    expect(descending).toBeInTheDocument();
+    expect(descending).toBeChecked();
+    expect(recordCount).toBeInTheDocument();
+    expect(recordCount).toHaveValue(1000);
+    expect(useTimeRange).toBeInTheDocument();
+    expect(useTimeRange).toBeChecked();
+    expect(useTimeRangeFor).toBeInTheDocument();
+    expect(screen.getAllByText('Updated').length).toBe(1);
+  });
 
-    beforeEach(() => {
-      useTimeRange = screen.getAllByRole('checkbox')[1];
-      useTimeRangeFor = screen.getAllByRole('combobox')[2];
+  test('should update properties when user adds a property', async () => {
+    await select(properties, 'properties', { container: document.body });
+    await waitFor(() => {
+      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ properties: ['properties'] }));
     });
+  });
 
-    test('renders with default query', async () => {
-      expect(properties).toBeInTheDocument();
-      expect(properties).toHaveDisplayValue('');
-      expect(dataOutput).toBeInTheDocument();
-      expect(dataOutput).toBeChecked();
-      expect(orderBy).toBeInTheDocument();
-      expect(orderBy).toHaveAccessibleDescription('Select field to order by');
-      expect(descending).toBeInTheDocument();
-      expect(descending).not.toBeChecked();
-      expect(recordCount).toBeInTheDocument();
-      expect(recordCount).toHaveValue(1000);
-      expect(useTimeRange).toBeInTheDocument();
-      expect(useTimeRange).toBeChecked();
-      expect(useTimeRangeFor).toBeInTheDocument();
-      expect(useTimeRangeFor).toHaveAccessibleDescription('Choose');
+  test('should update orderBy when user changes the orderBy', async () => {
+    await select(orderBy, 'Started At', { container: document.body });
+    await waitFor(() => {
+      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ orderBy: 'STARTED_AT' }));
     });
+  });
 
-    test('updates when user makes changes', async () => {
-      // User adds a properties
-      await select(properties, 'properties', { container: document.body });
-      await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ properties: ['properties'] }));
-      });
+  test('should update descending when user clicks on the descending checkbox', async () => {
+    await userEvent.click(descending);
+    await waitFor(() => {
+      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ descending: false }));
+    });
+  });
 
-      // User changes order by
-      await select(orderBy, 'Started At', { container: document.body });
-      await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ orderBy: 'STARTED_AT' }));
-      });
-
-      // User changes descending checkbox
-      await userEvent.click(descending);
-      await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ descending: true }));
-      });
-
-      // User enters numeric value for record count
+  describe('recordCount', () => {
+    test('should update record count when user enters numeric values in the take', async () => {
       await userEvent.clear(recordCount);
       await userEvent.type(recordCount, '500');
       await waitFor(() => {
         expect(recordCount).toHaveValue(500);
       });
+    });
 
-      // User enters non-numeric value for record count
+    test('should not update record count when user enters non-numeric values in the take', async () => {
       await userEvent.clear(recordCount);
       await userEvent.type(recordCount, 'Test');
       await waitFor(() => {
         expect(recordCount).toHaveValue(null);
       });
-
-      // User changes useTimeRange checkbox
-      await userEvent.click(useTimeRange);
-      await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ useTimeRange: false }));
-      });
-
-      // User changes useTimeRangeFor
-      await userEvent.click(useTimeRange); // To enable useTimeRangeFor
-      await select(useTimeRangeFor, 'Updated', { container: document.body });
-      await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ useTimeRangeFor: 'Updated' }));
-      });
-
-      // User changes output type to Total Count
-      await userEvent.click(totalCountOutput);
-      await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ outputType: 'Total Count' }));
-      });
     });
   });
 
-  describe('Total Count outputType', () => {
-    test('renders correctly when outputType is Total Count', async () => {
-      await userEvent.click(totalCountOutput);
+  test('should call handle query change with total count outputType when user changes the output type to Total Count', async () => {
+    await userEvent.click(totalCountOutput);
+    await waitFor(() => {
+      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ outputType: 'Total Count' }));
+    });
+  });
 
+  describe('ResultsQueryBuilder', () => {
+
+    [OutputType.Data, OutputType.TotalCount].forEach(outputType => {
+      test('should render ResultsQueryBuilder for both Data and TotalCount when component is loaded',async() => {
+        cleanup();
+        await act(async () => {
+          render(
+            <QueryResultsEditor
+              query={{
+                refId: 'A',
+                queryType: QueryType.Results,
+                outputType: outputType,
+              }}
+              handleQueryChange={mockHandleQueryChange}
+              datasource={mockDatasource}
+            />
+          );
+        });
+  
+        expect(screen.getByTestId('results-query-builder')).toBeInTheDocument();
+      })
+    });
+
+    test('should call loadWorkspaces and getResultsPartNumbers when component is loaded',() => {
+      expect(mockDatasource.loadWorkspaces).toHaveBeenCalledTimes(1);
+      expect(mockDatasource.getResultsPartNumbers).toHaveBeenCalledTimes(1);
+    })
+
+    test('should render ResultsQueryBuilder with default props when component is loaded', () => {
+      const resultsQueryBuilder = screen.getByTestId('results-query-builder');
+      expect(resultsQueryBuilder).toBeInTheDocument();
+      expect(screen.getByTestId('filter')).toHaveTextContent('partNumber = "PN1"');
+      expect(screen.getByTestId('workspaces')).toHaveTextContent(JSON.stringify(mockWorkspaces));
+      expect(screen.getByTestId('part-numbers')).toHaveTextContent(JSON.stringify(mockPartNumbers));
+      expect(screen.getByTestId('status')).toHaveTextContent(JSON.stringify(['PASSED', 'FAILED']));
+      expect(screen.getByTestId('global-vars')).toHaveTextContent(JSON.stringify(mockGlobalVars));
+    });
+
+    test('should update queryBy when filter is changed', async () => {
+      const triggerChangeButton = screen.getByTestId('trigger-change');
+      await userEvent.click(triggerChangeButton);
       await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ outputType: 'Total Count' }));
+        expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ queryBy: 'workspace = "Workspace1"' }));
       });
-      expect(properties).not.toBeInTheDocument();
-      expect(orderBy).not.toBeInTheDocument();
-      expect(descending).not.toBeInTheDocument();
-      expect(recordCount).not.toBeInTheDocument();
-      expect(screen.getAllByRole('checkbox')[0]).toBeInTheDocument(); // useTimeRange
-      expect(screen.getAllByRole('combobox')[0]).toBeInTheDocument(); // useTimeRangeFor
     });
   });
 });

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -9,18 +9,39 @@ import {
   VerticalGroup,
 } from '@grafana/ui';
 import { enumToOptions, validateNumericInput } from 'core/utils';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import '../../ResultsQueryEditor.scss';
 import { OrderBy, QueryResults, ResultsProperties } from 'datasources/results/types/QueryResults.types';
-import { OutputType } from 'datasources/results/types/types';
+import { OutputType, TestMeasurementStatus } from 'datasources/results/types/types';
 import { TimeRangeControls } from '../time-range/TimeRangeControls';
+import { Workspace } from 'core/types';
+import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
+import { ResultsQueryBuilder } from '../../query-builders/query-results/ResultsQueryBuilder';
 
 type Props = {
   query: QueryResults;
   handleQueryChange: (query: QueryResults, runQuery?: boolean) => void;
+  datasource: QueryResultsDataSource;
 };
 
-export function QueryResultsEditor({ query, handleQueryChange }: Props) {
+export function QueryResultsEditor({ query, handleQueryChange, datasource }: Props) {
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [partNumbers, setPartNumbers] = useState<string[]>([]);
+
+  useEffect(() => {
+    const loadWorkspaces = async () => {
+      await datasource.loadWorkspaces();
+      setWorkspaces(Array.from(datasource.workspacesCache.values()));
+    };
+    const loadPartNumbers = async () => {
+      await datasource.getResultsPartNumbers();
+      setPartNumbers(Array.from(datasource.partNumbersCache.values()));
+    };
+
+    loadWorkspaces();
+    loadPartNumbers();
+  }, [datasource]);
+
   const onOutputChange = (value: OutputType) => {
     handleQueryChange({ ...query, outputType: value });
   };
@@ -44,6 +65,10 @@ export function QueryResultsEditor({ query, handleQueryChange }: Props) {
     handleQueryChange({ ...query, recordCount: value });
   };
 
+  const onParameterChange = (value: string) => {
+    console.log(value)
+  }
+
   return (
     <>
       <VerticalGroup>
@@ -55,25 +80,45 @@ export function QueryResultsEditor({ query, handleQueryChange }: Props) {
           />
         </InlineField>
         {query.outputType === OutputType.Data && (
-          <VerticalGroup>
-            <InlineField label="Properties" labelWidth={25} tooltip={tooltips.properties}>
-              <MultiSelect
-                placeholder="Select properties to fetch"
-                options={enumToOptions(ResultsProperties)}
-                onChange={onPropertiesChange}
-                value={query.properties}
-                defaultValue={query.properties!}
-                noMultiValueWrap={true}
-                maxVisibleValues={5}
-                width={60}
-                allowCustomValue={false}
-                closeMenuOnSelect={false}
-              />
-            </InlineField>
-            <div>
+          <InlineField label="Properties" labelWidth={25} tooltip={tooltips.properties}>
+            <MultiSelect
+              placeholder="Select properties to fetch"
+              options={enumToOptions(ResultsProperties)}
+              onChange={onPropertiesChange}
+              value={query.properties}
+              defaultValue={query.properties!}
+              noMultiValueWrap={true}
+              maxVisibleValues={5}
+              width={60}
+              allowCustomValue={false}
+              closeMenuOnSelect={false}
+            />
+          </InlineField>
+        )}
+        <div>
+        <TimeRangeControls
+          query={query}
+          handleQueryChange={(updatedQuery, runQuery) => {
+            handleQueryChange(updatedQuery as QueryResults, runQuery);
+          }}
+        />
+        <div className="horizontal-control-group">
+          <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
+            <ResultsQueryBuilder
+              filter={query.queryBy}
+              workspaces={workspaces}
+              partNumbers={partNumbers}
+              status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
+              globalVariableOptions={datasource.globalVariableOptions()}
+              onChange={(event: any) => onParameterChange(event.detail.linq)}>
+            </ResultsQueryBuilder>
+          </InlineField>
+          {query.outputType === OutputType.Data && (
+            <div className="right-query-controls">
               <div className="horizontal-control-group">
                 <InlineField label="OrderBy" labelWidth={25} tooltip={tooltips.orderBy}>
                   <Select
+                    width={25}
                     options={OrderBy as SelectableValue[]}
                     placeholder="Select field to order by"
                     onChange={onOrderByChange}
@@ -90,8 +135,8 @@ export function QueryResultsEditor({ query, handleQueryChange }: Props) {
               </div>
               <InlineField label="Take" labelWidth={25} tooltip={tooltips.recordCount}>
                 <AutoSizeInput
-                  minWidth={20}
-                  maxWidth={40}
+                  minWidth={25}
+                  maxWidth={25}
                   type="number"
                   defaultValue={query.recordCount}
                   onCommitChange={recordCountChange}
@@ -99,23 +144,10 @@ export function QueryResultsEditor({ query, handleQueryChange }: Props) {
                   onKeyDown={(event) => {validateNumericInput(event)}}
                 />
               </InlineField>
-              <TimeRangeControls
-                query={query}
-                handleQueryChange={(updatedQuery, runQuery) => {
-                  handleQueryChange(updatedQuery as QueryResults, runQuery);
-                }}
-              />
             </div>
-          </VerticalGroup>
-        )}
-        {query.outputType === OutputType.TotalCount && (
-          <TimeRangeControls
-            query={query}
-            handleQueryChange={(updatedQuery, runQuery) => {
-              handleQueryChange(updatedQuery as QueryResults, runQuery);
-            }}
-          />
-        )}
+          )}
+        </div>
+        </div>
       </VerticalGroup>
     </>
   );
@@ -127,4 +159,5 @@ const tooltips = {
   recordCount: 'This field sets the maximum number of results.',
   orderBy: 'This field orders the query results by field.',
   descending: 'This field returns the query results in descending order.',
+  queryBy: 'Specifies the filter to be applied on the queried results. This is an optional field.',
 };

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -105,7 +105,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           }}
         />
         <div className="horizontal-control-group">
-          <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
+          <InlineField label="Query By" labelWidth={25}>
             <ResultsQueryBuilder
               filter={query.queryBy}
               workspaces={workspaces}
@@ -161,5 +161,4 @@ const tooltips = {
   recordCount: 'This field sets the maximum number of results.',
   orderBy: 'This field orders the query results by field.',
   descending: 'This field returns the query results in descending order.',
-  queryBy: 'Specifies the filter to be applied on the queried results. This is an optional field.',
 };

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -9,40 +9,18 @@ import {
   VerticalGroup,
 } from '@grafana/ui';
 import { enumToOptions, validateNumericInput } from 'core/utils';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import '../../ResultsQueryEditor.scss';
 import { OrderBy, QueryResults, ResultsProperties } from 'datasources/results/types/QueryResults.types';
-import { OutputType, TestMeasurementStatus } from 'datasources/results/types/types';
+import { OutputType } from 'datasources/results/types/types';
 import { TimeRangeControls } from '../time-range/TimeRangeControls';
-import { ResultsQueryBuilder } from '../../query-builders/query-results/ResultsQueryBuilder';
-import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
-import { Workspace } from 'core/types';
 
 type Props = {
   query: QueryResults;
   handleQueryChange: (query: QueryResults, runQuery?: boolean) => void;
-  datasource: QueryResultsDataSource
 };
 
-export function QueryResultsEditor({ query, handleQueryChange,datasource }: Props) {
-
-  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [partNumbers, setPartNumbers] = useState<string[]>([]);
-  
-  useEffect(() => {
-    const loadWorkspaces = async () => {
-      await datasource.loadWorkspaces();
-      setWorkspaces(Array.from(datasource.workspacesCache.values()));
-    };
-    const loadPartNumbers = async () => {
-      await datasource.getResultsPartNumbers();
-      setPartNumbers(Array.from(datasource.partNumbersCache.values()));
-    };
-
-    loadWorkspaces();
-    loadPartNumbers();
-  }, [datasource]);
-
+export function QueryResultsEditor({ query, handleQueryChange }: Props) {
   const onOutputChange = (value: OutputType) => {
     handleQueryChange({ ...query, outputType: value });
   };
@@ -65,10 +43,6 @@ export function QueryResultsEditor({ query, handleQueryChange,datasource }: Prop
     const value = parseInt((event.target as HTMLInputElement).value, 10);
     handleQueryChange({ ...query, recordCount: value });
   };
-
-  const onParameterChange = (value: string) => {
-    console.log(value)
-  }
 
   return (
     <>
@@ -142,14 +116,6 @@ export function QueryResultsEditor({ query, handleQueryChange,datasource }: Prop
             }}
           />
         )}
-        <ResultsQueryBuilder
-          filter={query.queryBy}
-          workspaces={workspaces}
-          partNumbers={partNumbers}
-          status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
-          globalVariableOptions={datasource.globalVariableOptions()}
-          onChange={(event: any) => onParameterChange(event.detail.linq)}>
-        </ResultsQueryBuilder>
       </VerticalGroup>
     </>
   );

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -66,7 +66,9 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
   };
 
   const onParameterChange = (value: string) => {
-    console.log(value)
+    if (query.queryBy !== value) {
+      handleQueryChange({ ...query, queryBy: value });
+    }
   }
 
   return (

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
@@ -1,0 +1,77 @@
+import { QueryBuilderOption, Workspace } from "core/types";
+import React, { ReactNode } from "react";
+import { ResultsQueryBuilder } from "./ResultsQueryBuilder";
+import { render } from "@testing-library/react";
+
+describe('ResultsQueryBuilder', () => {
+  describe('useEffects', () => {
+    let reactNode: ReactNode
+
+    const containerClass = 'smart-filter-group-condition-container';
+    const workspace = { id: '1', name: 'Selected workspace' } as Workspace;
+    const partNumber = ['partNumber1', 'partNumber2'];
+    const status = ['PASSED', 'FAILED'];
+
+    function renderElement(workspaces: Workspace[], partNumbers: string[], status: string[], filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
+      reactNode = React.createElement(ResultsQueryBuilder, { filter, workspaces, partNumbers, status, globalVariableOptions, onChange: jest.fn(), });
+      const renderResult = render(reactNode);
+      return {
+        renderResult,
+        conditionsContainer: renderResult.container.getElementsByClassName(`${containerClass}`)
+      };
+    }
+
+    it('should render empty query builder', () => {
+      const { renderResult, conditionsContainer } = renderElement([], [], [], '');
+
+      expect(conditionsContainer.length).toBe(1);
+      expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
+    })
+
+    it('should select workspace in query builder', () => {
+      const { conditionsContainer } = renderElement([workspace], partNumber, status, 'Workspace = "1" && PartNumber = "partNumber1"');
+
+      expect(conditionsContainer?.length).toBe(2);
+      expect(conditionsContainer.item(0)?.textContent).toContain(workspace.name);
+      expect(conditionsContainer.item(1)?.textContent).toContain("partNumber1");
+    })
+
+    it('should select part number in query builder', () => {
+      const { conditionsContainer } = renderElement([workspace], partNumber, status,  'PartNumber = "partNumber1"');
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain("partNumber1");
+    });
+
+    it('should select status in query builder', () => {
+      const { conditionsContainer } = renderElement([workspace], partNumber, status, 'Status = "PASSED"');
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain("PASSED");
+    });
+
+    it('should select global variable option', () => {
+      const globalVariableOption = { label: 'Global variable', value: 'global_variable' };
+      const { conditionsContainer } = renderElement([workspace], partNumber, status, 'PartNumber = \"global_variable\"', [globalVariableOption]);
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
+    });
+
+    [['${__from:date}', 'From'], ['${__to:date}', 'To'], ['${__now:date}', 'Now']].forEach(([value, label]) => {
+      it(`should select user friendly value for updated date`, () => {
+        const { conditionsContainer } = renderElement([workspace], partNumber, status, `UpdatedAt > \"${value}\"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+      });
+    });
+
+    it('should sanitize fields in query builder', () => {
+      const { conditionsContainer } = renderElement([workspace], partNumber, status, 'Family = "<script>alert(\'Family\')</script>"');
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.innerHTML).not.toContain('alert(\'Family\')');
+    })
+  });
+});

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
@@ -29,25 +29,30 @@ describe('ResultsQueryBuilder', () => {
     })
 
     it('should select workspace in query builder', () => {
-      const { conditionsContainer } = renderElement([workspace], partNumber, status, 'Workspace = "1" && PartNumber = "partNumber1"');
+      const { conditionsContainer } = renderElement([workspace], partNumber, status, 'Workspace = "1"');
 
-      expect(conditionsContainer?.length).toBe(2);
-      expect(conditionsContainer.item(0)?.textContent).toContain(workspace.name);
-      expect(conditionsContainer.item(1)?.textContent).toContain("partNumber1");
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain("Workspace"); //label
+      expect(conditionsContainer.item(0)?.textContent).toContain("Equals"); //operator
+      expect(conditionsContainer.item(0)?.textContent).toContain(workspace.name); //value
     })
 
     it('should select part number in query builder', () => {
       const { conditionsContainer } = renderElement([workspace], partNumber, status,  'PartNumber = "partNumber1"');
 
       expect(conditionsContainer?.length).toBe(1);
-      expect(conditionsContainer.item(0)?.textContent).toContain("partNumber1");
+      expect(conditionsContainer.item(0)?.textContent).toContain("Part number"); //label
+      expect(conditionsContainer.item(0)?.textContent).toContain("Equals"); //operator
+      expect(conditionsContainer.item(0)?.textContent).toContain("partNumber1"); //value
     });
 
     it('should select status in query builder', () => {
       const { conditionsContainer } = renderElement([workspace], partNumber, status, 'Status = "PASSED"');
 
       expect(conditionsContainer?.length).toBe(1);
-      expect(conditionsContainer.item(0)?.textContent).toContain("PASSED");
+      expect(conditionsContainer.item(0)?.textContent).toContain("Status"); //label
+      expect(conditionsContainer.item(0)?.textContent).toContain("Equals"); //operator
+      expect(conditionsContainer.item(0)?.textContent).toContain("PASSED"); //value
     });
 
     it('should select global variable option', () => {
@@ -55,7 +60,27 @@ describe('ResultsQueryBuilder', () => {
       const { conditionsContainer } = renderElement([workspace], partNumber, status, 'PartNumber = \"global_variable\"', [globalVariableOption]);
 
       expect(conditionsContainer?.length).toBe(1);
-      expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
+      expect(conditionsContainer.item(0)?.textContent).toContain("Part number"); //label
+      expect(conditionsContainer.item(0)?.textContent).toContain("Equals"); //operator
+      expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label); //value
+    });
+
+    it('should render multiple conditions in query builder', () => {
+      const filter = '(PartNumber = "partNumber1" && ProgramName = "programName1") || Status = "FAILED"';
+      const { renderResult, conditionsContainer } = renderElement([workspace], partNumber, status, filter);
+      const filterConditions = renderResult.container.getElementsByClassName('smart-filter-group-condition');
+      const logicalOperators = renderResult.container.getElementsByClassName('smart-filter-group-operator');
+;    
+      expect(conditionsContainer?.length).toBe(2);
+      expect(filterConditions?.length).toBe(3);
+      expect(logicalOperators?.length).toBe(2);
+
+      expect(logicalOperators?.item(0)?.textContent).toContain("And");
+      expect(logicalOperators?.item(1)?.textContent).toContain("Or");
+
+      expect(filterConditions.item(0)?.textContent).toContain('partNumber1');
+      expect(filterConditions.item(1)?.textContent).toContain('programName1');
+      expect(filterConditions.item(2)?.textContent).toContain('FAILED');
     });
 
     [['${__from:date}', 'From'], ['${__to:date}', 'To'], ['${__now:date}', 'Now']].forEach(([value, label]) => {
@@ -63,7 +88,9 @@ describe('ResultsQueryBuilder', () => {
         const { conditionsContainer } = renderElement([workspace], partNumber, status, `UpdatedAt > \"${value}\"`);
 
         expect(conditionsContainer?.length).toBe(1);
-        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        expect(conditionsContainer.item(0)?.textContent).toContain("Updated"); //label
+        expect(conditionsContainer.item(0)?.textContent).toContain("Greater than"); //operator
+        expect(conditionsContainer.item(0)?.textContent).toContain(label); //value
       });
     });
 
@@ -73,5 +100,28 @@ describe('ResultsQueryBuilder', () => {
       expect(conditionsContainer?.length).toBe(1);
       expect(conditionsContainer.item(0)?.innerHTML).not.toContain('alert(\'Family\')');
     })
+
+    describe('theme', () => {  
+      const mockUseTheme = jest.spyOn(require('@grafana/ui'), 'useTheme2');
+
+      beforeEach(() => {
+        jest.spyOn(document.body, 'setAttribute')
+      });
+      
+      it('should set light theme when isDark is false', () => {
+        mockUseTheme.mockReturnValue({ isDark: false });
+        
+        renderElement([], [], [], '');
+       
+        expect(document.body.setAttribute).toHaveBeenCalledWith('theme', 'orange');
+      });
+      it('should set dark theme when isDark is true', () => {
+        mockUseTheme.mockReturnValue({ isDark: true });
+
+        renderElement([], [], [], '');
+  
+        expect(document.body.setAttribute).toHaveBeenCalledWith('theme', 'dark-orange');
+      });
+    });
   });
 });

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -47,7 +47,6 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
 
   const workspaceField = useMemo(() => {
     const workspaceField = ResultsQueryBuilderFields.WORKSPACE;
-
     return {
       ...workspaceField,
       lookup: {
@@ -62,7 +61,6 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
 
   const statusField = useMemo(() => {
     const statusField = ResultsQueryBuilderFields.STATUS;
-
     return {
       ...statusField,
       lookup: {
@@ -109,7 +107,6 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
 
   const partNumberField = useMemo(() => {
     const partNumberField = ResultsQueryBuilderFields.PARTNUMBER;
-
     return {
       ...partNumberField,
       lookup: {
@@ -123,7 +120,14 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
   }, [partNumbers]);
 
   useEffect(() => {
-    const updatedFields = [partNumberField, ...ResultsQueryBuilderStaticFields!, updatedAtField, workspaceField, startedAtField, statusField].map(
+    const updatedFields = [
+      partNumberField,
+      ...ResultsQueryBuilderStaticFields!,
+      updatedAtField,
+      workspaceField,
+      startedAtField,
+      statusField
+    ].map(
       field => {
         if (field.lookup?.dataSource) {
           return {
@@ -195,7 +199,9 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
       messages={queryBuilderMessages}
       onChange={onChange}
       value={sanitizedFilter}
-      showIcons
+      autoPrompt={true}
+      applyMode="immediately"
+      fieldsMode="static"
     />
   );
 };

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -1,0 +1,201 @@
+import { useTheme2 } from '@grafana/ui';
+import { queryBuilderMessages, QueryBuilderOperations } from 'core/query-builder.constants';
+import { expressionBuilderCallback, expressionReaderCallback } from 'core/query-builder.utils';
+import { Workspace, QueryBuilderOption } from 'core/types';
+import { filterXSSField, filterXSSLINQExpression } from 'core/utils';
+
+import React, { useState, useEffect, useMemo } from 'react';
+import QueryBuilder, { QueryBuilderCustomOperation, QueryBuilderProps } from 'smart-webcomponents-react/querybuilder';
+
+import 'smart-webcomponents-react/source/styles/smart.dark-orange.css';
+import 'smart-webcomponents-react/source/styles/smart.orange.css';
+import 'smart-webcomponents-react/source/styles/components/smart.base.css';
+import 'smart-webcomponents-react/source/styles/components/smart.common.css';
+import 'smart-webcomponents-react/source/styles/components/smart.querybuilder.css';
+import { QBField } from 'datasources/results/types/QueryResults.types';
+import {
+  ResultsQueryBuilderFields,
+  ResultsQueryBuilderStaticFields,
+} from 'datasources/results/constants/ResultsQueryBuilder.constants';
+
+type ResultsQueryBuilderProps = QueryBuilderProps &
+  React.HTMLAttributes<Element> & {
+    filter?: string;
+    workspaces: Workspace[];
+    partNumbers: string[];
+    status: string[];
+    globalVariableOptions: QueryBuilderOption[];
+  };
+
+export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
+  filter,
+  onChange,
+  workspaces,
+  partNumbers,
+  status,
+  globalVariableOptions,
+}) => {
+  const theme = useTheme2();
+  document.body.setAttribute('theme', theme.isDark ? 'dark-orange' : 'orange');
+
+  const [fields, setFields] = useState<QBField[]>([]);
+  const [operations, setOperations] = useState<QueryBuilderCustomOperation[]>([]);
+
+  const sanitizedFilter = useMemo(() => {
+    return filterXSSLINQExpression(filter);
+  }, [filter]);
+
+  const workspaceField = useMemo(() => {
+    const workspaceField = ResultsQueryBuilderFields.WORKSPACE;
+
+    return {
+      ...workspaceField,
+      lookup: {
+        ...workspaceField.lookup,
+        dataSource: [
+          ...(workspaceField.lookup?.dataSource || []),
+          ...workspaces.map(({ id, name }) => ({ label: name, value: id })),
+        ],
+      },
+    };
+  }, [workspaces]);
+
+  const statusField = useMemo(() => {
+    const statusField = ResultsQueryBuilderFields.STATUS;
+
+    return {
+      ...statusField,
+      lookup: {
+        ...statusField.lookup,
+        dataSource: [
+          ...(statusField.lookup?.dataSource || []),
+          ...status.map(name => ({ label: name, value: name })),
+        ],
+      },
+    };
+  }, [status]);
+
+  const updatedAtField = useMemo(() => {
+    const updatedField = ResultsQueryBuilderFields.UPDATEDAT;
+    return {
+      ...updatedField,
+      lookup: {
+        ...updatedField.lookup,
+        dataSource: [
+          ...(updatedField.lookup?.dataSource || []),
+          { label: 'From', value: '${__from:date}' },
+          { label: 'To', value: '${__to:date}' },
+          { label: 'Now', value: '${__now:date}' },
+        ],
+      },
+    };
+  }, []);
+
+  const startedAtField = useMemo(() => {
+    const startedField = ResultsQueryBuilderFields.STARTEDAT;
+    return {
+      ...startedField,
+      lookup: {
+        ...startedField.lookup,
+        dataSource: [
+          ...(startedField.lookup?.dataSource || []),
+          { label: 'From', value: '${__from:date}' },
+          { label: 'To', value: '${__to:date}' },
+          { label: 'Now', value: '${__now:date}' },
+        ],
+      },
+    };
+  }, []);
+
+  const partNumberField = useMemo(() => {
+    const partNumberField = ResultsQueryBuilderFields.PARTNUMBER;
+
+    return {
+      ...partNumberField,
+      lookup: {
+        ...partNumberField.lookup,
+        dataSource: [
+          ...(partNumberField.lookup?.dataSource || []),
+          ...partNumbers.map(partNumber => ({ label: partNumber, value: partNumber })),
+        ],
+      },
+    };
+  }, [partNumbers]);
+
+  useEffect(() => {
+    const updatedFields = [partNumberField, ...ResultsQueryBuilderStaticFields!, updatedAtField, workspaceField, startedAtField, statusField].map(
+      field => {
+        if (field.lookup?.dataSource) {
+          return {
+            ...field,
+            lookup: {
+              dataSource: [...globalVariableOptions, ...field.lookup!.dataSource].map(filterXSSField),
+            },
+          };
+        }
+        return field;
+      }
+    );
+
+    setFields(updatedFields);
+
+    const options = Object.values(updatedFields).reduce((accumulator, fieldConfig) => {
+      if (fieldConfig.lookup) {
+        accumulator[fieldConfig.dataField!] = fieldConfig.lookup.dataSource;
+      }
+
+      return accumulator;
+    }, {} as Record<string, QueryBuilderOption[]>);
+
+    const callbacks = {
+      expressionBuilderCallback: expressionBuilderCallback(options),
+      expressionReaderCallback: expressionReaderCallback(options),
+    };
+
+    const customOperations = [
+      QueryBuilderOperations.EQUALS,
+      QueryBuilderOperations.DOES_NOT_EQUAL,
+      QueryBuilderOperations.STARTS_WITH,
+      QueryBuilderOperations.ENDS_WITH,
+      QueryBuilderOperations.CONTAINS,
+      QueryBuilderOperations.DOES_NOT_CONTAIN,
+      QueryBuilderOperations.LESS_THAN,
+      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO,
+      QueryBuilderOperations.GREATER_THAN,
+      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO,
+      QueryBuilderOperations.IS_BLANK,
+      QueryBuilderOperations.IS_NOT_BLANK,
+    ].map(operation => {
+      return {
+        ...operation,
+        ...callbacks,
+      };
+    });
+
+    const keyValueOperations = [
+      QueryBuilderOperations.KEY_VALUE_MATCH,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_MATCH,
+      QueryBuilderOperations.KEY_VALUE_CONTAINS,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_CONTAINS,
+      QueryBuilderOperations.KEY_VALUE_IS_GREATER_THAN,
+      QueryBuilderOperations.KEY_VALUE_IS_GREATER_THAN_OR_EQUAL,
+      QueryBuilderOperations.KEY_VALUE_IS_LESS_THAN,
+      QueryBuilderOperations.KEY_VALUE_IS_LESS_THAN_OR_EQUAL,
+      QueryBuilderOperations.KEY_VALUE_IS_NUMERICAL_EQUAL,
+      QueryBuilderOperations.KEY_VALUE_IS_NUMERICAL_NOT_EQUAL,
+    ];
+
+    setOperations([...customOperations, ...keyValueOperations]);
+  }, [workspaceField, startedAtField, updatedAtField, partNumberField, globalVariableOptions, statusField]);
+
+  return (
+    <QueryBuilder
+      customOperations={operations}
+      fields={fields}
+      messages={queryBuilderMessages}
+      onChange={onChange}
+      value={sanitizedFilter}
+      showIcons
+    />
+  );
+};

--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -1,0 +1,174 @@
+import { QueryBuilderOperations } from 'core/query-builder.constants';
+import { QBField } from '../types/QueryResults.types';
+
+export enum ResultsQueryBuilderFieldNames {
+  PART_NUMBER = 'PartNumber',
+  PROGRAM_NAME = 'ProgramName',
+  SERIAL_NUMBER = 'SerialNumber',
+  KEYWORDS = 'Keywords',
+  PROPERTIES = 'Properties',
+  OPERATOR = 'Operator',
+  STARTED_AT = 'StartedAt',
+  UPDATED_AT = 'UpdatedAt',
+  SYSTEM_ID = 'SystemId',
+  WORKSPACE = 'Workspace',
+  STATUS = 'Status',
+  HOSTNAME = 'HostName',
+}
+
+export const ResultsQueryBuilderFields: Record<string, QBField> = {
+  PARTNUMBER: {
+    label: 'Part Number',
+    dataField: ResultsQueryBuilderFieldNames.PART_NUMBER,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.STARTS_WITH.name,
+      QueryBuilderOperations.ENDS_WITH.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  PROGRAMNAME: {
+    label: 'Program Name',
+    dataField: ResultsQueryBuilderFieldNames.PROGRAM_NAME,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  SERIALNUMBER: {
+    label: 'Serial Number',
+    dataField: ResultsQueryBuilderFieldNames.SERIAL_NUMBER,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  KEYWORDS: {
+    label: 'Keywords',
+    dataField: ResultsQueryBuilderFieldNames.KEYWORDS,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+    ],
+  },
+  PROPERTIES: {
+    label: 'Properties',
+    dataField: ResultsQueryBuilderFieldNames.PROPERTIES,
+    dataType: 'object',
+    filterOperations: [
+      QueryBuilderOperations.KEY_VALUE_MATCH.name,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_MATCH.name,
+      QueryBuilderOperations.KEY_VALUE_CONTAINS.name,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_CONTAINS.name,
+      QueryBuilderOperations.KEY_VALUE_IS_GREATER_THAN.name,
+      QueryBuilderOperations.KEY_VALUE_IS_GREATER_THAN_OR_EQUAL.name,
+      QueryBuilderOperations.KEY_VALUE_IS_LESS_THAN.name,
+      QueryBuilderOperations.KEY_VALUE_IS_LESS_THAN_OR_EQUAL.name,
+      QueryBuilderOperations.KEY_VALUE_IS_NUMERICAL_EQUAL.name,
+      QueryBuilderOperations.KEY_VALUE_IS_NUMERICAL_NOT_EQUAL.name,
+    ],
+  },
+  OPERATOR: {
+    label: 'Operator',
+    dataField: ResultsQueryBuilderFieldNames.OPERATOR,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  STARTEDAT: {
+    label: 'Started At',
+    dataField: ResultsQueryBuilderFieldNames.STARTED_AT,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.GREATER_THAN.name,
+      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
+      QueryBuilderOperations.LESS_THAN.name,
+      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  UPDATEDAT: {
+    label: 'Updated At',
+    dataField: ResultsQueryBuilderFieldNames.UPDATED_AT,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.GREATER_THAN.name,
+      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
+      QueryBuilderOperations.LESS_THAN.name,
+      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  SYSTEMID: {
+    label: 'System ID',
+    dataField: ResultsQueryBuilderFieldNames.SYSTEM_ID,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  WORKSPACE: {
+    label: 'Workspace',
+    dataField: ResultsQueryBuilderFieldNames.WORKSPACE,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  STATUS: {
+    label: 'Status',
+    dataField: ResultsQueryBuilderFieldNames.STATUS,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+    ],
+  },
+  HOSTNAME: {
+    label: 'Host Name',
+    dataField: ResultsQueryBuilderFieldNames.HOSTNAME,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+};
+
+// export const ResultsQueryBuilderStaticFields = [
+//   ResultsQueryBuilderFields.PROPERTIES,
+// ];

--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -154,6 +154,9 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
       QueryBuilderOperations.EQUALS.name,
       QueryBuilderOperations.DOES_NOT_EQUAL.name,
     ],
+    lookup: {
+      dataSource: [],
+    },
   },
   HOSTNAME: {
     label: 'Host Name',
@@ -169,6 +172,12 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
   },
 };
 
-// export const ResultsQueryBuilderStaticFields = [
-//   ResultsQueryBuilderFields.PROPERTIES,
-// ];
+export const ResultsQueryBuilderStaticFields = [
+  ResultsQueryBuilderFields.PROGRAMNAME,
+  ResultsQueryBuilderFields.PROPERTIES,
+  ResultsQueryBuilderFields.SYSTEMID,
+  ResultsQueryBuilderFields.KEYWORDS,
+  ResultsQueryBuilderFields.OPERATOR,
+  ResultsQueryBuilderFields.SERIALNUMBER,
+  ResultsQueryBuilderFields.HOSTNAME,
+];

--- a/src/datasources/results/constants/StepsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/StepsQueryBuilder.constants.ts
@@ -1,0 +1,116 @@
+import { QueryBuilderOperations } from 'core/query-builder.constants';
+import { QBField } from '../types/QueryResults.types';
+
+export enum StepsQueryBuilderFieldNames {
+  KEYWORDS = 'keywords',
+  NAME = 'stepName',
+  PATH = 'path',
+  PROPERTIES = 'properties',
+  STATUS = 'status',
+  TYPE = 'stepType',
+  UPDATED_AT = 'updatedAt',
+  WORKSPACE = 'workspace',
+}
+
+export const StepsQueryBuilderFields: Record<string, QBField> = {
+  KEYWORDS: {
+    label: 'Keyword',
+    dataField: StepsQueryBuilderFieldNames.KEYWORDS,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+    ],
+  },
+  NAME: {
+    label: 'Step name',
+    dataField: StepsQueryBuilderFieldNames.NAME,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  PATH: {
+    label: 'Step path',
+    dataField: StepsQueryBuilderFieldNames.PATH,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.STARTS_WITH.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  PROPERTIES: {
+    label: 'Properties',
+    dataField: StepsQueryBuilderFieldNames.PROPERTIES,
+    dataType: 'object',
+    filterOperations: [
+      QueryBuilderOperations.KEY_VALUE_MATCH.name,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_MATCH.name,
+      QueryBuilderOperations.KEY_VALUE_CONTAINS.name,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_CONTAINS.name,
+      QueryBuilderOperations.KEY_VALUE_IS_GREATER_THAN.name,
+      QueryBuilderOperations.KEY_VALUE_IS_GREATER_THAN_OR_EQUAL.name,
+      QueryBuilderOperations.KEY_VALUE_IS_LESS_THAN.name,
+      QueryBuilderOperations.KEY_VALUE_IS_LESS_THAN_OR_EQUAL.name,
+      QueryBuilderOperations.KEY_VALUE_IS_NUMERICAL_EQUAL.name,
+      QueryBuilderOperations.KEY_VALUE_IS_NUMERICAL_NOT_EQUAL.name,
+    ],
+  },
+  STATUS: {
+    label: 'Status',
+    dataField: StepsQueryBuilderFieldNames.STATUS,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  TYPE: {
+    label: 'Step type',
+    dataField: StepsQueryBuilderFieldNames.TYPE,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+    ],
+  },
+  UPDATEDAT: {
+    label: 'Step updated At',
+    dataField: StepsQueryBuilderFieldNames.UPDATED_AT,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.GREATER_THAN.name,
+      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
+      QueryBuilderOperations.LESS_THAN.name,
+      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
+  WORKSPACE: {
+    label: 'Workspace',
+    dataField: StepsQueryBuilderFieldNames.WORKSPACE,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [],
+    },
+  },
+};
+
+export const StepsQueryBuilderStaticFields = [
+  StepsQueryBuilderFields.name,
+  StepsQueryBuilderFields.keywords,
+  StepsQueryBuilderFields.properties,
+  StepsQueryBuilderFields.type,
+];

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -17,6 +17,7 @@ const mockQueryResultsResponse: QueryResultsResponse = {
   ],
   totalCount: 1
 };
+const mockQueryResultsValuesResponse = ["partNumber1", "partNumber2"];
 
 let datastore: QueryResultsDataSource, backendServer: MockProxy<BackendSrv>, templateSrv: MockProxy<TemplateSrv>;
 
@@ -27,6 +28,10 @@ describe('QueryResultsDataSource', () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
       .mockReturnValue(createFetchResponse(mockQueryResultsResponse));
+
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-result-values', method: 'POST' }))
+      .mockReturnValue(createFetchResponse(mockQueryResultsValuesResponse));
   })
 
   describe('queryResults', () => {
@@ -178,6 +183,55 @@ describe('QueryResultsDataSource', () => {
         expect(fields).toEqual([
           { name: 'properties', values: [""], type: 'string' },
         ]);
+    });
+
+    test('returns part numbers', async () => {  
+      await datastore.getResultsPartNumbers();
+  
+      expect(datastore.partNumbersCache.get('partNumber1')).toBe('partNumber1');
+      expect(datastore.partNumbersCache.get('partNumber2')).toBe('partNumber2');
+    });
+
+    test('should not query part number values if cache exists', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-result-values' }))
+        .mockReturnValue(createFetchResponse(['value1']));
+      datastore.partNumbersCache.set('partNumber', 'value1');
+      backendServer.fetch.mockClear();
+  
+      await datastore.query(buildQuery())
+  
+      expect(backendServer.fetch).not.toHaveBeenCalled();
+    });
+
+    test('returns workspaces', async () => {
+      await datastore.loadWorkspaces();
+  
+      expect(datastore.workspacesCache.get('1')).toEqual({"id": "1", "name": "Default workspace"});
+      expect(datastore.workspacesCache.get('2')).toEqual({"id": "2", "name": "Other workspace"});
+    });
+  
+    test('should not query workspace values if cache exists', async () => {
+      const mockWorkspacesResponse = { id: 'workspace1', name: 'workspace1', default: false, enabled: true };
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/niauth/v1/user' }))
+        .mockReturnValue(createFetchResponse(mockWorkspacesResponse));
+      datastore.workspacesCache.set('workspace', mockWorkspacesResponse);
+      backendServer.fetch.mockClear();
+      const query = buildQuery(
+        {
+          refId: 'A',
+          outputType: OutputType.Data
+        },
+      );
+
+      await datastore.query(query)
+  
+      expect(backendServer.fetch).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/niauth/v1/user',
+        })
+      );
     });
   });
 

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -5,7 +5,6 @@ import { OutputType } from "datasources/results/types/types";
 import { defaultResultsQuery } from "datasources/results/defaultQueries";
 import { ExpressionTransformFunction, transformComputedFieldsQuery } from "core/query-builder.utils";
 import { ResultsQueryBuilderFieldNames } from "datasources/results/constants/ResultsQueryBuilder.constants";
-import { QueryBuilderOperations } from "core/query-builder.constants";
 
 export class QueryResultsDataSource extends ResultsDataSourceBase {
   queryResultsUrl = this.baseUrl + '/v2/query-results';

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -3,6 +3,9 @@ import { ResultsDataSourceBase } from "datasources/results/ResultsDataSourceBase
 import { DataQueryRequest, DataFrameDTO, FieldType } from "@grafana/data";
 import { OutputType } from "datasources/results/types/types";
 import { defaultResultsQuery } from "datasources/results/defaultQueries";
+import { ExpressionTransformFunction, transformComputedFieldsQuery } from "core/query-builder.utils";
+import { ResultsQueryBuilderFieldNames } from "datasources/results/constants/ResultsQueryBuilder.constants";
+import { QueryBuilderOperations } from "core/query-builder.constants";
 
 export class QueryResultsDataSource extends ResultsDataSourceBase {
   queryResultsUrl = this.baseUrl + '/v2/query-results';
@@ -38,8 +41,17 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
     await this.getResultsPartNumbers();
     await this.loadWorkspaces();
 
+    if (query.queryBy) {
+      query.queryBy = transformComputedFieldsQuery(
+        this.templateSrv.replace(query.queryBy, options.scopedVars),
+        this.resultsComputedDataFields,
+      );
+    }
+
+    const useTimeRangeFilter = this.getTimeRangeFilter(options, query.useTimeRange, query.useTimeRangeFor);
+
     const responseData = await this.queryResults(
-      this.getTimeRangeFilter(options, query.useTimeRange, query.useTimeRangeFor),
+      [query.queryBy, useTimeRangeFilter].filter(Boolean).join(' && '),
       query.orderBy,
       query.properties,
       query.recordCount,
@@ -98,6 +110,15 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
     partNumbers?.forEach(partNumber => this.partNumbersCache.set(partNumber, partNumber));
   }
 
+  readonly resultsComputedDataFields = new Map<string, ExpressionTransformFunction>(
+    Object.values(ResultsQueryBuilderFieldNames).map(field => [
+      field,
+      field === (ResultsQueryBuilderFieldNames.UPDATED_AT) || field === (ResultsQueryBuilderFieldNames.STARTED_AT)
+        ? this.timeFieldsQuery(field)
+        : this.multipleValuesQuery(field),
+    ])
+  );
+  
   shouldRunQuery(_: QueryResults): boolean {
     return true;
   }

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -6,8 +6,11 @@ import { defaultResultsQuery } from "datasources/results/defaultQueries";
 
 export class QueryResultsDataSource extends ResultsDataSourceBase {
   queryResultsUrl = this.baseUrl + '/v2/query-results';
+  queryResultsValuesUrl = this.baseUrl + '/v2/query-result-values';
 
   defaultQuery = defaultResultsQuery;
+
+  readonly partNumbersCache = new Map<string, string>([]);
 
   async queryResults(
     filter?: string,
@@ -32,6 +35,9 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
   }
 
   async runQuery(query: QueryResults, options: DataQueryRequest): Promise<DataFrameDTO> {
+    await this.getResultsPartNumbers();
+    await this.loadWorkspaces();
+
     const responseData = await this.queryResults(
       this.getTimeRangeFilter(options, query.useTimeRange, query.useTimeRangeFor),
       query.orderBy,
@@ -76,6 +82,20 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
         fields: [{ name: 'Total count', values: [responseData.totalCount] }],
       };
     }
+  }
+
+  async getResultsPartNumbers(): Promise<void> {
+    if (this.partNumbersCache.size > 0) {
+      return;
+    }
+    
+    const partNumbers = await this.post<string[]>(this.queryResultsValuesUrl, {
+      field: ResultsPropertiesOptions.PART_NUMBER,
+    }).catch(error => {
+      throw new Error(error);
+    });
+
+    partNumbers?.forEach(partNumber => this.partNumbersCache.set(partNumber, partNumber));
   }
 
   shouldRunQuery(_: QueryResults): boolean {

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -1,3 +1,4 @@
+import { QueryBuilderField } from 'smart-webcomponents-react';
 import { OutputType, ResultsQuery } from './types';
 
 export interface QueryResults extends ResultsQuery {
@@ -8,6 +9,7 @@ export interface QueryResults extends ResultsQuery {
   useTimeRange?: boolean;
   useTimeRangeFor?: string;
   recordCount?: number;
+  queryBy?: string;
 }
 
 export const OrderBy = [
@@ -136,4 +138,14 @@ export interface QueryResultsResponse {
   results: ResultsResponseProperties[];
   continuationToken?: string;
   totalCount?: number;
+}
+
+export interface QBField extends QueryBuilderField {
+  lookup?: {
+    readonly?: boolean;
+    dataSource: Array<{
+      label: string,
+      value: string
+    }>;
+  },
 }

--- a/src/datasources/results/types/QuerySteps.types.ts
+++ b/src/datasources/results/types/QuerySteps.types.ts
@@ -1,3 +1,4 @@
+import { QueryBuilderField } from 'smart-webcomponents-react';
 import { OutputType, ResultsQuery } from './types';
 
 export interface QuerySteps extends ResultsQuery {
@@ -156,3 +157,13 @@ export interface BatchQueryConfig {
   maxTakePerRequest: number;
   requestsPerSecond: number;
 };
+
+export interface QBField extends QueryBuilderField {
+  lookup?: {
+    readonly?: boolean;
+    dataSource: Array<{
+      label: string,
+      value: string
+    }>;
+  },
+}

--- a/src/datasources/results/types/types.ts
+++ b/src/datasources/results/types/types.ts
@@ -18,3 +18,17 @@ export enum UseTimeRangeFor {
   Started = 'Started',
   Updated = 'Updated'
 }
+
+export enum TestMeasurementStatus {
+  Done = 'DONE',
+  Errored = 'ERRORED',
+  Failed = 'FAILED',
+  Passed = 'PASSED',
+  Skipped = 'SKIPPED',
+  Terminated = 'TERMINATED',
+  TimedOut = 'TIMED_OUT',
+  Custom = 'CUSTOM',
+  Looping = 'LOOPING',
+  Running = 'RUNNING',
+  Waiting = 'WAITING',
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As a part of this [User Story 2798322](https://ni.visualstudio.com/DevCentral/_workitems/edit/2798322): FE | Add Query Builder for Results Datasource

this PR introduces constants and types required for implementing the steps query builder functionality for the Results datasource.

## 👩‍💻 Implementation

In `StepsQueryBuilder.constants.ts`: 

- Added `StepsQueryBuilderFieldNames` to define the field names used in the query builder.
- Added `StepsQueryBuilderFields` to configure field metadata, including labels, filter operations, and lookup values.
- Added `StepsQueryBuilderStaticFields` to define static fields for the query builder.

## 🧪 Testing

NA

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).