### PR TITLE
feat(results):  Conditionally render QueryBy field and adjust label widths

### DIFF
--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -1,10 +1,12 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ResultsVariableQueryEditor } from './ResultsVariableQueryEditor';
 import { setupRenderer } from 'test/fixtures';
 import { ResultsDataSource } from 'datasources/results/ResultsDataSource';
 import { ResultsQuery } from 'datasources/results/types/types';
 import { Workspace } from 'core/types';
 import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
+import { ResultsVariableProperties, ResultsVariableQuery } from 'datasources/results/types/QueryResults.types';
+import React = require('react');
 
 const fakeWorkspaces: Workspace[] = [
   {
@@ -40,12 +42,18 @@ const renderEditor = setupRenderer(ResultsVariableQueryEditor, FakeResultsDataSo
 let propertiesSelect: HTMLElement;
 let queryBy: HTMLElement;
 
-it('should render properties select and results query builder', async () => {
+it('should render properties select and results query builder progressively', async () => {
   renderEditor({ refId: '', properties: '', queryBy: '' } as unknown as ResultsQuery);
   propertiesSelect = screen.getAllByRole('combobox')[0];
-  queryBy = screen.getByText('Query By');
 
   expect(propertiesSelect).toBeInTheDocument();
+
+  //simulate user selecting a property
+  fireEvent.keyDown(propertiesSelect, { key: 'ArrowDown' });
+  const option = await screen.findByText(ResultsVariableProperties[0].label);
+  fireEvent.click(option);
+
+  queryBy = screen.getByText('Query by result properties');
   expect(queryBy).toBeInTheDocument();
 
   await waitFor(() => expect(screen.getAllByText('Property').length).toBe(1));

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -52,7 +52,7 @@ it('should render properties select and results query builder progressively', as
   const option = await screen.findByText(ResultsVariableProperties[0].label);
   fireEvent.click(option);
 
-  queryBy = screen.getByText('Query by result properties');
+  queryBy = screen.getByText('Query by results properties');
   expect(queryBy).toBeInTheDocument();
 
   await waitFor(() => expect(screen.getAllByText('Property').length).toBe(1));

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { ResultsVariableQueryEditor } from './ResultsVariableQueryEditor';
 import { setupRenderer } from 'test/fixtures';
 import { ResultsDataSource } from 'datasources/results/ResultsDataSource';
@@ -6,7 +6,6 @@ import { ResultsQuery } from 'datasources/results/types/types';
 import { Workspace } from 'core/types';
 import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
 import { ResultsVariableProperties, ResultsVariableQuery } from 'datasources/results/types/QueryResults.types';
-import React = require('react');
 
 const fakeWorkspaces: Workspace[] = [
   {

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -5,7 +5,7 @@ import { ResultsDataSource } from 'datasources/results/ResultsDataSource';
 import { ResultsQuery } from 'datasources/results/types/types';
 import { Workspace } from 'core/types';
 import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
-import { ResultsVariableProperties, ResultsVariableQuery } from 'datasources/results/types/QueryResults.types';
+import { ResultsVariableProperties } from 'datasources/results/types/QueryResults.types';
 
 const fakeWorkspaces: Workspace[] = [
   {

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -41,7 +41,7 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
 
   return (
     <>
-      <InlineField label="Properties" labelWidth={12} tooltip={tooltips.properties}>
+      <InlineField label="Properties" labelWidth={25} tooltip={tooltips.properties}>
         <Select
           onChange={onPropertiesChange}
           options={ResultsVariableProperties as SelectableValue[]}
@@ -49,16 +49,19 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
           defaultValue={queryResultsquery.properties}
         ></Select>
       </InlineField>
-      <InlineField label="Query By" labelWidth={12} tooltip={tooltips.queryBy}>
-        <ResultsQueryBuilder
-          filter={queryResultsquery.queryBy}
-          onChange={(event: any) => onQueryByChange(event.detail.linq)}
-          workspaces={workspaces}
-          partNumbers={partNumbers}
-          status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
-          globalVariableOptions={queryResultsDataSource.current.globalVariableOptions()}
-        ></ResultsQueryBuilder>
-      </InlineField>
+      {(queryResultsquery.properties! === ResultsVariableProperties[0].value ||
+        queryResultsquery.properties === ResultsVariableProperties[1].value) && (
+        <InlineField label="Query by result properties" labelWidth={25} tooltip={tooltips.queryBy}>
+          <ResultsQueryBuilder
+            filter={queryResultsquery.queryBy}
+            onChange={(event: any) => onQueryByChange(event.detail.linq)}
+            workspaces={workspaces}
+            partNumbers={partNumbers}
+            status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
+            globalVariableOptions={queryResultsDataSource.current.globalVariableOptions()}
+          ></ResultsQueryBuilder>
+        </InlineField>
+      )}
     </>
   );
 }

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -41,7 +41,7 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
 
   return (
     <>
-      <InlineField label="Properties" labelWidth={25} tooltip={tooltips.properties}>
+      <InlineField label="Properties" labelWidth={26} tooltip={tooltips.properties}>
         <Select
           onChange={onPropertiesChange}
           options={ResultsVariableProperties as SelectableValue[]}
@@ -51,7 +51,7 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
       </InlineField>
       {(queryResultsquery.properties! === ResultsVariableProperties[0].value ||
         queryResultsquery.properties === ResultsVariableProperties[1].value) && (
-        <InlineField label="Query by result properties" labelWidth={25} tooltip={tooltips.queryBy}>
+        <InlineField label="Query by results properties" labelWidth={26} tooltip={tooltips.queryBy}>
           <ResultsQueryBuilder
             filter={queryResultsquery.queryBy}
             onChange={(event: any) => onQueryByChange(event.detail.linq)}

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -420,20 +420,37 @@ describe('QueryResultsDataSource', () => {
       const mockResults = [
         { dataTableIds: ['A', 'B'] },
         { dataTableIds: ['B', 'C'] },
-        { partNumber: 'D' }
+        { dataTableIds: ['C'] },
       ];
       backendServer.fetch
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
         .mockReturnValue(createFetchResponse({ results: mockResults, totalCount: 3 }));
 
-      const query = { properties: ResultsPropertiesOptions.PART_NUMBER, queryBy: '' } as ResultsVariableQuery;
+      const query = { properties: 'DATA_TABLE_IDS', queryBy: '' } as ResultsVariableQuery;
       const result = await datastore.metricFindQuery(query, {});
 
       expect(result).toEqual([
         { text: 'A', value: 'A' },
         { text: 'B', value: 'B' },
         { text: 'C', value: 'C' },
-        { text: 'D', value: 'D' }
+      ]);
+    });
+
+    test('should return values when results is scalar', async () => {
+      const mockResults = [
+        { programName: 'programName1' },
+        { programName: 'programName2' },
+      ];
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
+        .mockReturnValue(createFetchResponse({ results: mockResults, totalCount: 2 }));
+
+      const query = { properties: 'PROGRAM_NAME', queryBy: '' } as ResultsVariableQuery;
+      const result = await datastore.metricFindQuery(query, {});
+
+      expect(result).toEqual([
+        { text: 'programName1', value: 'programName1' },
+        { text: 'programName2', value: 'programName2' },
       ]);
     });
 
@@ -449,7 +466,7 @@ describe('QueryResultsDataSource', () => {
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
         .mockReturnValue(createFetchResponse({ results: mockResults, totalCount: 1 }));
 
-      const query = { properties: ResultsPropertiesOptions.PROGRAM_NAME, queryBy } as ResultsVariableQuery;
+      const query = { properties: 'PROGRAM_NAME', queryBy } as ResultsVariableQuery;
       const options = { scopedVars: { var: { value: 'ReplacedValue' } } };
       const result = await datastore.metricFindQuery(query, options);
 

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -406,7 +406,7 @@ describe('QueryResultsDataSource', () => {
 
   describe('metricFindQuery', () => {
     test('should return empty array when properties is not selected', async () => {
-      const query = { properties: '', queryBy: '' } as ResultsVariableQuery;
+      const query = { properties: undefined, queryBy: '' } as ResultsVariableQuery;
       const result = await datastore.metricFindQuery(query, {});
 
       expect(result).toEqual([]);

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -405,6 +405,13 @@ describe('QueryResultsDataSource', () => {
   });
 
   describe('metricFindQuery', () => {
+    test('should return empty array when properties is not selected', async () => {
+      const query = { properties: '', queryBy: '' } as ResultsVariableQuery;
+      const result = await datastore.metricFindQuery(query, {});
+
+      expect(result).toEqual([]);
+    });
+
     test('should return empty array when there are no results', async () => {
       backendServer.fetch
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -106,23 +106,25 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
   );
 
   async metricFindQuery(query: ResultsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
-    const filter = query.queryBy ? transformComputedFieldsQuery(
-      this.templateSrv.replace(query.queryBy, options?.scopedVars),
-      this.resultsComputedDataFields
-    ) : undefined;
+    if (query.properties !== '') {
+      const filter = query.queryBy ? transformComputedFieldsQuery(
+        this.templateSrv.replace(query.queryBy, options?.scopedVars),
+        this.resultsComputedDataFields
+      ) : undefined;
 
-    const metadata = (await this.queryResults(
-      filter,
-      'UPDATED_AT',
-      [query.properties as ResultsProperties],
-      1000
-    )).results;
+      const metadata = (await this.queryResults(
+        filter,
+        'UPDATED_AT',
+        [query.properties as ResultsProperties],
+        1000
+      )).results;
 
-    if (metadata.length > 0) {
-      const propertyKey = ResultsPropertiesOptions[query.properties as keyof typeof ResultsPropertiesOptions] as keyof ResultsResponseProperties;
-      const values = metadata.map((data: ResultsResponseProperties) => data[propertyKey]).filter(value => value !== undefined && value !== null);
-      const flattenedResults = this.flattenAndDeduplicate(values as string[]);
-      return flattenedResults.map(value => ({ text: String(value), value }));
+      if (metadata.length > 0) {
+        const propertyKey = ResultsPropertiesOptions[query.properties as keyof typeof ResultsPropertiesOptions] as keyof ResultsResponseProperties;
+        const values = metadata.map((data: ResultsResponseProperties) => data[propertyKey]).filter(value => value !== undefined && value !== null);
+        const flattenedResults = this.flattenAndDeduplicate(values as string[]);
+        return flattenedResults.map(value => ({ text: String(value), value }));
+      }
     }
     return [];
   }

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -104,12 +104,45 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
         : this.multipleValuesQuery(field),
     ])
   );
-  
-  async metricFindQuery(_query: ResultsVariableQuery, _options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+
+  async metricFindQuery(query: ResultsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+    const filter = query.queryBy ? transformComputedFieldsQuery(
+      this.templateSrv.replace(query.queryBy, options?.scopedVars),
+      this.resultsComputedDataFields
+    ) : undefined;
+
+    const metadata = (await this.queryResults(
+      filter,
+      'UPDATED_AT',
+      [query.properties as ResultsProperties],
+      1000
+    )).results;
+
+    if (metadata.length > 0) {
+      const propertyKey = ResultsPropertiesOptions[query.properties as keyof typeof ResultsPropertiesOptions] as keyof ResultsResponseProperties;
+      const values = metadata.map((data: ResultsResponseProperties) => data[propertyKey]).filter(value => value !== undefined && value !== null);
+      const flattenedResults = this.flattenAndDeduplicate(values as string[]);
+      return flattenedResults.map(value => ({ text: String(value), value }));
+    }
     return [];
+  }
+
+  /**
+   * Flattens an array of strings, where each element may be a string or an array of strings,
+   * into a single-level array and removes duplicate values.
+   *
+   * @param values - An array containing strings or arrays of strings to be flattened and deduplicated.
+   * @returns A new array containing unique string values from the input, flattened to a single level.
+   */
+  private flattenAndDeduplicate(values: string[]): any[] {
+    const flatValues = values.flatMap(
+      (value) => Array.isArray(value) ? value : [value]);
+    return Array.from(new Set(flatValues));
   }
 
   shouldRunQuery(_: QueryResults): boolean {
     return true;
   }
 }
+
+

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -106,7 +106,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
   );
 
   async metricFindQuery(query: ResultsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
-    if (query.properties !== '') {
+    if (query.properties !== undefined) {
       const filter = query.queryBy ? transformComputedFieldsQuery(
         this.templateSrv.replace(query.queryBy, options?.scopedVars),
         this.resultsComputedDataFields

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -134,7 +134,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
    * @param values - An array containing strings or arrays of strings to be flattened and deduplicated.
    * @returns A new array containing unique string values from the input, flattened to a single level.
    */
-  private flattenAndDeduplicate(values: string[]): any[] {
+  private flattenAndDeduplicate(values: string[]): string[] {
     const flatValues = values.flatMap(
       (value) => Array.isArray(value) ? value : [value]);
     return Array.from(new Set(flatValues));


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
This PR contains changes to conditionally render the query builder in the Results Variable Query Editor.
![Progressive Variable query - Results](https://github.com/user-attachments/assets/31fb3bcc-b59a-4ea7-9d1e-9771b890a607)


## 👩‍💻 Implementation
- Add a condition to render the "Query by result properties" field only when properties are selected . This ensures the query builder is displayed contextually.
- Add condition to call the API only when the properties are selected.
- Increase the label width for the "Properties" and "Query by result properties" fields from 12 to 25 for better alignment and readability.

## 🧪 Testing

 - Updated the Unit test cases to check the conditional rendering

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).