### PR TITLE
fix(results): Align label widths

### DIFF
--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -42,7 +42,7 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
 
   return (
     <>
-      <InlineField label="Query Type" labelWidth={25} tooltip={tooltips.queryType}>
+      <InlineField label="Query Type" labelWidth={26} tooltip={tooltips.queryType}>
         <RadioButtonGroup
           options={Object.values(QueryType).map(value => ({ label: value, value })) as SelectableValue[]}
           value={query.queryType}

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -74,7 +74,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
   return (
     <>
       <VerticalGroup>
-        <InlineField label="Output" labelWidth={25} tooltip={tooltips.output}>
+        <InlineField label="Output" labelWidth={26} tooltip={tooltips.output}>
           <RadioButtonGroup
             options={Object.values(OutputType).map(value => ({ label: value, value })) as SelectableValue[]}
             value={query.outputType}
@@ -82,7 +82,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           />
         </InlineField>
         {query.outputType === OutputType.Data && (
-          <InlineField label="Properties" labelWidth={25} tooltip={tooltips.properties}>
+          <InlineField label="Properties" labelWidth={26} tooltip={tooltips.properties}>
             <MultiSelect
               placeholder="Select properties to fetch"
               options={enumToOptions(ResultsProperties)}
@@ -105,7 +105,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           }}
         />
         <div className="horizontal-control-group">
-          <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
+          <InlineField label="Query By" labelWidth={26} tooltip={tooltips.queryBy}>
             <ResultsQueryBuilder
               filter={query.queryBy}
               workspaces={workspaces}
@@ -118,7 +118,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           {query.outputType === OutputType.Data && (
             <div className="right-query-controls">
               <div className="horizontal-control-group">
-                <InlineField label="OrderBy" labelWidth={25} tooltip={tooltips.orderBy}>
+                <InlineField label="OrderBy" labelWidth={26} tooltip={tooltips.orderBy}>
                   <Select
                     width={25}
                     options={OrderBy as SelectableValue[]}
@@ -135,7 +135,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
                   />
                 </InlineField>
               </div>
-              <InlineField label="Take" labelWidth={25} tooltip={tooltips.recordCount}>
+              <InlineField label="Take" labelWidth={26} tooltip={tooltips.recordCount}>
                 <AutoSizeInput
                   minWidth={25}
                   maxWidth={25}

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -66,7 +66,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
   return (
     <>
       <VerticalGroup>
-        <InlineField label="Output" labelWidth={25} tooltip={tooltips.output}>
+        <InlineField label="Output" labelWidth={26} tooltip={tooltips.output}>
           <RadioButtonGroup
             options={Object.values(OutputType).map(value => ({ label: value, value })) as SelectableValue[]}
             value={query.outputType}
@@ -74,7 +74,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
           />
         </InlineField>
         {query.outputType === OutputType.Data && (
-          <InlineField label="Properties" labelWidth={25} tooltip={tooltips.properties}>
+          <InlineField label="Properties" labelWidth={26} tooltip={tooltips.properties}>
             <MultiSelect
               placeholder="Select properties to fetch"
               options={enumToOptions(StepsProperties)}
@@ -91,7 +91,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
         )}
         <div>
           {query.outputType === OutputType.Data && (
-            <InlineField label="Show Measurements" labelWidth={25} tooltip={tooltips.showMeasurements}>
+            <InlineField label="Show Measurements" labelWidth={26} tooltip={tooltips.showMeasurements}>
               <InlineSwitch
                 onChange={event => onShowMeasurementChange(event.currentTarget.checked)}
                 value={query.showMeasurements}
@@ -117,7 +117,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
 
           <div className="right-query-controls">
             <div className="horizontal-control-group">
-              <InlineField label="OrderBy" labelWidth={25} tooltip={tooltips.orderBy}>
+              <InlineField label="OrderBy" labelWidth={26} tooltip={tooltips.orderBy}>
                 <Select
                   options={OrderBy as SelectableValue[]}
                   width={25}
@@ -134,7 +134,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
                 />
               </InlineField>
             </div>
-            <InlineField label="Take" labelWidth={25} tooltip={tooltips.recordCount}>
+            <InlineField label="Take" labelWidth={26} tooltip={tooltips.recordCount}>
               <AutoSizeInput
                 minWidth={25}
                 maxWidth={25}

--- a/src/datasources/results/components/editors/time-range/TimeRangeControls.tsx
+++ b/src/datasources/results/components/editors/time-range/TimeRangeControls.tsx
@@ -26,7 +26,7 @@ export function TimeRangeControls({query, handleQueryChange}: Props) {
 
   return (
     <div className="horizontal-control-group">
-      <InlineField label="Use time range" tooltip={tooltips.useTimeRange} labelWidth={25}>
+      <InlineField label="Use time range" tooltip={tooltips.useTimeRange} labelWidth={26}>
         <InlineSwitch
           onChange={event => onUseTimeRangeChecked(event.currentTarget.checked)}
           value={query.useTimeRange}

--- a/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
+++ b/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
@@ -46,7 +46,7 @@ export const StepsQueryBuilderWrapper = (
   
   return (
     <div>
-      <InlineField label="Query by results properties" labelWidth={25} tooltip={tooltips.resultsQueryBuilder}>
+      <InlineField label="Query by results properties" labelWidth={26} tooltip={tooltips.resultsQueryBuilder}>
         <ResultsQueryBuilder
           filter={resultsQuery}
           onChange={(event) => onResultsQueryChange((event as CustomEvent<{ linq: string }>).detail.linq)}
@@ -56,7 +56,7 @@ export const StepsQueryBuilderWrapper = (
           globalVariableOptions={datasource.globalVariableOptions()}>
         </ResultsQueryBuilder>
       </InlineField>
-      <InlineField label="Query by steps properties" labelWidth={25} tooltip={tooltips.stepsQueryBuilder}>
+      <InlineField label="Query by steps properties" labelWidth={26} tooltip={tooltips.stepsQueryBuilder}>
         <StepsQueryBuilder
           filter={stepsQuery}
           workspaces={workspaces}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As a part of this [User Story 2798322](https://ni.visualstudio.com/DevCentral/_workitems/edit/2798322): FE | Add Query Builder for Results Datasource,

This PR increases the label width from 25 to 26 across all controls. The adjustment was necessary because, in the Results Query Editor for steps, the labels were misaligned, and the text exceeded the available space after adding a tooltip. To ensure consistent alignment and spacing across all controls, the label width has been updated to 26.

## 👩‍💻 Implementation

- Updated `labelWidth` of all controlsr from `25` to `26`. 

Before
![image](https://github.com/user-attachments/assets/873f961c-9280-4907-b21f-556247c383f0)


After
![image](https://github.com/user-attachments/assets/7c268bec-cc5b-496c-a69d-6c8a8dc07c5d)


## 🧪 Testing

NA

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).