### PR TITLE
feat(results): Add logic to MetricFindQuery for Steps Query in Variable Editor

### DIFF
--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -256,6 +256,38 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
   }
 
   async metricFindQuery(query: StepsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+    if (query.queryByResults !== undefined) {
+      const resultsQuery = query.queryByResults ? transformComputedFieldsQuery(
+        this.templateSrv.replace(query.queryByResults, options?.scopedVars),
+        this.resultsComputedDataFields
+      ) : undefined;
+
+      const stepsQuery = query.queryBySteps ? transformComputedFieldsQuery(
+        this.templateSrv.replace(query.queryBySteps, options?.scopedVars),
+        this.resultsComputedDataFields
+      ) : undefined;
+
+      let responseData: QueryStepsResponse;
+      try {
+        responseData = await this.queryStepsInBatches(
+          stepsQuery,
+          'STARTED_AT',
+          [StepsPropertiesOptions.NAME as StepsProperties],
+          1000,
+          true,
+          resultsQuery,
+        );
+      } catch (error) {
+        console.error('Error in querying steps:', error);
+        return [];
+      }
+
+      if (responseData.steps.length > 0) {
+        return responseData.steps
+          ? responseData.steps.map((data: StepsResponseProperties) => ({ text: data.name!, value: data.name! }))
+          : [];
+      }
+    }
     return [];
   }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
As part of [Task 3131168](https://dev.azure.com/ni/DevCentral/_workitems/edit/3131168): PR5 | Update metricFindValues in the QueryStepsDatasource, This PR contains changes to the QueryResultsDatasource by adding logic to the metricFindQuery method of QueryStepsDatasource.

## 👩‍💻 Implementation
-  Updated the `metricFindQuery` method in `QueryStepsDataSource` to transform and replace `queryByResults` and `queryBySteps` using `templateSrv`, and to query steps in batches with improved error handling. If an error occurs or no steps are returned, it now gracefully handles the situation by returning an empty array.

## 🧪 Testing

- Added Unit test cases 

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).