### PR TITLE
feat: add properties to test plans query editor

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -2,7 +2,7 @@ import { MockProxy } from "jest-mock-extended";
 import { TestPlansDataSource } from "./TestPlansDataSource";
 import { BackendSrv } from "@grafana/runtime";
 import { createFetchError, createFetchResponse, requestMatching, setupDataSource } from "test/fixtures";
-import { OutputType } from "./types";
+import { OutputType, PropertiesOptions } from "./types";
 
 
 let datastore: TestPlansDataSource, backendServer: MockProxy<BackendSrv>
@@ -32,8 +32,19 @@ describe('testDatasource', () => {
       .toThrow('Request to url "/niworkorder/v1/query-testplans" failed with status code: 400. Error message: "Error"');
   });
 
-  test('default query output type should be properties', async () => {
+  test('default query output type as properties and default properties', async () => {
     const defaultQuery = datastore.defaultQuery;
     expect(defaultQuery.outputType).toEqual(OutputType.Properties);
+    expect(defaultQuery.properties).toEqual([
+      PropertiesOptions.NAME,
+      PropertiesOptions.STATE,
+      PropertiesOptions.ASSIGNED_TO,
+      PropertiesOptions.PRODUCT,
+      PropertiesOptions.DUT,
+      PropertiesOptions.PLANNED_START_DATE,
+      PropertiesOptions.ESTIMATED_DURATION,
+      PropertiesOptions.SYSTEM,
+      PropertiesOptions.UPDATED_AT
+    ]);
   });
 });

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -1,7 +1,7 @@
 import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
-import { OutputType, TestPlansQuery } from './types';
+import { OutputType, Properties, PropertiesOptions, TestPlansQuery } from './types';
 
 export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   constructor(
@@ -16,7 +16,18 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   queryTestPlansUrl = `${this.baseUrl}/query-testplans`;
 
   defaultQuery = {
-    outputType: OutputType.Properties
+    outputType: OutputType.Properties,
+    properties: [
+      PropertiesOptions.NAME,
+      PropertiesOptions.STATE,
+      PropertiesOptions.ASSIGNED_TO,
+      PropertiesOptions.PRODUCT,
+      PropertiesOptions.DUT,
+      PropertiesOptions.PLANNED_START_DATE,
+      PropertiesOptions.ESTIMATED_DURATION,
+      PropertiesOptions.SYSTEM,
+      PropertiesOptions.UPDATED_AT
+    ] as Properties[]
   };
 
   async runQuery(query: TestPlansQuery, { range }: DataQueryRequest): Promise<DataFrameDTO> {

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
@@ -3,8 +3,9 @@ import { render, waitFor } from '@testing-library/react';
 import { TestPlansQueryEditor } from './TestPlansQueryEditor';
 import { QueryEditorProps } from '@grafana/data';
 import { TestPlansDataSource } from '../TestPlansDataSource';
-import { OutputType, TestPlansQuery } from '../types';
+import { OutputType, Properties, TestPlansQuery } from '../types';
 import userEvent from '@testing-library/user-event';
+import { select } from 'react-select-event';
 
 const mockOnChange = jest.fn();
 const mockOnRunQuery = jest.fn();
@@ -32,13 +33,64 @@ describe('TestPlansQueryEditor', () => {
         return render(reactNode);
     }
 
-    it('should render default query', () => {
+    it('should render default query', async () => {
         const container = renderElement();
 
         expect(container.getByRole('radio', { name: OutputType.Properties })).toBeInTheDocument();
         expect(container.getByRole('radio', { name: OutputType.Properties })).toBeChecked();
         expect(container.getByRole('radio', { name: OutputType.TotalCount })).toBeInTheDocument();
         expect(container.getByRole('radio', { name: OutputType.TotalCount })).not.toBeChecked();
+        await waitFor(() => {
+            const properties = container.getAllByRole('combobox')[0];
+            expect(properties).toBeInTheDocument();
+            expect(properties).toHaveAttribute('aria-expanded', 'false');
+            expect(properties).toHaveDisplayValue('');
+        });
+    });
+
+    it('should not render properties when output type is total count', async () => {
+        const query = {
+            refId: 'A',
+            outputType: OutputType.TotalCount,
+        };
+        const container = renderElement(query);
+
+        await waitFor(() => {
+            const properties = container.queryByRole('combobox', { name: 'Properties' });
+            expect(properties).not.toBeInTheDocument();
+        });
+    });
+
+    it('should render properties when output type is properties', async () => {
+        const query = {
+            refId: 'A',
+            outputType: OutputType.Properties,
+        };
+        const container = renderElement(query);
+
+        await waitFor(() => {
+            const properties = container.getAllByRole('combobox')[0];
+            expect(properties).toBeInTheDocument();
+            expect(properties).toHaveAttribute('aria-expanded', 'false');
+            expect(properties).toHaveDisplayValue('');
+        });
+    });
+
+    it('should call onChange with properties when user selects properties', async () => {
+        const query = {
+            refId: 'A',
+            outputType: OutputType.Properties,
+        };
+        const container = renderElement(query);
+
+        const propertiesSelect = container.getAllByRole('combobox')[0];
+        userEvent.click(propertiesSelect);
+        await select(propertiesSelect, Properties.assignedTo, { container: document.body });
+
+        await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ properties: ['assignedTo'] }));
+            expect(mockOnRunQuery).toHaveBeenCalled();
+        });
     });
 
     describe('onChange', () => {

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -1,32 +1,65 @@
 import React, { useCallback } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { TestPlansDataSource } from '../TestPlansDataSource';
-import { OutputType, TestPlansQuery } from '../types';
-import { InlineField, RadioButtonGroup } from '@grafana/ui';
+import { OutputType, Properties, TestPlansQuery } from '../types';
+import { InlineField, MultiSelect, RadioButtonGroup, VerticalGroup } from '@grafana/ui';
 
 type Props = QueryEditorProps<TestPlansDataSource, TestPlansQuery>;
 
 export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   query = datasource.prepareQuery(query);
 
-  const onOutputTypeChange = useCallback((value: OutputType) => {
-    onChange({ ...query, outputType: value });
-    onRunQuery();
-  }, [query, onChange, onRunQuery]);
+  const handleQueryChange = useCallback(
+    (query: TestPlansQuery, runQuery = true): void => {
+      onChange(query);
+      if (runQuery) {
+        onRunQuery();
+      }
+    }, [onChange, onRunQuery]
+  );
+
+  const onOutputTypeChange = (value: OutputType) => {
+    handleQueryChange({ ...query, outputType: value });
+  };
+
+  const onPropertiesChange = (items: Array<SelectableValue<string>>) => {
+    if (items !== undefined) {
+      handleQueryChange({ ...query, properties: items.map(i => i.value as Properties) });
+    }
+  };
 
   return (
     <>
-      <InlineField label="Output" labelWidth={14} tooltip={tooltips.outputType}>
-        <RadioButtonGroup
-          options={Object.values(OutputType).map(value => ({ label: value, value })) as SelectableValue[]}
-          onChange={onOutputTypeChange}
-          value={query.outputType}
-        />
-      </InlineField>
+      <VerticalGroup>
+        <InlineField label="Output" labelWidth={18} tooltip={tooltips.outputType}>
+          <RadioButtonGroup
+            options={Object.values(OutputType).map(value => ({ label: value, value })) as SelectableValue[]}
+            onChange={onOutputTypeChange}
+            value={query.outputType}
+          />
+        </InlineField>
+        {query.outputType === OutputType.Properties && (
+          <InlineField label="Properties" labelWidth={18} tooltip={tooltips.properties}>
+            <MultiSelect
+              placeholder="Select properties to query"
+              options={Object.entries(Properties).map(([key, value]) => ({ label: value, value: key })) as SelectableValue[]}
+              onChange={onPropertiesChange}
+              value={query.properties}
+              defaultValue={query.properties}
+              noMultiValueWrap={true}
+              maxVisibleValues={5}
+              width={60}
+              allowCustomValue={false}
+              closeMenuOnSelect={false}
+            />
+          </InlineField>
+        )}
+      </VerticalGroup>
     </>
   );
 }
 
 const tooltips = {
-  outputType: 'This field specifies the output type to fetch test plan properties or total count'
+  outputType: 'This field specifies the output type to fetch test plan properties or total count.',
+  properties: "Specifies the properties to be queried."
 };

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -41,7 +41,7 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
         {query.outputType === OutputType.Properties && (
           <InlineField label="Properties" labelWidth={25} tooltip={tooltips.properties}>
             <MultiSelect
-              placeholder="Select properties to query"
+              placeholder="Select the properties to query"
               options={Object.entries(Properties).map(([key, value]) => ({ label: value, value: key })) as SelectableValue[]}
               onChange={onPropertiesChange}
               value={query.properties}
@@ -61,5 +61,5 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
 
 const tooltips = {
   outputType: 'This field specifies the output type to fetch test plan properties or total count.',
-  properties: "Specifies the properties to be queried."
+  properties: 'This field specifies the properties to use in the query.'
 };

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -31,7 +31,7 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
   return (
     <>
       <VerticalGroup>
-        <InlineField label="Output" labelWidth={18} tooltip={tooltips.outputType}>
+        <InlineField label="Output" labelWidth={25} tooltip={tooltips.outputType}>
           <RadioButtonGroup
             options={Object.values(OutputType).map(value => ({ label: value, value })) as SelectableValue[]}
             onChange={onOutputTypeChange}
@@ -39,7 +39,7 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
           />
         </InlineField>
         {query.outputType === OutputType.Properties && (
-          <InlineField label="Properties" labelWidth={18} tooltip={tooltips.properties}>
+          <InlineField label="Properties" labelWidth={25} tooltip={tooltips.properties}>
             <MultiSelect
               placeholder="Select properties to query"
               options={Object.entries(Properties).map(([key, value]) => ({ label: value, value: key })) as SelectableValue[]}

--- a/src/datasources/test-plans/types.ts
+++ b/src/datasources/test-plans/types.ts
@@ -1,10 +1,69 @@
 import { DataQuery } from '@grafana/schema'
 
 export interface TestPlansQuery extends DataQuery {
+    properties?: Properties[];
     outputType: OutputType;
 }
 
 export enum OutputType {
     Properties = "Properties",
     TotalCount = "Total Count"
+}
+
+export enum Properties {
+    assignedTo = 'Assigned to',
+    createdAt = 'Created at',
+    createdBy = 'Created by',
+    description = 'Description',
+    dueDate = 'Due date',
+    earliestStartDate = 'Earliest start date',
+    id = 'ID',
+    name = 'Name',
+    properties = 'Properties',
+    requestedBy = 'Requested by',
+    state = 'State',
+    type = 'Type',
+    updatedAt = 'Updated at',
+    updatedBy = 'Updated by',
+    workspace = 'Workspace',
+    workOrder = 'Work order name (Work oder ID)',
+    product = 'Product (Part number)',
+    plannedStartDate = 'Planned start date',
+    estimatedEndDate = 'Estimated end date',
+    estimatedDuration = 'Estimated duration',
+    system = 'System',
+    template = 'Test plan template (Template ID)',
+    testProgram = 'Test program name',
+    substate = 'Substate',
+    fixtureIds = 'Fixture IDs',
+    dut = 'DUT',
+}
+
+export const PropertiesOptions = {
+    ASSIGNED_TO: 'assignedTo',
+    CREATED_AT: 'createdAt',
+    CREATED_BY: 'createdBy',
+    DESCRIPTION: 'description',
+    DUE_DATE: 'dueDate',
+    EARLIEST_START_DATE: 'earliestStartDate',
+    ID: 'id',
+    NAME: 'name',
+    PROPERTIES: 'properties',
+    REQUESTED_BY: 'requestedBy',
+    STATE: 'state',
+    TYPE: 'type',
+    UPDATED_AT: 'updatedAt',
+    UPDATED_BY: 'updatedBy',
+    WORKSPACE: 'workspace',
+    WORK_ORDER: 'workOrder',
+    PRODUCT: 'product',
+    PLANNED_START_DATE: 'plannedStartDate',
+    ESTIMATED_END_DATE: 'estimatedEndDate',
+    ESTIMATED_DURATION: 'estimatedDuration',
+    SYSTEM: 'system',
+    TEMPLATE: 'template',
+    TEST_PROGRAM: 'testProgram',
+    SUBSTATE: 'substate',
+    FIXTURE_IDS: 'fixtureIds',
+    DUT: 'dut',
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

[User Story 3064428](https://ni.visualstudio.com/DevCentral/_workitems/edit/3064428): FE | Add Query Editor

![image](https://github.com/user-attachments/assets/b202b919-8eb3-44f6-ae9d-ce759e2080dc)


## 👩‍💻 Implementation

Added multi select for properties in query editor and added default properties in datasource

## 🧪 Testing

Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).