### PR TITLE
feat: Update Date-Time query builder operators to 'isAfter' & 'isBefore'

### DIFF
--- a/src/core/query-builder.constants.ts
+++ b/src/core/query-builder.constants.ts
@@ -293,7 +293,19 @@ export const QueryBuilderOperations = {
     handleValue: handleNumberValue,
     expressionBuilderCallback: keyValueExpressionBuilderCallback,
     expressionReaderCallback: numericKeyValueExpressionReaderCallback,
+  },
+  // DateTime expressions
+  DATE_TIME_IS_AFTER: {
+    label: 'is after',
+    name: 'isafter',
+    expressionTemplate: '{0} > "{1}"',
+  },
+  DATE_TIME_IS_BEFORE: {
+    label: 'is before',
+    name: 'isbefore',
+    expressionTemplate: '{0} < "{1}"',
   }
+
 };
 
 export const customOperations: QueryBuilderCustomOperation[] = [
@@ -321,4 +333,6 @@ export const customOperations: QueryBuilderCustomOperation[] = [
     QueryBuilderOperations.PROPERTY_DOES_NOT_CONTAIN,
     QueryBuilderOperations.PROPERTY_IS_BLANK,
     QueryBuilderOperations.PROPERTY_IS_NOT_BLANK,
+    QueryBuilderOperations.DATE_TIME_IS_AFTER,
+    QueryBuilderOperations.DATE_TIME_IS_BEFORE,
   ];

--- a/src/datasources/products/components/query-builder/ProductsQueryBuilder.tsx
+++ b/src/datasources/products/components/query-builder/ProductsQueryBuilder.tsx
@@ -143,6 +143,8 @@ export const ProductsQueryBuilder: React.FC<ProductsQueryBuilderProps> = ({
       QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO,
       QueryBuilderOperations.IS_BLANK,
       QueryBuilderOperations.IS_NOT_BLANK,
+      QueryBuilderOperations.DATE_TIME_IS_AFTER,
+      QueryBuilderOperations.DATE_TIME_IS_BEFORE,
     ].map((operation) => {
       return {
         ...operation,

--- a/src/datasources/products/constants/ProductsQueryBuilder.constants.ts
+++ b/src/datasources/products/constants/ProductsQueryBuilder.constants.ts
@@ -73,12 +73,8 @@ export const ProductsQueryBuilderFields: Record<string, QBField> = {
         label: 'Updated At',
         dataField: ProductsQueryBuilderFieldNames.UPDATED_AT,
         filterOperations: [
-            QueryBuilderOperations.EQUALS.name,
-            QueryBuilderOperations.DOES_NOT_EQUAL.name,
-            QueryBuilderOperations.GREATER_THAN.name,
-            QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
-            QueryBuilderOperations.LESS_THAN.name,
-            QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name
+            QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+            QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
         ],
         lookup: {
             dataSource: []

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
@@ -98,7 +98,7 @@ describe('ResultsQueryBuilder', () => {
 
         expect(conditionsContainer?.length).toBe(1);
         expect(conditionsContainer.item(0)?.textContent).toContain("Updated"); //label
-        expect(conditionsContainer.item(0)?.textContent).toContain("Greater than"); //operator
+        expect(conditionsContainer.item(0)?.textContent).toContain("is after"); //operator
         expect(conditionsContainer.item(0)?.textContent).toContain(label); //value
       });
     });

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -172,6 +172,8 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
       QueryBuilderOperations.LIST_DOES_NOT_EQUAL,
       QueryBuilderOperations.LIST_CONTAINS,
       QueryBuilderOperations.LIST_DOES_NOT_CONTAIN,
+      QueryBuilderOperations.DATE_TIME_IS_AFTER,
+      QueryBuilderOperations.DATE_TIME_IS_BEFORE,
     ].map(operation => {
       return {
         ...operation,

--- a/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.test.tsx
+++ b/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.test.tsx
@@ -131,7 +131,7 @@ describe('StepsQueryBuilder', () => {
 
         expect(filterContainer?.length).toBe(1);
         expect(filterContainer.item(0)?.textContent).toContain('Step updated at'); //label
-        expect(filterContainer.item(0)?.textContent).toContain('Greater than'); //operator
+        expect(filterContainer.item(0)?.textContent).toContain('is after'); //operator
         expect(filterContainer.item(0)?.textContent).toContain(label); //value
       });
     });

--- a/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.tsx
@@ -153,6 +153,8 @@ export const StepsQueryBuilder: React.FC<StepsQueryBuilderProps> = ({
       QueryBuilderOperations.LIST_DOES_NOT_EQUAL,
       QueryBuilderOperations.LIST_CONTAINS,
       QueryBuilderOperations.LIST_DOES_NOT_CONTAIN,
+      QueryBuilderOperations.DATE_TIME_IS_AFTER,
+      QueryBuilderOperations.DATE_TIME_IS_BEFORE
     ].map(operation => {
       return {
         ...operation,

--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -101,12 +101,8 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
     label: 'Started',
     dataField: ResultsQueryBuilderFieldNames.STARTED_AT,
     filterOperations: [
-      QueryBuilderOperations.EQUALS.name,
-      QueryBuilderOperations.DOES_NOT_EQUAL.name,
-      QueryBuilderOperations.GREATER_THAN.name,
-      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
-      QueryBuilderOperations.LESS_THAN.name,
-      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
+      QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+      QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
     ],
     lookup: {
       dataSource: [],
@@ -151,12 +147,8 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
     label: 'Updated',
     dataField: ResultsQueryBuilderFieldNames.UPDATED_AT,
     filterOperations: [
-      QueryBuilderOperations.EQUALS.name,
-      QueryBuilderOperations.DOES_NOT_EQUAL.name,
-      QueryBuilderOperations.GREATER_THAN.name,
-      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
-      QueryBuilderOperations.LESS_THAN.name,
-      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
+      QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+      QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
     ],
     lookup: {
       dataSource: [],

--- a/src/datasources/results/constants/StepsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/StepsQueryBuilder.constants.ts
@@ -87,12 +87,8 @@ export const StepsQueryBuilderFields: Record<string, QBField> = {
     label: 'Step updated at',
     dataField: StepsQueryBuilderFieldNames.UPDATED_AT,
     filterOperations: [
-      QueryBuilderOperations.EQUALS.name,
-      QueryBuilderOperations.DOES_NOT_EQUAL.name,
-      QueryBuilderOperations.GREATER_THAN.name,
-      QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
-      QueryBuilderOperations.LESS_THAN.name,
-      QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name,
+      QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+      QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
     ],
     lookup: {
       dataSource: [],


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
As part of  [User Story 3112060](https://dev.azure.com/ni/DevCentral/_workitems/edit/3112060): Refactor | Update date time type filter operators. This pull request replaces older date-time filter operations to `DATE_TIME_IS_AFTER` and `DATE_TIME_IS_BEFORE`, in the query builder. 

## 👩‍💻 Implementation

-  Added `DATE_TIME_IS_AFTER` and `DATE_TIME_IS_BEFORE` operations to `QueryBuilderOperations` with corresponding labels, names, and expression templates.
- Included these new operations in the `customOperations` array for broader usage.
-  Integrated the new operations into the `ProductsQueryBuilder`, `ResultsQueryBuilder`, and `StepsQueryBuilder` components to support filtering by date-time fields.
- Replaced older numeric-based filter operations (e.g., `GREATER_THAN`, `LESS_THAN`) with `DATE_TIME_IS_AFTER` and `DATE_TIME_IS_BEFORE` for relevant fields

## 🧪 Testing

- Updated the Test Cases 

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).