### PR TITLE
feat(results): Add variable Query editor template for Results Datasource

### DIFF
--- a/src/datasources/results/ResultsDataSource.test.ts
+++ b/src/datasources/results/ResultsDataSource.test.ts
@@ -105,11 +105,11 @@ describe('ResultsDataSource', () => {
       expect(result).toBe(false);
     });
     describe('metricFindQuery', () => {
-      test('should call QueryResultsDataSource metricFindQuery with correct arguments', async () => {
-        const mockQuery = { properties: 'TestProgramName', queryBy: 'TestProgramName'} as unknown as ResultsVariableQuery;
-        const mockOptions = { range: {} };
-        const mockResponse = [{ text: 'value1', value: '1' }];
+      const mockQuery = { properties: 'TestProgramName', queryBy: 'TestProgramName'} as unknown as ResultsVariableQuery;
+      const mockResponse = [{ text: 'value1', value: '1' }];
 
+      test('should call QueryResultsDataSource metricFindQuery with correct arguments', async () => {
+        const mockOptions = { range: {} };
         const queryResultsDataSource = datastore.queryResultsDataSource;
         queryResultsDataSource.metricFindQuery = jest.fn().mockResolvedValue(mockResponse);
 
@@ -120,9 +120,6 @@ describe('ResultsDataSource', () => {
       });
 
       test('should call QueryResultsDataSource metricFindQuery with undefined options', async () => {
-        const mockQuery = {queryType:'', properties: 'TestProgramName', queryBy: 'TestProgramName'} as unknown as ResultsVariableQuery;
-        const mockResponse = [{ text: 'value2', value: '2' }];
-
         const queryResultsDataSource = datastore.queryResultsDataSource;
         queryResultsDataSource.metricFindQuery = jest.fn().mockResolvedValue(mockResponse);
 

--- a/src/datasources/results/ResultsDataSource.test.ts
+++ b/src/datasources/results/ResultsDataSource.test.ts
@@ -3,7 +3,7 @@ import { ResultsDataSource } from './ResultsDataSource';
 import { BackendSrv } from '@grafana/runtime';
 import { createFetchError, createFetchResponse, requestMatching, setupDataSource } from 'test/fixtures';
 import { ResultsQuery } from './types/types';
-import { DataFrameDTO, DataQueryRequest } from '@grafana/data';
+import { DataFrameDTO, DataQueryRequest, LegacyMetricFindQueryOptions } from '@grafana/data';
 
 let datastore: ResultsDataSource, backendServer: MockProxy<BackendSrv>
 
@@ -103,6 +103,34 @@ describe('ResultsDataSource', () => {
 
       expect(result).toBe(false);
     });
+    describe('metricFindQuery', () => {
+      test('should call QueryResultsDataSource metricFindQuery with correct arguments', async () => {
+        const mockQuery = { properties: 'TestProgramName', queryBy: 'TestProgramName'};
+        const mockOptions = { range: {} };
+        const mockResponse = [{ text: 'value1', value: '1' }];
 
+        const queryResultsDataSource = datastore.queryResultsDataSource;
+        queryResultsDataSource.metricFindQuery = jest.fn().mockResolvedValue(mockResponse);
+
+        const result = await datastore.metricFindQuery(mockQuery, mockOptions as LegacyMetricFindQueryOptions);
+
+        expect(queryResultsDataSource.metricFindQuery).toHaveBeenCalledWith(mockQuery, mockOptions);
+        expect(result).toBe(mockResponse);
+      });
+
+      test('should call QueryResultsDataSource metricFindQuery with undefined options', async () => {
+        const mockQuery = {queryType:'', properties: 'TestProgramName', queryBy: 'TestProgramName'};
+        const mockResponse = [{ text: 'value2', value: '2' }];
+
+        const queryResultsDataSource = datastore.queryResultsDataSource;
+        queryResultsDataSource.metricFindQuery = jest.fn().mockResolvedValue(mockResponse);
+
+        const result = await datastore.metricFindQuery(mockQuery);
+
+        expect(queryResultsDataSource.metricFindQuery).toHaveBeenCalledWith(mockQuery, undefined);
+        expect(result).toBe(mockResponse);
+      });
+    });
   });
+
 });

--- a/src/datasources/results/ResultsDataSource.test.ts
+++ b/src/datasources/results/ResultsDataSource.test.ts
@@ -4,6 +4,7 @@ import { BackendSrv } from '@grafana/runtime';
 import { createFetchError, createFetchResponse, requestMatching, setupDataSource } from 'test/fixtures';
 import { ResultsQuery } from './types/types';
 import { DataFrameDTO, DataQueryRequest, LegacyMetricFindQueryOptions } from '@grafana/data';
+import { ResultsVariableQuery } from './types/QueryResults.types';
 
 let datastore: ResultsDataSource, backendServer: MockProxy<BackendSrv>
 
@@ -105,7 +106,7 @@ describe('ResultsDataSource', () => {
     });
     describe('metricFindQuery', () => {
       test('should call QueryResultsDataSource metricFindQuery with correct arguments', async () => {
-        const mockQuery = { properties: 'TestProgramName', queryBy: 'TestProgramName'};
+        const mockQuery = { properties: 'TestProgramName', queryBy: 'TestProgramName'} as unknown as ResultsVariableQuery;
         const mockOptions = { range: {} };
         const mockResponse = [{ text: 'value1', value: '1' }];
 
@@ -119,7 +120,7 @@ describe('ResultsDataSource', () => {
       });
 
       test('should call QueryResultsDataSource metricFindQuery with undefined options', async () => {
-        const mockQuery = {queryType:'', properties: 'TestProgramName', queryBy: 'TestProgramName'};
+        const mockQuery = {queryType:'', properties: 'TestProgramName', queryBy: 'TestProgramName'} as unknown as ResultsVariableQuery;
         const mockResponse = [{ text: 'value2', value: '2' }];
 
         const queryResultsDataSource = datastore.queryResultsDataSource;

--- a/src/datasources/results/ResultsDataSource.ts
+++ b/src/datasources/results/ResultsDataSource.ts
@@ -1,9 +1,9 @@
-import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, TestDataSourceResponse } from '@grafana/data';
+import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, LegacyMetricFindQueryOptions, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { QueryType, ResultsDataSourceOptions, ResultsQuery } from './types/types';
 import { QueryResultsDataSource } from './query-handlers/query-results/QueryResultsDataSource';
-import { QueryResults } from './types/QueryResults.types';
+import { QueryResults, ResultsVariableQuery } from './types/QueryResults.types';
 import { QuerySteps } from './types/QuerySteps.types';
 import { QueryStepsDataSource } from './query-handlers/query-steps/QueryStepsDataSource';
 
@@ -42,6 +42,10 @@ export class ResultsDataSource extends DataSourceBase<ResultsQuery, ResultsDataS
       return this.queryStepsDataSource.shouldRunQuery(query as QuerySteps);
     }
     return false;
+  }
+
+  async metricFindQuery(query: ResultsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+    return this.queryResultsDataSource.metricFindQuery(query as ResultsVariableQuery, options);
   }
 
   get queryResultsDataSource(): QueryResultsDataSource {

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -1,25 +1,19 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { ResultsVariableQueryEditor } from './ResultsVariableQueryEditor';
 import { ResultsVariableQuery } from 'datasources/results/types/QueryResults.types';
 import { setupRenderer } from 'test/fixtures';
 import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
-import { select } from 'react-select-event';
-import userEvent from '@testing-library/user-event';
-import { ResultsQueryBuilder } from '../query-builders/query-results/ResultsQueryBuilder';
-import React from 'react';
 
-class FakeResultsDataSource extends QueryResultsDataSource {
+class FakeQueryResultsDataSource extends QueryResultsDataSource {
   globalVariableOptions = jest.fn(() => [{ label: 'Global', value: 'global' }]);
 }
 
-const render = setupRenderer(ResultsVariableQueryEditor, FakeResultsDataSource as any, () => {});
-let onChange: jest.Mock<any, any>;
+const renderEditor = setupRenderer(ResultsVariableQueryEditor, FakeQueryResultsDataSource as any, () => {});
 let propertiesSelect: HTMLElement;
 let queryBy: HTMLElement;
 
-
-it('renders properties select and results query builder', async () => {
-  render({ refId: '', properties: '', queryBy: '' } as ResultsVariableQuery);
+it('should render properties select and results query builder', async () => {
+  renderEditor({ refId: '', properties: '', queryBy: '' } as ResultsVariableQuery);
   propertiesSelect = screen.getAllByRole('combobox')[0];
   queryBy = screen.getByText('Query By');
 
@@ -29,14 +23,4 @@ it('renders properties select and results query builder', async () => {
   await waitFor(() => expect(screen.getAllByText('Property').length).toBe(1));
   await waitFor(() => expect(screen.getAllByText('Operator').length).toBe(1));
   await waitFor(() => expect(screen.getAllByText('Value').length).toBe(1));
-});
-
-it('should call onChange when user changes the properties', async () => {
-  [onChange] = render({ refId: '', properties: '', queryBy: '' } as ResultsVariableQuery);
-  await waitFor(() => (propertiesSelect = screen.getAllByRole('combobox')[0]));
-
-  await select(propertiesSelect, 'Test Program Name', { container: document.body });
-  await waitFor(() => {
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ properties: 'programName' }));
-  });
 });

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { ResultsVariableQueryEditor } from './ResultsVariableQueryEditor';
+import { ResultsVariableQuery } from 'datasources/results/types/QueryResults.types';
+import { setupRenderer } from 'test/fixtures';
+import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
+import { select } from 'react-select-event';
+import userEvent from '@testing-library/user-event';
+import { ResultsQueryBuilder } from '../query-builders/query-results/ResultsQueryBuilder';
+import React from 'react';
+
+class FakeResultsDataSource extends QueryResultsDataSource {
+  globalVariableOptions = jest.fn(() => [{ label: 'Global', value: 'global' }]);
+}
+
+const render = setupRenderer(ResultsVariableQueryEditor, FakeResultsDataSource as any, () => {});
+let onChange: jest.Mock<any, any>;
+let propertiesSelect: HTMLElement;
+let queryBy: HTMLElement;
+
+
+it('renders properties select and results query builder', async () => {
+  render({ refId: '', properties: '', queryBy: '' } as ResultsVariableQuery);
+  propertiesSelect = screen.getAllByRole('combobox')[0];
+  queryBy = screen.getByText('Query By');
+
+  expect(propertiesSelect).toBeInTheDocument();
+  expect(queryBy).toBeInTheDocument();
+
+  await waitFor(() => expect(screen.getAllByText('Property').length).toBe(1));
+  await waitFor(() => expect(screen.getAllByText('Operator').length).toBe(1));
+  await waitFor(() => expect(screen.getAllByText('Value').length).toBe(1));
+});
+
+it('should call onChange when user changes the properties', async () => {
+  [onChange] = render({ refId: '', properties: '', queryBy: '' } as ResultsVariableQuery);
+  await waitFor(() => (propertiesSelect = screen.getAllByRole('combobox')[0]));
+
+  await select(propertiesSelect, 'Test Program Name', { container: document.body });
+  await waitFor(() => {
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ properties: 'programName' }));
+  });
+});

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -1,0 +1,47 @@
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { InlineField } from 'core/components/InlineField';
+import React from 'react';
+import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
+import { ResultsVariableProperties, ResultsVariableQuery } from 'datasources/results/types/QueryResults.types';
+import { ResultsQueryBuilder } from '../query-builders/query-results/ResultsQueryBuilder';
+import { Select } from '@grafana/ui';
+
+type Props = QueryEditorProps<QueryResultsDataSource, ResultsVariableQuery>;
+
+export function ResultsVariableQueryEditor({ query, onChange, datasource }: Props) {
+  const onPropertiesChange = (item: SelectableValue<string>) => {
+    onChange({ ...query, properties: item.value });
+  };
+
+  const onQueryByChange = (value: string) => {
+    onChange({ ...query, queryBy: value });
+  };
+
+  return (
+    <>
+      <InlineField label="Properties" labelWidth={12} tooltip={tooltips.properties}>
+        <Select 
+            onChange={onPropertiesChange}
+            options={ResultsVariableProperties as SelectableValue[]}
+            value={query.properties}
+            defaultValue={query.properties}
+        ></Select>
+      </InlineField>
+      <InlineField label="Query By" labelWidth={12} tooltip={tooltips.queryBy}>
+        <ResultsQueryBuilder
+          filter={query.queryBy}
+          onChange={(event: any) => onQueryByChange(event.detail.linq)}
+          workspaces={[]}
+          partNumbers={[]}
+          status={[]}
+          globalVariableOptions={datasource.globalVariableOptions()}
+        ></ResultsQueryBuilder>
+      </InlineField>
+    </>
+  );
+}
+
+const tooltips = {
+  queryBy: 'Specifies the filter to be applied on the queried products.',
+  properties: "Select the properties to be included in the query.",
+};

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -42,6 +42,6 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
 }
 
 const tooltips = {
-  queryBy: 'Specifies the filter to be applied on the queried products.',
-  properties: "Select the properties to be included in the query.",
+  queryBy: 'Specifies the filter to be applied on the queried results.',
+  properties: "This field specifies the properties to use in the query.",
 };

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -34,7 +34,7 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
           workspaces={[]}
           partNumbers={[]}
           status={[]}
-          globalVariableOptions={datasource.globalVariableOptions()}
+          globalVariableOptions={[]}
         ></ResultsQueryBuilder>
       </InlineField>
     </>

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -42,6 +42,6 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
 }
 
 const tooltips = {
-  queryBy: 'Specifies the filter to be applied on the queried results.',
+  queryBy: 'This field applies a filter to the query results.',
   properties: "This field specifies the properties to use in the query.",
 };

--- a/src/datasources/results/module.ts
+++ b/src/datasources/results/module.ts
@@ -3,7 +3,9 @@ import { ResultsDataSource } from './ResultsDataSource';
 import { ResultsQueryEditor } from './components/ResultsQueryEditor';
 import { ResultsConfigEditor } from './ResultsConfigEditor';
 import { ResultsDataSourceOptions, ResultsQuery } from './types/types';
+import { ResultsVariableQueryEditor } from './components/variable-editors/ResultsVariableQueryEditor';
 
 export const plugin = new DataSourcePlugin<ResultsDataSource, ResultsQuery, ResultsDataSourceOptions>(ResultsDataSource)
   .setConfigEditor(ResultsConfigEditor)
-  .setQueryEditor(ResultsQueryEditor);
+  .setQueryEditor(ResultsQueryEditor)
+  .setVariableQueryEditor(ResultsVariableQueryEditor)

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -233,6 +233,20 @@ describe('QueryResultsDataSource', () => {
       );
     });
   });
+  describe('metricFindQuery', () => {
+    test('returns an empty array when called', async () => {
+      const query = {};
+      const options = {};
+      const result = await datastore.metricFindQuery(query, options);
+      expect(result).toEqual([]);
+    });
+
+    test('returns an empty array when called without options', async () => {
+      const query = {};
+      const result = await datastore.metricFindQuery(query);
+      expect(result).toEqual([]);
+    });
+  });
 
   const buildQuery = getQueryBuilder<QueryResults>()({
     refId: 'A',

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -3,7 +3,7 @@ import { BackendSrv, TemplateSrv } from '@grafana/runtime';
 import { createFetchError, createFetchResponse, getQueryBuilder, requestMatching, setupDataSource } from 'test/fixtures';
 import { Field } from '@grafana/data';
 import { QueryResultsDataSource } from './QueryResultsDataSource';
-import { QueryResults, QueryResultsResponse, ResultsProperties, ResultsPropertiesOptions } from 'datasources/results/types/QueryResults.types';
+import { QueryResults, QueryResultsResponse, ResultsProperties, ResultsPropertiesOptions, ResultsVariableQuery } from 'datasources/results/types/QueryResults.types';
 import { OutputType, QueryType } from 'datasources/results/types/types';
 
 const mockQueryResultsResponse: QueryResultsResponse = {
@@ -234,15 +234,15 @@ describe('QueryResultsDataSource', () => {
     });
   });
   describe('metricFindQuery', () => {
-    test('returns an empty array when called', async () => {
-      const query = {};
+    test('should return an empty array when called', async () => {
+      const query = { queryType:'', properties: 'TestProgramName', queryBy: 'TestProgramName'} as unknown as ResultsVariableQuery;
       const options = {};
       const result = await datastore.metricFindQuery(query, options);
       expect(result).toEqual([]);
     });
 
-    test('returns an empty array when called without options', async () => {
-      const query = {};
+    test('should return an empty array when called without options', async () => {
+      const query = {queryType:'', properties: 'TestProgramName', queryBy: 'TestProgramName'} as unknown as ResultsVariableQuery;
       const result = await datastore.metricFindQuery(query);
       expect(result).toEqual([]);
     });

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -98,7 +98,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
     partNumbers?.forEach(partNumber => this.partNumbersCache.push(partNumber));
   }
 
-  async metricFindQuery(query: ResultsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+  async metricFindQuery(_query: ResultsVariableQuery, _options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
     return [];
   }
 

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -1,6 +1,6 @@
-import { QueryResults, QueryResultsResponse, ResultsProperties, ResultsPropertiesOptions, ResultsResponseProperties } from "datasources/results/types/QueryResults.types";
+import { QueryResults, QueryResultsResponse, ResultsProperties, ResultsPropertiesOptions, ResultsResponseProperties, ResultsVariableQuery } from "datasources/results/types/QueryResults.types";
 import { ResultsDataSourceBase } from "datasources/results/ResultsDataSourceBase";
-import { DataQueryRequest, DataFrameDTO, FieldType } from "@grafana/data";
+import { DataQueryRequest, DataFrameDTO, FieldType, LegacyMetricFindQueryOptions, MetricFindValue } from "@grafana/data";
 import { OutputType } from "datasources/results/types/types";
 import { defaultResultsQuery } from "datasources/results/defaultQueries";
 
@@ -96,6 +96,10 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
     });
 
     partNumbers?.forEach(partNumber => this.partNumbersCache.push(partNumber));
+  }
+
+  async metricFindQuery(query: ResultsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+    return [];
   }
 
   shouldRunQuery(_: QueryResults): boolean {

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -11,6 +11,24 @@ export interface QueryResults extends ResultsQuery {
   recordCount?: number;
 }
 
+export interface ResultsVariableQuery extends ResultsQuery {
+  properties?: string;
+  queryBy?: string;
+}
+
+export const ResultsVariableProperties = [
+  {
+    value: 'dataTableIds',
+    label: 'Data Table IDs',
+    description: 'Data Table IDs associated with the result',
+  },
+  {
+    value: 'programName',
+    label: 'Test Program Name',
+    description: 'Test Program Name of the result',
+  }
+]
+
 export const OrderBy = [
   {
     value: 'ID',

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -18,12 +18,12 @@ export interface ResultsVariableQuery extends ResultsQuery {
 
 export const ResultsVariableProperties = [
   {
-    value: 'dataTableIds',
+    value: 'DATA_TABLE_IDS',
     label: 'Data Table IDs',
     description: 'Data Table IDs associated with the result',
   },
   {
-    value: 'programName',
+    value: 'PROGRAM_NAME',
     label: 'Test Program Name',
     description: 'Test Program Name of the result',
   }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
As part of [Task 2962922](https://dev.azure.com/ni/DevCentral/_workitems/edit/2962922): Add query editor for Results variable support, this PR contains the changes for the template of the variable query editor with the query builder and the properties element

## 👩‍💻 Implementation

- Added a `metricFindQuery` method to `ResultsDataSource` and `QueryResultsDataSource` to handle variable queries.
- Introduced a new interface `ResultsVariableQuery` to extend the existing `ResultsQuery` with `properties` and `queryBy` fields. 
- Created a new React component to allow users to configure variable queries via a user interface

## 🧪 Testing

- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).