### PR TITLE
refactor(results): Move QBField Type to Core Types for Reusability

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,3 +1,4 @@
+import { QueryBuilderField } from "smart-webcomponents-react";
 import { SystemProperties } from "../datasources/system/types";
 
 export const LEGACY_METADATA_TYPE = 'Metadata';
@@ -44,3 +45,13 @@ export interface PropertyFieldKeyValuePair {
   key: string;
   value: string | number;
 };
+
+export interface QBField extends QueryBuilderField {
+  lookup?: {
+    readonly?: boolean;
+    dataSource: Array<{
+      label: string,
+      value: string
+    }>;
+  },
+}

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -1,7 +1,7 @@
 import { useTheme2 } from '@grafana/ui';
 import { queryBuilderMessages, QueryBuilderOperations } from 'core/query-builder.constants';
 import { expressionBuilderCallback, expressionReaderCallback } from 'core/query-builder.utils';
-import { Workspace, QueryBuilderOption } from 'core/types';
+import { Workspace, QueryBuilderOption, QBField } from 'core/types';
 import { filterXSSField, filterXSSLINQExpression } from 'core/utils';
 
 import React, { useState, useEffect, useMemo } from 'react';
@@ -12,7 +12,6 @@ import 'smart-webcomponents-react/source/styles/smart.orange.css';
 import 'smart-webcomponents-react/source/styles/components/smart.base.css';
 import 'smart-webcomponents-react/source/styles/components/smart.common.css';
 import 'smart-webcomponents-react/source/styles/components/smart.querybuilder.css';
-import { QBField } from 'datasources/results/types/QueryResults.types';
 import {
   ResultsQueryBuilderFields,
   ResultsQueryBuilderStaticFields,

--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -1,5 +1,5 @@
 import { QueryBuilderOperations } from 'core/query-builder.constants';
-import { QBField } from '../types/QueryResults.types';
+import { QBField } from 'core/types';
 
 export enum ResultsQueryBuilderFieldNames {
   HOSTNAME = 'HostName',

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -138,13 +138,3 @@ export interface QueryResultsResponse {
   continuationToken?: string;
   totalCount?: number;
 }
-
-export interface QBField extends QueryBuilderField {
-  lookup?: {
-    readonly?: boolean;
-    dataSource: Array<{
-      label: string,
-      value: string
-    }>;
-  },
-}

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -1,4 +1,3 @@
-import { QueryBuilderField } from 'smart-webcomponents-react';
 import { OutputType, ResultsQuery } from './types';
 
 export interface QueryResults extends ResultsQuery {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As a part of [User Story 2798322](https://ni.visualstudio.com/DevCentral/_workitems/edit/2798322): FE | Add Query Builder for Results Datasource,

this PR moves the `QBField` type to `core>types.ts` to make it reusable across multiple datasources.

## 👩‍💻 Implementation

- `QBField` extends the `QueryBuilderField` type and adds a `lookup` property to support additional metadata, such as `readonly` and `dataSource`.

## 🧪 Testing

NA

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).