### PR TITLE
feat(workorders): add support for output type

### DIFF
--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -68,7 +68,7 @@ describe('WorkOrdersDataSource', () => {
     test('returns work orders from API response', async () => {
       jest.spyOn(datastore, 'queryWorkOrders').mockResolvedValue(mockWorkOrders);
 
-      const result = await datastore.queryWorkordersData('filter', 10);
+      const result = await datastore.queryWorkordersData('filter');
 
       expect(result).toMatchSnapshot();
     });

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -2,12 +2,106 @@ import { BackendSrv } from '@grafana/runtime';
 import { MockProxy } from 'jest-mock-extended';
 import { setupDataSource, requestMatching, createFetchResponse, createFetchError } from 'test/fixtures';
 import { WorkOrdersDataSource } from './WorkOrdersDataSource';
+import { OutputType, State, Type, WorkOrdersResponse } from './types';
+import { DataQueryRequest } from '@grafana/data';
 
 let datastore: WorkOrdersDataSource, backendServer: MockProxy<BackendSrv>;
 
 describe('WorkOrdersDataSource', () => {
+  const mockWorkOrders: WorkOrdersResponse = {
+    workOrders: [
+      {
+        name: 'WorkOrder1',
+        id: '1',
+        state: State.Closed,
+        type: Type.TestRequest,
+        workspace: 'Workspace1',
+        earliestStartDate: '2023-01-04T00:00:00Z',
+        dueDate: '2023-01-03T00:00:00Z',
+        createdAt: '2023-01-01T00:00:00Z',
+        updatedAt: '2023-01-02T00:00:00Z',
+        assignedTo: 'User1',
+        requestedBy: 'User2',
+        createdBy: 'User3',
+        updatedBy: 'User4',
+        description: 'Test description',
+        properties: {},
+      },
+    ],
+    continuationToken: '',
+    totalCount: 2,
+  };
+
   beforeEach(() => {
     [datastore, backendServer] = setupDataSource(WorkOrdersDataSource);
+
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/niworkorder/v1/query-workorders', method: 'POST' }))
+      .mockReturnValue(createFetchResponse(mockWorkOrders));
+  });
+
+  describe('runQuery', () => {
+    test('processes work orders query when outputType is Properties', async () => {
+      const mockQuery = { refId: 'A', outputType: OutputType.Properties, queryBy: 'filter' };
+
+      jest.spyOn(datastore, 'queryWorkordersData').mockResolvedValue(mockWorkOrders.workOrders);
+
+      const response = await datastore.runQuery(mockQuery, {} as DataQueryRequest);
+
+      expect(response.fields).toHaveLength(1);
+      expect(response.fields).toMatchSnapshot();
+    });
+
+    test('returns total count when outputType is total count', async () => {
+      const mockQuery = { refId: 'B', outputType: OutputType.TotalCount, queryBy: 'filter' };
+
+      jest.spyOn(datastore, 'queryWorkordersCount').mockResolvedValue(42);
+
+      const result = await datastore.runQuery(mockQuery, {} as DataQueryRequest);
+
+      expect(result.fields).toEqual([{ name: 'Total count', values: [42] }]);
+      expect(result.refId).toEqual('B');
+    });
+  });
+
+  describe('queryWorkordersData', () => {
+    test('returns work orders from API response', async () => {
+      jest.spyOn(datastore, 'queryWorkOrders').mockResolvedValue(mockWorkOrders);
+
+      const result = await datastore.queryWorkordersData('filter', 10);
+
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('queryWorkordersCount', () => {
+    test('returns total count from API response', async () => {
+      jest.spyOn(datastore, 'queryWorkOrders').mockResolvedValue(mockWorkOrders);
+
+      const result = await datastore.queryWorkordersCount('filter');
+
+      expect(result).toEqual(2);
+    });
+  });
+
+  describe('queryWorkOrders', () => {
+    test('returns response from API', async () => {
+      const body = { filter: 'filter', take: 10 };
+      const response = await datastore.queryWorkOrders(body);
+
+      expect(response).toMatchSnapshot();
+    });
+
+    test('throws error when API call fails', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/niworkorder/v1/query-workorders' }))
+        .mockReturnValue(createFetchError(400));
+      const body = { filter: 'filter', take: 10 };
+
+      await expect(datastore.queryWorkOrders(body)).rejects.toThrow(
+        'Request to url "/niworkorder/v1/query-workorders" failed with status code: 400. Error message: "Error"'
+      );
+    });
   });
 
   describe('testDataSource', () => {

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -1,7 +1,7 @@
 import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
-import { WorkOrdersQuery } from './types';
+import { OutputType, QueryWorkOrdersRequestBody, WorkOrder, WorkOrdersQuery, WorkOrdersResponse } from './types';
 
 export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
   constructor(
@@ -15,17 +15,70 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
   baseUrl = `${this.instanceSettings.url}/niworkorder/v1`;
   queryWorkOrdersUrl = `${this.baseUrl}/query-workorders`;
 
-  defaultQuery = {};
+  defaultQuery = {
+    outputType: OutputType.Properties,
+  };
 
   async runQuery(query: WorkOrdersQuery, options: DataQueryRequest): Promise<DataFrameDTO> {
-    return {
-      refId: query.refId,
-      fields: [],
-    };
+    if (query.outputType === OutputType.Properties) {
+      return this.processWorkOrdersQuery(query);
+    } else {
+      const totalCount = await this.queryWorkordersCount(query.queryBy);
+
+      return {
+        refId: query.refId,
+        name: query.refId,
+        fields: [{ name: 'Total count', values: [totalCount] }],
+      };
+    }
   }
 
   shouldRunQuery(query: WorkOrdersQuery): boolean {
     return true;
+  }
+
+  async processWorkOrdersQuery(query: WorkOrdersQuery): Promise<DataFrameDTO> {
+    const workOrders: WorkOrder[] = await this.queryWorkordersData(query.queryBy);
+
+    // TODO: Update selected fields based on the properties selected in the query
+    const selectedFields = ['name'];
+
+    const mappedFields = selectedFields.map((field) => {
+      const fieldName = field;
+      const fieldValue = workOrders.map(data => data[field as unknown as keyof WorkOrder]);
+      return { name: fieldName, values: fieldValue };
+    });
+
+    return { refId: query.refId, fields: mappedFields };
+  }
+
+  async queryWorkordersData(filter = ''): Promise<WorkOrder[]> {
+    const body = {
+      filter
+    };
+
+    const response = await this.queryWorkOrders(body);
+    return response.workOrders;
+  }
+
+  async queryWorkordersCount(filter = ''): Promise<number> {
+    const body = {
+      filter,
+      take: 0,
+      returnCount: true,
+    };
+
+    const response = await this.queryWorkOrders(body);
+    return response.totalCount ?? 0;
+  }
+
+  async queryWorkOrders(body: QueryWorkOrdersRequestBody): Promise<WorkOrdersResponse> {
+    try {
+      let response = await this.post<WorkOrdersResponse>(this.queryWorkOrdersUrl, body);
+      return response;
+    } catch (error) {
+      throw new Error(`An error occurred while querying workorders: ${error}`);
+    }
   }
 
   async testDatasource(): Promise<TestDataSourceResponse> {

--- a/src/datasources/work-orders/__snapshots__/WorkOrdersDataSource.test.ts.snap
+++ b/src/datasources/work-orders/__snapshots__/WorkOrdersDataSource.test.ts.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WorkOrdersDataSource queryWorkOrders returns response from API 1`] = `
+{
+  "continuationToken": "",
+  "totalCount": 2,
+  "workOrders": [
+    {
+      "assignedTo": "User1",
+      "createdAt": "2023-01-01T00:00:00Z",
+      "createdBy": "User3",
+      "description": "Test description",
+      "dueDate": "2023-01-03T00:00:00Z",
+      "earliestStartDate": "2023-01-04T00:00:00Z",
+      "id": "1",
+      "name": "WorkOrder1",
+      "properties": {},
+      "requestedBy": "User2",
+      "state": "CLOSED",
+      "type": "TEST_REQUEST",
+      "updatedAt": "2023-01-02T00:00:00Z",
+      "updatedBy": "User4",
+      "workspace": "Workspace1",
+    },
+  ],
+}
+`;
+
+exports[`WorkOrdersDataSource queryWorkordersData returns work orders from API response 1`] = `
+[
+  {
+    "assignedTo": "User1",
+    "createdAt": "2023-01-01T00:00:00Z",
+    "createdBy": "User3",
+    "description": "Test description",
+    "dueDate": "2023-01-03T00:00:00Z",
+    "earliestStartDate": "2023-01-04T00:00:00Z",
+    "id": "1",
+    "name": "WorkOrder1",
+    "properties": {},
+    "requestedBy": "User2",
+    "state": "CLOSED",
+    "type": "TEST_REQUEST",
+    "updatedAt": "2023-01-02T00:00:00Z",
+    "updatedBy": "User4",
+    "workspace": "Workspace1",
+  },
+]
+`;
+
+exports[`WorkOrdersDataSource runQuery processes work orders query when outputType is Properties 1`] = `
+[
+  {
+    "name": "name",
+    "values": [
+      "WorkOrder1",
+    ],
+  },
+]
+`;

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
@@ -1,15 +1,72 @@
-import { setupRenderer } from 'test/fixtures';
-import { screen } from '@testing-library/react';
-import { WorkOrdersQuery } from '../types';
-import { WorkOrdersDataSource } from '../WorkOrdersDataSource';
+import { render, waitFor } from '@testing-library/react';
+import { OutputType, WorkOrdersQuery } from '../types';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { QueryEditorProps } from '@grafana/data';
 import { WorkOrdersQueryEditor } from './WorkOrdersQueryEditor';
+import { WorkOrdersDataSource } from '../WorkOrdersDataSource';
 
-const render = setupRenderer(WorkOrdersQueryEditor, WorkOrdersDataSource);
+const mockOnChange = jest.fn();
+const mockOnRunQuery = jest.fn();
+const mockDatasource = {
+    prepareQuery: jest.fn((query: WorkOrdersQuery) => query),
+} as unknown as WorkOrdersDataSource;
+
+const defaultProps: QueryEditorProps<WorkOrdersDataSource, WorkOrdersQuery> = {
+    query: {
+        refId: 'A',
+        outputType: OutputType.Properties,
+    },
+    onChange: mockOnChange,
+    onRunQuery: mockOnRunQuery,
+    datasource: mockDatasource,
+};
 
 describe('WorkOrdersQueryEditor', () => {
-  it('renders with query defaults', async () => {
-    render({} as WorkOrdersQuery);
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  function renderElement(query: WorkOrdersQuery = { refId: 'A', outputType: OutputType.Properties }) {
+    const reactNode = React.createElement(WorkOrdersQueryEditor, { ...defaultProps, query });
+    return render(reactNode);
+  }
 
-    expect(screen.getByText('Placeholder for querybuilder')).toBeInTheDocument();
+  it('should render default query', () => {
+    const container = renderElement();
+
+    expect(container.getByRole('radio', { name: OutputType.Properties })).toBeInTheDocument();
+    expect(container.getByRole('radio', { name: OutputType.Properties })).toBeChecked();
+    expect(container.getByRole('radio', { name: OutputType.TotalCount })).toBeInTheDocument();
+    expect(container.getByRole('radio', { name: OutputType.TotalCount })).not.toBeChecked();
+  });
+
+  describe('onChange', () => {
+    it('should call onChange with properties output type when switching from total count', async () => {
+      const query = {
+        refId: 'A',
+        outputType: OutputType.TotalCount,
+      };
+      const container = renderElement(query);
+
+      const propertiesRadio = container.getByRole('radio', { name: OutputType.Properties });
+      userEvent.click(propertiesRadio);
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ outputType: OutputType.Properties }));
+        expect(mockOnRunQuery).toHaveBeenCalled();
+      });
+    });
+
+    it('should call onChange with total count output type when switching from properties', async () => {
+      const container = renderElement();
+
+      const totalCountRadio = container.getByRole('radio', { name: OutputType.TotalCount });
+      userEvent.click(totalCountRadio);
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ outputType: OutputType.TotalCount }));
+        expect(mockOnRunQuery).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
@@ -1,15 +1,32 @@
-import React from 'react';
-import { QueryEditorProps } from '@grafana/data';
+import React, { useCallback } from 'react';
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { WorkOrdersDataSource } from '../WorkOrdersDataSource';
-import { WorkOrdersQuery } from '../types';
+import { OutputType, WorkOrdersQuery } from '../types';
+import { InlineField, RadioButtonGroup } from '@grafana/ui';
 
 type Props = QueryEditorProps<WorkOrdersDataSource, WorkOrdersQuery>;
 
-export function WorkOrdersQueryEditor({ query, onChange, onRunQuery }: Props) {
+export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+  query = datasource.prepareQuery(query);
+
+  const onOutputTypeChange = useCallback((value: OutputType) => {
+    onChange({ ...query, outputType: value });
+    onRunQuery();
+  }, [query, onChange, onRunQuery]);
 
   return (
     <>
-    <span>Placeholder for querybuilder</span>
+      <InlineField label="Output" labelWidth={14} tooltip={tooltips.outputType}>
+        <RadioButtonGroup
+          options={Object.values(OutputType).map(value => ({ label: value, value })) as SelectableValue[]}
+          onChange={onOutputTypeChange}
+          value={query.outputType}
+        />
+      </InlineField>
     </>
   );
 }
+
+const tooltips = {
+  outputType: 'This field specifies the output type to fetch test plan properties or total count'
+};

--- a/src/datasources/work-orders/types.ts
+++ b/src/datasources/work-orders/types.ts
@@ -1,4 +1,62 @@
-import { DataQuery } from '@grafana/schema'
+import { DataQuery } from '@grafana/schema';
 
 export interface WorkOrdersQuery extends DataQuery {
+    outputType: OutputType;
+    queryBy?: string;
+}
+
+export enum OutputType {
+    Properties = "Properties",
+    TotalCount = "Total Count"
+}
+export interface QueryWorkOrdersRequestBody {
+    filter?: string;
+    take?: number;
+    orderBy?: string;
+    descending?: boolean;
+    returnCount?: boolean;
+    projection?: string[];
+    substitutions?: string[];
+    continuationToken?: string;
+}
+
+export interface WorkOrdersResponse {
+    workOrders: WorkOrder[];
+    continuationToken?: string;
+    totalCount?: number;
+}
+
+export interface WorkOrder {
+    id: string;
+    name: string;
+    type: Type;
+    description: string | null;
+    state: State;
+    createdBy: string;
+    updatedBy: string;
+    assignedTo: string | null;
+    requestedBy: string | null;
+    createdAt: string;
+    updatedAt: string;
+    earliestStartDate: string | null;
+    dueDate: string | null;
+    properties: {
+        [key: string]: string
+    };
+    workspace: string;
+}
+
+export enum Type {
+    TestRequest = 'TEST_REQUEST'
+}
+
+export enum State {
+    New = 'NEW',
+    Defined = 'DEFINED',
+    Reviewed = 'REVIEWED',
+    Scheduled = 'SCHEDULED',
+    InProgress = 'IN_PROGRESS',
+    PendingApproval = 'PENDING_APPROVAL',
+    Closed = 'CLOSED',
+    Canceled = 'CANCELED'
 }


### PR DESCRIPTION
# Pull Request
[User Story 3064385](https://dev.azure.com/ni/DevCentral/_workitems/edit/3064385): FE | Add Query editor
To enable toggle for output type to select Properties or Total Count
![image](https://github.com/user-attachments/assets/a6b2bbd4-c378-47cc-a1bb-26fb9d8d6ea1)


## 👩‍💻 Implementation

- Added Radio selection control in test plans query editor
- Added output type in the test plan query
- Added methods and models to query workorders
- Added support to query workorders properties or data based on output type

## 🧪 Testing

- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [X] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).