### PR TITLE
feat: add output type to test plans query editor

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -2,6 +2,7 @@ import { MockProxy } from "jest-mock-extended";
 import { TestPlansDataSource } from "./TestPlansDataSource";
 import { BackendSrv } from "@grafana/runtime";
 import { createFetchError, createFetchResponse, requestMatching, setupDataSource } from "test/fixtures";
+import { OutputType } from "./types";
 
 
 let datastore: TestPlansDataSource, backendServer: MockProxy<BackendSrv>
@@ -29,5 +30,10 @@ describe('testDatasource', () => {
     await expect(datastore.testDatasource())
       .rejects
       .toThrow('Request to url "/niworkorder/v1/query-testplans" failed with status code: 400. Error message: "Error"');
+  });
+
+  test('default query output type should be properties', async () => {
+    const defaultQuery = datastore.defaultQuery;
+    expect(defaultQuery.outputType).toEqual(OutputType.Properties);
   });
 });

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -1,7 +1,7 @@
 import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
-import { TestPlansQuery } from './types';
+import { OutputType, TestPlansQuery } from './types';
 
 export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   constructor(
@@ -15,7 +15,9 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   baseUrl = `${this.instanceSettings.url}/niworkorder/v1`;
   queryTestPlansUrl = `${this.baseUrl}/query-testplans`;
 
-  defaultQuery = {};
+  defaultQuery = {
+    outputType: OutputType.Properties
+  };
 
   async runQuery(query: TestPlansQuery, { range }: DataQueryRequest): Promise<DataFrameDTO> {
     return {

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -1,13 +1,32 @@
-import React from 'react';
-import { QueryEditorProps } from '@grafana/data';
+import React, { useCallback } from 'react';
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { TestPlansDataSource } from '../TestPlansDataSource';
-import { TestPlansQuery } from '../types';
+import { OutputType, TestPlansQuery } from '../types';
+import { InlineField, RadioButtonGroup } from '@grafana/ui';
 
 type Props = QueryEditorProps<TestPlansDataSource, TestPlansQuery>;
 
-export function TestPlansQueryEditor({ query, onChange, onRunQuery }: Props) {
+export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+  query = datasource.prepareQuery(query);
+
+  const onOutputTypeChange = useCallback((value: OutputType) => {
+    onChange({ ...query, outputType: value });
+    onRunQuery();
+  }, [query, onChange, onRunQuery]);
+
   return (
     <>
+      <InlineField label="Output" labelWidth={14} tooltip={tooltips.outputType}>
+        <RadioButtonGroup
+          options={Object.values(OutputType).map(value => ({ label: value, value })) as SelectableValue[]}
+          onChange={onOutputTypeChange}
+          value={query.outputType}
+        />
+      </InlineField>
     </>
   );
 }
+
+const tooltips = {
+  outputType: 'This field specifies the output type to fetch test plan properties or total count'
+};

--- a/src/datasources/test-plans/types.ts
+++ b/src/datasources/test-plans/types.ts
@@ -1,4 +1,10 @@
 import { DataQuery } from '@grafana/schema'
 
 export interface TestPlansQuery extends DataQuery {
+    outputType: OutputType;
+}
+
+export enum OutputType {
+    Properties = "Properties",
+    TotalCount = "Total Count"
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
[User Story 3064428](https://ni.visualstudio.com/DevCentral/_workitems/edit/3064428): FE | Add Query Editor
To enable toggle for output type to select `Properties` or `Total Count`
![image](https://github.com/user-attachments/assets/dbdb5959-c4a2-4088-b99c-9513c0b7ee5c)


## 👩‍💻 Implementation

- Added Radio selection control in test plans query editor
- Added output type in the test plan query

## 🧪 Testing

Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).