### PR TITLE
feat(results): Load PartNumber and Workspace lookups in Variable Editor Query builder

### DIFF
--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -1,19 +1,47 @@
 import { screen, waitFor } from '@testing-library/react';
 import { ResultsVariableQueryEditor } from './ResultsVariableQueryEditor';
-import { ResultsVariableQuery } from 'datasources/results/types/QueryResults.types';
 import { setupRenderer } from 'test/fixtures';
+import { ResultsDataSource } from 'datasources/results/ResultsDataSource';
+import { ResultsQuery } from 'datasources/results/types/types';
+import { Workspace } from 'core/types';
 import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
 
-class FakeQueryResultsDataSource extends QueryResultsDataSource {
-  globalVariableOptions = jest.fn(() => [{ label: 'Global', value: 'global' }]);
+const fakeWorkspaces: Workspace[] = [
+  {
+    id: '1',
+    name: 'workspace1',
+    default: false,
+    enabled: true,
+  },
+  {
+    id: '2',
+    name: 'workspace2',
+    default: false,
+    enabled: true,
+  },
+];
+
+class FakeQueryResultsSource extends QueryResultsDataSource {
+  getWorkspaces(): Promise<Workspace[]> {
+    return Promise.resolve(fakeWorkspaces);
+  }
+  getPartNumbers(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
-const renderEditor = setupRenderer(ResultsVariableQueryEditor, FakeQueryResultsDataSource as any, () => {});
+class FakeResultsDataSource extends ResultsDataSource {
+  get queryResultsDataSource() {
+    return new FakeQueryResultsSource(this.instanceSettings, this.backendSrv, this.templateSrv);
+  }
+}
+
+const renderEditor = setupRenderer(ResultsVariableQueryEditor, FakeResultsDataSource, () => {});
 let propertiesSelect: HTMLElement;
 let queryBy: HTMLElement;
 
 it('should render properties select and results query builder', async () => {
-  renderEditor({ refId: '', properties: '', queryBy: '' } as ResultsVariableQuery);
+  renderEditor({ refId: '', properties: '', queryBy: '' } as unknown as ResultsQuery);
   propertiesSelect = screen.getAllByRole('combobox')[0];
   queryBy = screen.getByText('Query By');
 
@@ -23,4 +51,18 @@ it('should render properties select and results query builder', async () => {
   await waitFor(() => expect(screen.getAllByText('Property').length).toBe(1));
   await waitFor(() => expect(screen.getAllByText('Operator').length).toBe(1));
   await waitFor(() => expect(screen.getAllByText('Value').length).toBe(1));
+});
+
+it('should load part numbers on mount', async () => {
+  const queryResultValuesSpy = jest.spyOn(FakeQueryResultsSource.prototype, 'getPartNumbers');
+  renderEditor({ refId: '', properties: '', queryBy: '' } as unknown as ResultsQuery);
+
+  expect(queryResultValuesSpy).toHaveBeenCalledTimes(1);
+});
+
+it('should load workspaces on mount', async () => {
+  const getWorkspace = jest.spyOn(FakeQueryResultsSource.prototype, 'getWorkspaces');
+  renderEditor({ refId: '', properties: '', queryBy: '' } as unknown as ResultsQuery);
+
+  expect(getWorkspace).toHaveBeenCalledTimes(1);
 });

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -1,40 +1,62 @@
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { InlineField } from 'core/components/InlineField';
-import React from 'react';
-import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
+import React, { useEffect, useRef, useState } from 'react';
 import { ResultsVariableProperties, ResultsVariableQuery } from 'datasources/results/types/QueryResults.types';
 import { ResultsQueryBuilder } from '../query-builders/query-results/ResultsQueryBuilder';
 import { Select } from '@grafana/ui';
+import { Workspace } from 'core/types';
+import { enumToOptions } from 'core/utils';
+import { ResultsDataSourceOptions, ResultsQuery, TestMeasurementStatus } from 'datasources/results/types/types';
+import { ResultsDataSource } from 'datasources/results/ResultsDataSource';
 
-type Props = QueryEditorProps<QueryResultsDataSource, ResultsVariableQuery>;
+type Props = QueryEditorProps<ResultsDataSource, ResultsQuery, ResultsDataSourceOptions>;
 
 export function ResultsVariableQueryEditor({ query, onChange, datasource }: Props) {
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [partNumbers, setPartNumbers] = useState<string[]>([]);
+  const queryResultsquery = query as ResultsVariableQuery;
+  const queryResultsDataSource = useRef(datasource.queryResultsDataSource);
+
+  useEffect(() => { 
+    const loadWorkspaces = async () => {
+      await queryResultsDataSource.current.loadWorkspaces();
+      setWorkspaces(Array.from(queryResultsDataSource.current.workspacesCache.values()));
+    };
+    const loadPartNumbers = async () => {
+      await queryResultsDataSource.current.getPartNumbers();
+      setPartNumbers(queryResultsDataSource.current.partNumbersCache);
+    };
+
+    loadWorkspaces();
+    loadPartNumbers();
+  }, [datasource]);
+
   const onPropertiesChange = (item: SelectableValue<string>) => {
-    onChange({ ...query, properties: item.value });
+    onChange({ ...queryResultsquery, properties: item.value } as ResultsVariableQuery);
   };
 
   const onQueryByChange = (value: string) => {
-    onChange({ ...query, queryBy: value });
+    onChange({ ...queryResultsquery, queryBy: value } as ResultsVariableQuery);
   };
 
   return (
     <>
       <InlineField label="Properties" labelWidth={12} tooltip={tooltips.properties}>
-        <Select 
-            onChange={onPropertiesChange}
-            options={ResultsVariableProperties as SelectableValue[]}
-            value={query.properties}
-            defaultValue={query.properties}
+        <Select
+          onChange={onPropertiesChange}
+          options={ResultsVariableProperties as SelectableValue[]}
+          value={queryResultsquery.properties}
+          defaultValue={queryResultsquery.properties}
         ></Select>
       </InlineField>
       <InlineField label="Query By" labelWidth={12} tooltip={tooltips.queryBy}>
         <ResultsQueryBuilder
-          filter={query.queryBy}
+          filter={queryResultsquery.queryBy}
           onChange={(event: any) => onQueryByChange(event.detail.linq)}
-          workspaces={[]}
-          partNumbers={[]}
-          status={[]}
-          globalVariableOptions={[]}
+          workspaces={workspaces}
+          partNumbers={partNumbers}
+          status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
+          globalVariableOptions={queryResultsDataSource.current.globalVariableOptions()}
         ></ResultsQueryBuilder>
       </InlineField>
     </>
@@ -43,5 +65,5 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
 
 const tooltips = {
   queryBy: 'This field applies a filter to the query results.',
-  properties: "This field specifies the properties to use in the query.",
+  properties: 'This field specifies the properties to use in the query.',
 };

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -64,6 +64,6 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
 }
 
 const tooltips = {
-  queryBy: 'This field applies a filter to the query results.',
-  properties: 'This field specifies the properties to use in the query.',
+  queryBy: 'Apply a filter to the query results using this field.',
+  properties: 'Select the property to return from the query.',
 };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As part of  [User Story 2798323](https://dev.azure.com/ni/DevCentral/_workitems/edit/2798323): FE | Add Variable Query Editor for Results DataSource, this PR contains changes to the queryProps of `ResultsVariableQueryEditor` and adding functionality to load workspaces and part numbers.

## 👩‍💻 Implementation

- Replaced `QueryResultsDataSource` with `ResultsDataSource` to get the queryResultsDatasource instance and methods like the `getProductNames` and `getWorkspaces` from the base class. 
- Added `useEffect` hooks to load workspaces and part numbers on mount, and updated state management with `useState` and `useRef`. 
- Updated the `tooltips` object for consistency in formatting.

## 🧪 Testing

- Added unit test cases to check loading of lookups

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).