### PR TITLE
feat(results): Add logic to metricFindQuery of results variable query

### DIFF
--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -420,20 +420,37 @@ describe('QueryResultsDataSource', () => {
       const mockResults = [
         { dataTableIds: ['A', 'B'] },
         { dataTableIds: ['B', 'C'] },
-        { partNumber: 'D' }
+        { dataTableIds: ['C'] },
       ];
       backendServer.fetch
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
         .mockReturnValue(createFetchResponse({ results: mockResults, totalCount: 3 }));
 
-      const query = { properties: ResultsPropertiesOptions.PART_NUMBER, queryBy: '' } as ResultsVariableQuery;
+      const query = { properties: 'DATA_TABLE_IDS', queryBy: '' } as ResultsVariableQuery;
       const result = await datastore.metricFindQuery(query, {});
 
       expect(result).toEqual([
         { text: 'A', value: 'A' },
         { text: 'B', value: 'B' },
         { text: 'C', value: 'C' },
-        { text: 'D', value: 'D' }
+      ]);
+    });
+
+    test('should return values when results is scalar', async () => {
+      const mockResults = [
+        { programName: 'programName1' },
+        { programName: 'programName2' },
+      ];
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
+        .mockReturnValue(createFetchResponse({ results: mockResults, totalCount: 2 }));
+
+      const query = { properties: 'PROGRAM_NAME', queryBy: '' } as ResultsVariableQuery;
+      const result = await datastore.metricFindQuery(query, {});
+
+      expect(result).toEqual([
+        { text: 'programName1', value: 'programName1' },
+        { text: 'programName2', value: 'programName2' },
       ]);
     });
 
@@ -449,7 +466,7 @@ describe('QueryResultsDataSource', () => {
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
         .mockReturnValue(createFetchResponse({ results: mockResults, totalCount: 1 }));
 
-      const query = { properties: ResultsPropertiesOptions.PROGRAM_NAME, queryBy } as ResultsVariableQuery;
+      const query = { properties: 'PROGRAM_NAME', queryBy } as ResultsVariableQuery;
       const options = { scopedVars: { var: { value: 'ReplacedValue' } } };
       const result = await datastore.metricFindQuery(query, options);
 

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -104,12 +104,45 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
         : this.multipleValuesQuery(field),
     ])
   );
-  
-  async metricFindQuery(_query: ResultsVariableQuery, _options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+
+  async metricFindQuery(query: ResultsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+    const filter = query.queryBy ? transformComputedFieldsQuery(
+      this.templateSrv.replace(query.queryBy, options?.scopedVars),
+      this.resultsComputedDataFields
+    ) : undefined;
+
+    const metadata = (await this.queryResults(
+      filter,
+      'UPDATED_AT',
+      [query.properties as ResultsProperties],
+      1000
+    )).results;
+
+    if (metadata.length > 0) {
+      const propertyKey = ResultsPropertiesOptions[query.properties as keyof typeof ResultsPropertiesOptions] as keyof ResultsResponseProperties;
+      const values = metadata.map((data: ResultsResponseProperties) => data[propertyKey]).filter(value => value !== undefined && value !== null);
+      const flattenedResults = this.flattenAndDeduplicate(values as string[]);
+      return flattenedResults.map(value => ({ text: String(value), value }));
+    }
     return [];
+  }
+
+  /**
+   * Flattens an array of strings, where each element may be a string or an array of strings,
+   * into a single-level array and removes duplicate values.
+   *
+   * @param values - An array containing strings or arrays of strings to be flattened and deduplicated.
+   * @returns A new array containing unique string values from the input, flattened to a single level.
+   */
+  private flattenAndDeduplicate(values: string[]): any[] {
+    const flatValues = values.flatMap(
+      (value) => Array.isArray(value) ? value : [value]);
+    return Array.from(new Set(flatValues));
   }
 
   shouldRunQuery(_: QueryResults): boolean {
     return true;
   }
 }
+
+

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -134,7 +134,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
    * @param values - An array containing strings or arrays of strings to be flattened and deduplicated.
    * @returns A new array containing unique string values from the input, flattened to a single level.
    */
-  private flattenAndDeduplicate(values: string[]): any[] {
+  private flattenAndDeduplicate(values: string[]): string[] {
     const flatValues = values.flatMap(
       (value) => Array.isArray(value) ? value : [value]);
     return Array.from(new Set(flatValues));


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As part of [User Story 2798323](https://dev.azure.com/ni/DevCentral/_workitems/edit/2798323): FE | Add Variable Query Editor for Results DataSource. This PR contains changes to the `QueryResultsDatasource` by adding logic to the `metricFindQuery` method. 

## 👩‍💻 Implementation

- Updated the `metricFindQuery` method to process queries with optional filters, transform computed fields, and handle query results with better type safety.
- Added a private utility method `flattenAndDeduplicate` to simplify and deduplicate arrays of strings or arrays of strings. 

## 🧪 Testing

- Added unit test cases

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).