### PR TITLE
fix(products): Render and run Query on Mount

### DIFF
--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -23,7 +23,6 @@ describe('ProductsQueryEditor', () => {
     recordCount = screen.getByDisplayValue('1000');
   });
 
-
   it('should render with default query and call onRunQuery on mount', async () => {
     expect(properties).toBeInTheDocument();
     expect(properties).toHaveDisplayValue('');

--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -8,6 +8,7 @@ import userEvent from "@testing-library/user-event";
 
 const render = setupRenderer(ProductsQueryEditor, ProductsDataSource);
 let onChange: jest.Mock<any, any>
+let onRunQuery: jest.Mock<any, any>
 let properties: HTMLElement
 let orderBy: HTMLElement
 let descending: HTMLElement
@@ -15,12 +16,13 @@ let recordCount: HTMLElement
 
 describe('ProductsQueryEditor', () => {
   beforeEach(async () => {
-    [onChange] = render({ refId: '', properties: [], orderBy: undefined } as ProductQuery);
+    [onChange, onRunQuery] = render({ refId: '', properties: [], orderBy: undefined } as ProductQuery);
     await waitFor(() => properties = screen.getAllByRole('combobox')[0]);
     orderBy = screen.getAllByRole('combobox')[1];
     descending = screen.getByRole('checkbox');
     recordCount = screen.getByDisplayValue('1000');
   });
+
 
   it('renders with default query', async () => {
     expect(properties).toBeInTheDocument();
@@ -31,6 +33,17 @@ describe('ProductsQueryEditor', () => {
     expect(descending).toBeChecked();
     expect(recordCount).toBeInTheDocument();
     expect(recordCount).toHaveValue(1000);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refId: 'A',
+        properties: [],
+        orderBy: undefined,
+        descending: true,
+        recordCount: 1000,
+        queryBy: ''
+      }));
+    expect(onRunQuery).toHaveBeenCalledTimes(1);
   });
 
   it('renders the query builder', async () => {

--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -24,7 +24,7 @@ describe('ProductsQueryEditor', () => {
   });
 
 
-  it('renders with default query', async () => {
+  it('should render with default query and call onRunQuery on mount', async () => {
     expect(properties).toBeInTheDocument();
     expect(properties).toHaveDisplayValue('');
     expect(orderBy).toBeInTheDocument();

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -18,6 +18,11 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [partNumbers, setPartNumbers] = useState<string[]>([]);
   const [familyNames, setFamilyNames] = useState<string[]>([]);
+
+  useEffect(() => {
+      handleQueryChange(query, true);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Only run on mount
   
   useEffect(() => {
     const loadWorkspaces = async () => {
@@ -37,6 +42,10 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
     loadPartNumbers();
     loadFamilyNames();
   }, [datasource]);
+
+  useEffect(() => {
+
+  },[] );
 
   const handleQueryChange = useCallback((query: ProductQuery, runQuery = true): void => {
     onChange(query);

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -43,10 +43,6 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
     loadFamilyNames();
   }, [datasource]);
 
-  useEffect(() => {
-
-  },[] );
-
   const handleQueryChange = useCallback((query: ProductQuery, runQuery = true): void => {
     onChange(query);
     if (runQuery) {


### PR DESCRIPTION

# Pull Request

## 🤨 Rationale

To Fix: [Bug 3120762](https://dev.azure.com/ni/DevCentral/_workitems/edit/3120762): Products Datasource | Panel failed to refresh with default values.

## 👩‍💻 Implementation

- Added an `useEffect` which triggers the `HandleQueryChange` to run on mount .

## 🧪 Testing
- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).