### PR TITLE
feat(results): Add tooltip for results and steps query builder

### DIFF
--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -105,7 +105,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           }}
         />
         <div className="horizontal-control-group">
-          <InlineField label="Query By" labelWidth={25} tooltip={tooltips.properties}>
+          <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
             <ResultsQueryBuilder
               filter={query.queryBy}
               workspaces={workspaces}

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -161,5 +161,5 @@ const tooltips = {
   recordCount: 'This field sets the maximum number of results.',
   orderBy: 'This field orders the query results by field.',
   descending: 'This field returns the query results in descending order.',
-  queryBy: 'Specifies the filter to be applied on the queried results. This is an optional field.',
+  queryBy: 'This optional field applies a filter to the query results.',
 };

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -105,7 +105,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           }}
         />
         <div className="horizontal-control-group">
-          <InlineField label="Query By" labelWidth={25}>
+          <InlineField label="Query By" labelWidth={25} tooltip={tooltips.properties}>
             <ResultsQueryBuilder
               filter={query.queryBy}
               workspaces={workspaces}
@@ -161,4 +161,5 @@ const tooltips = {
   recordCount: 'This field sets the maximum number of results.',
   orderBy: 'This field orders the query results by field.',
   descending: 'This field returns the query results in descending order.',
+  queryBy: 'Specifies the filter to be applied on the queried results. This is an optional field.',
 };

--- a/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
+++ b/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
@@ -72,6 +72,6 @@ export const StepsQueryBuilderWrapper = (
 };
 
 const tooltips = {
-  resultsQueryBuilder: 'Specifies the filter to be applied on the queried results.',
-  stepsQueryBuilder: 'Specifies the filter to be applied on the queried steps. This is an optional field.',
+  resultsQueryBuilder: 'This field applies a filter to the query results.',
+  stepsQueryBuilder: 'This optional field applies a filter to the query steps.',
 };

--- a/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
+++ b/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
@@ -46,7 +46,7 @@ export const StepsQueryBuilderWrapper = (
   
   return (
     <div>
-      <InlineField label="Query by results properties" labelWidth={25}>
+      <InlineField label="Query by results properties" labelWidth={25} tooltip={tooltips.resultsQueryBuilder}>
         <ResultsQueryBuilder
           filter={resultsQuery}
           onChange={(event) => onResultsQueryChange((event as CustomEvent<{ linq: string }>).detail.linq)}
@@ -56,7 +56,7 @@ export const StepsQueryBuilderWrapper = (
           globalVariableOptions={datasource.globalVariableOptions()}>
         </ResultsQueryBuilder>
       </InlineField>
-      <InlineField label="Query by steps properties" labelWidth={25}>
+      <InlineField label="Query by steps properties" labelWidth={25} tooltip={tooltips.stepsQueryBuilder}>
         <StepsQueryBuilder
           filter={stepsQuery}
           workspaces={workspaces}
@@ -69,4 +69,9 @@ export const StepsQueryBuilderWrapper = (
       </InlineField>
     </div>
   );
+};
+
+const tooltips = {
+  resultsQueryBuilder: 'Specifies the filter to be applied on the queried results. This is an optional field.',
+  stepsQueryBuilder: 'Specifies the filter to be applied on the queried steps. This is an optional field.',
 };

--- a/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
+++ b/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
@@ -72,6 +72,6 @@ export const StepsQueryBuilderWrapper = (
 };
 
 const tooltips = {
-  resultsQueryBuilder: 'Specifies the filter to be applied on the queried results. This is an optional field.',
+  resultsQueryBuilder: 'Specifies the filter to be applied on the queried results.',
   stepsQueryBuilder: 'Specifies the filter to be applied on the queried steps. This is an optional field.',
 };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As part of this [User Story 2798322](https://ni.visualstudio.com/DevCentral/_workitems/edit/2798322): FE | Add Query Builder for Results Datasource

this PR introduces the addition of tooltips for `ResultsQueryBuilder` and `StepsQueryBuilder` to provide concise information of query builder for the users.

## 👩‍💻 Implementation

- Added tooltip for `ResultsQueryBuilder` in `QueryResultsEditor`.
- Added tooltips for `ResultsQueryBuilder` and `StepsQueryBuilder` in `StepsQueryBuilderWrapper`.

## 🧪 Testing

NA

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).