### PR TITLE
fix(results): Update keyword filter operations in result query builder

### DIFF
--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
@@ -56,10 +56,10 @@ describe('ResultsQueryBuilder', () => {
     });
 
     it('should select keyword in query builder', () => {
-      const { conditionsContainer } = renderElement([], [], [], 'Keywords listequals "keyword1"');
+      const { conditionsContainer } = renderElement([], [], [], 'Keywords.Contains("keyword1")');
 
       expect(conditionsContainer?.length).toBe(1);
-      expect(conditionsContainer.item(0)?.textContent).toContain("Keywords"); //label
+      expect(conditionsContainer.item(0)?.textContent).toContain("Keyword"); //label
       expect(conditionsContainer.item(0)?.textContent).toContain("Equals"); //operator
       expect(conditionsContainer.item(0)?.textContent).toContain("keyword1"); //value
     });

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
@@ -55,6 +55,15 @@ describe('ResultsQueryBuilder', () => {
       expect(conditionsContainer.item(0)?.textContent).toContain("PASSED"); //value
     });
 
+    it('should select keyword in query builder', () => {
+      const { conditionsContainer } = renderElement([], [], [], 'Keywords listequals "keyword1"');
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain("Keywords"); //label
+      expect(conditionsContainer.item(0)?.textContent).toContain("Equals"); //operator
+      expect(conditionsContainer.item(0)?.textContent).toContain("keyword1"); //value
+    });
+
     it('should select global variable option', () => {
       const globalVariableOption = { label: 'Global variable', value: 'global_variable' };
       const { conditionsContainer } = renderElement([workspace], partNumber, status, 'PartNumber = \"global_variable\"', [globalVariableOption]);

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -169,6 +169,10 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
       QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO,
       QueryBuilderOperations.IS_BLANK,
       QueryBuilderOperations.IS_NOT_BLANK,
+      QueryBuilderOperations.LIST_EQUALS,
+      QueryBuilderOperations.LIST_DOES_NOT_EQUAL,
+      QueryBuilderOperations.LIST_CONTAINS,
+      QueryBuilderOperations.LIST_DOES_NOT_CONTAIN,
     ].map(operation => {
       return {
         ...operation,

--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -33,10 +33,10 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
     label: 'Keyword',
     dataField: ResultsQueryBuilderFieldNames.KEYWORDS,
     filterOperations: [
-      QueryBuilderOperations.EQUALS.name,
-      QueryBuilderOperations.DOES_NOT_EQUAL.name,
-      QueryBuilderOperations.CONTAINS.name,
-      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.LIST_EQUALS.name,
+      QueryBuilderOperations.LIST_DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.LIST_CONTAINS.name,
+      QueryBuilderOperations.LIST_DOES_NOT_CONTAIN.name,
     ],
   },
   OPERATOR: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To address the issue with the Keyword field filter operations, as it represents a list rather than a string, the filter operations have been updated to handle list-based operations instead of string-based ones.
![image](https://github.com/user-attachments/assets/ad58373b-d879-4e93-91ee-3b3efecb4591)

## 👩‍💻 Implementation

- Updated the filter operations for the Keyword field to handle it as a list instead of a string.
- Added the respective list-based operations to the custom operations array in the query builder.

## 🧪 Testing

Yet to add

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).