### PR TITLE
feat(results): Add Take control for Results Query in Results Variable Editor

### DIFF
--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -60,7 +60,7 @@ let queryBySteps: HTMLElement;
 
 describe('Results Query Type', () => {
   beforeEach(() => {
-    renderEditor({ refId: '', queryType: QueryType.Results, properties: '', queryBy: '' } as unknown as ResultsQuery);
+    renderEditor({ refId: '', queryType: QueryType.Results, properties: ResultsVariableProperties[0].value, queryBy: '', resultsTake: 1000 } as unknown as ResultsQuery);
   });
 
   it('should render query type radio buttons', () => {
@@ -92,6 +92,32 @@ describe('Results Query Type', () => {
     await waitFor(() => expect(screen.getAllByText('Property').length).toBe(1));
     await waitFor(() => expect(screen.getAllByText('Operator').length).toBe(1));
     await waitFor(() => expect(screen.getAllByText('Value').length).toBe(1));
+  });
+
+  describe('Take input field', () => {
+    it('should render take input field with 1000 as value by default', () => {
+      const takeInput = screen.getByPlaceholderText('Enter record count');
+      expect(takeInput).toBeInTheDocument();
+      expect(takeInput).toHaveValue(1000);
+    });
+
+    it('should only allows numbers in Take field', async () => {
+      const takeInput = screen.getByPlaceholderText('Enter record count');
+
+      // User tries to enter a non-numeric value
+      await userEvent.clear(takeInput);
+      await userEvent.type(takeInput, 'abc');
+      await waitFor(() => {
+        expect(takeInput).toHaveValue(null);
+      });
+
+      // User enters a valid numeric value
+      await userEvent.clear(takeInput);
+      await userEvent.type(takeInput, '500');
+      await waitFor(() => {
+        expect(takeInput).toHaveValue(500);
+      });
+    });
   });
 });
 
@@ -125,13 +151,13 @@ describe('Steps Query Type', () => {
       expect(takeInput).toHaveValue(1000);
     });
 
-    it('should render with existing take when take is already set', () => {
+    it('should render with existing stepsTake when take is already set', () => {
       renderEditor({
         refId: '',
         queryType: QueryType.Steps,
         queryByResults: 'resultsQuery',
         queryBySteps: '',
-        take: 2000,
+        stepsTake: 2000,
       } as unknown as ResultsQuery);
 
       const takeInput = screen.getByPlaceholderText('Enter record count');
@@ -144,7 +170,7 @@ describe('Steps Query Type', () => {
         queryType: QueryType.Steps,
         queryByResults: 'resultsQuery',
         queryBySteps: '',
-        take: 2000,
+        stepsTake: 2000,
       } as unknown as ResultsQuery);
       const takeInput = screen.getByPlaceholderText('Enter record count');
 

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -26,7 +26,8 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [partNumbers, setPartNumbers] = useState<string[]>([]);
   const [isQueryBuilderDisabled, disableStepsQueryBuilder] = useState<boolean>(true);
-  const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
+  const [stepsRecordCountInvalidMessage, setStepsRecordCountInvalidMessage] = useState<string>('');
+  const [resultsRecordCountInvalidMessage, setResultsRecordCountInvalidMessage] = useState<string>('');
   const queryResultsquery = query as ResultsVariableQuery;
   const stepsVariableQuery = query as StepsVariableQuery;
   const queryResultsDataSource = useRef(datasource.queryResultsDataSource);
@@ -34,13 +35,13 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
 
   useEffect(() => {
     if (!query.queryType) {
-      onChange({ ...query, queryType: QueryType.Results, take: 1000 } as ResultsVariableQuery);
+      onChange({ ...query, queryType: QueryType.Results, stepsTake: 1000, resultsTake: 1000 } as ResultsVariableQuery);
       return;
     }
     if (query.queryType === QueryType.Steps) {
       const stepsQuery = query as StepsVariableQuery;
-      if (stepsQuery.take === undefined || Number.isNaN(stepsQuery.take)) {
-        onChange({ ...stepsQuery, take: 1000 } as StepsVariableQuery);
+      if (stepsQuery.stepsTake === undefined || Number.isNaN(stepsQuery.stepsTake)) {
+        onChange({ ...stepsQuery, stepsTake: 1000 } as StepsVariableQuery);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -85,21 +86,27 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
     onChange({ ...stepsVariableQuery, queryBySteps: stepsQuery } as StepsVariableQuery);
   };
 
-  const recordCountChange = (event: React.FormEvent<HTMLInputElement>) => {
+  const onStepsRecordCountChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = parseInt((event.target as HTMLInputElement).value, 10);
-    switch (true) {
-      case isNaN(value) || value <= 0:
-        setRecordCountInvalidMessage('Enter a value greater than 0');
-        break;
-      case value > TAKE_LIMIT:
-        setRecordCountInvalidMessage('Enter a value less than or equal to 10,000');
-        break;
-      default:
-        setRecordCountInvalidMessage('');
-        break;
-    }
-    onChange({ ...stepsVariableQuery, take: value } as StepsVariableQuery);
+    setStepsRecordCountInvalidMessage(validateRecordCount(value, TAKE_LIMIT));
+    onChange({ ...stepsVariableQuery, stepsTake: value } as StepsVariableQuery);
   };
+
+  const onResultsRecordCountChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = parseInt((event.target as HTMLInputElement).value, 10);
+    setResultsRecordCountInvalidMessage(validateRecordCount(value, TAKE_LIMIT));
+    onChange({ ...queryResultsquery, resultsTake: value } as ResultsVariableQuery);
+  };
+
+  function validateRecordCount(value: number, takeLimit: number): string {
+    if (Number.isNaN(value) || value <= 0) {
+      return 'Enter a value greater than 0';
+    }
+    if (value > takeLimit) {
+      return `Enter a value less than or equal to ${takeLimit.toLocaleString()}`;
+    }
+    return '';
+  }
 
   return (
     <>
@@ -122,16 +129,37 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
           </InlineField>
           {(queryResultsquery.properties! === ResultsVariableProperties[0].value ||
             queryResultsquery.properties === ResultsVariableProperties[1].value) && (
-            <InlineField label="Query by results properties" labelWidth={26} tooltip={tooltips.queryBy}>
-              <ResultsQueryBuilder
-                filter={queryResultsquery.queryBy}
-                onChange={(event: any) => onQueryByChange(event.detail.linq)}
-                workspaces={workspaces}
-                partNumbers={partNumbers}
-                status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
-                globalVariableOptions={queryResultsDataSource.current.globalVariableOptions()}
-              ></ResultsQueryBuilder>
-            </InlineField>
+            <>
+              <InlineField label="Query by results properties" labelWidth={26} tooltip={tooltips.queryBy}>
+                <ResultsQueryBuilder
+                  filter={queryResultsquery.queryBy}
+                  onChange={(event: any) => onQueryByChange(event.detail.linq)}
+                  workspaces={workspaces}
+                  partNumbers={partNumbers}
+                  status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
+                  globalVariableOptions={queryResultsDataSource.current.globalVariableOptions()}
+                ></ResultsQueryBuilder>
+              </InlineField>
+              <InlineField
+                label="Take"
+                labelWidth={26}
+                tooltip={tooltips.resultsTake}
+                invalid={!!resultsRecordCountInvalidMessage}
+                error={resultsRecordCountInvalidMessage}
+              >
+                <AutoSizeInput
+                  minWidth={25}
+                  maxWidth={25}
+                  type="number"
+                  defaultValue={queryResultsquery.resultsTake ? queryResultsquery.resultsTake : 1000}
+                  onCommitChange={onResultsRecordCountChange}
+                  placeholder="Enter record count"
+                  onKeyDown={event => {
+                    validateNumericInput(event);
+                  }}
+                />
+              </InlineField>
+            </>
           )}
         </>
       )}
@@ -148,16 +176,16 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
           <InlineField
             label="Take"
             labelWidth={26}
-            tooltip={tooltips.take}
-            invalid={!!recordCountInvalidMessage}
-            error={recordCountInvalidMessage}
+            tooltip={tooltips.stepsTake}
+            invalid={!!stepsRecordCountInvalidMessage}
+            error={stepsRecordCountInvalidMessage}
           >
             <AutoSizeInput
               minWidth={25}
               maxWidth={25}
               type="number"
-              defaultValue={stepsVariableQuery.take ? stepsVariableQuery.take : 1000}
-              onCommitChange={recordCountChange}
+              defaultValue={stepsVariableQuery.stepsTake ? stepsVariableQuery.stepsTake : 1000}
+              onCommitChange={onStepsRecordCountChange}
               placeholder="Enter record count"
               onKeyDown={event => {
                 validateNumericInput(event);
@@ -172,7 +200,8 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
 
 const tooltips = {
   queryType: 'This field specifies the query type to return as either results data or steps data.',
-  take: 'This field sets the maximum number of steps to return.',
+  stepsTake: 'This field sets the maximum number of steps to return.',
+  resultsTake: 'This field sets the maximum number of results to return.',
   queryBy: 'This field applies a filter to the query results.',
   properties: 'This field specifies the property to return from the query.',
 };

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -406,18 +406,30 @@ describe('QueryResultsDataSource', () => {
 
   describe('metricFindQuery', () => {
     test('should return empty array when properties is not selected', async () => {
-      const query = { properties: undefined, queryBy: '' } as ResultsVariableQuery;
+      const query = { properties: undefined, queryBy: '', resultsTake: 1000 } as ResultsVariableQuery;
       const result = await datastore.metricFindQuery(query, {});
 
       expect(result).toEqual([]);
     });
+
+     it.each([-1, NaN, 10001])('should return empty array if resultsTake value is invalid (%p)', async (invalidResultsTake) => {
+            const query = {
+              refId: 'A',
+              queryType: QueryType.Results,
+              queryByResults: 'PartNumber = "partNumber1"',
+              resultsTake: invalidResultsTake,
+            } as unknown as ResultsVariableQuery;
+            const result = await datastore.metricFindQuery(query);
+    
+            expect(result).toEqual([]);
+          });
 
     test('should return empty array when there are no results', async () => {
       backendServer.fetch
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
         .mockReturnValue(createFetchResponse({ results: [], totalCount: 0 }));
 
-      const query = { properties: ResultsPropertiesOptions.PART_NUMBER, queryBy: '' } as ResultsVariableQuery;
+      const query = { properties: ResultsPropertiesOptions.PART_NUMBER, queryBy: '', resultsTake: 1000 } as ResultsVariableQuery;
       const result = await datastore.metricFindQuery(query, {});
 
       expect(result).toEqual([]);
@@ -433,7 +445,7 @@ describe('QueryResultsDataSource', () => {
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
         .mockReturnValue(createFetchResponse({ results: mockResults, totalCount: 3 }));
 
-      const query = { properties: 'DATA_TABLE_IDS', queryBy: '' } as ResultsVariableQuery;
+      const query = { properties: 'DATA_TABLE_IDS', queryBy: '', resultsTake: 1000 } as ResultsVariableQuery;
       const result = await datastore.metricFindQuery(query, {});
 
       expect(result).toEqual([
@@ -452,7 +464,7 @@ describe('QueryResultsDataSource', () => {
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
         .mockReturnValue(createFetchResponse({ results: mockResults, totalCount: 2 }));
 
-      const query = { properties: 'PROGRAM_NAME', queryBy: '' } as ResultsVariableQuery;
+      const query = { properties: 'PROGRAM_NAME', queryBy: '',resultsTake: 1000 } as ResultsVariableQuery;
       const result = await datastore.metricFindQuery(query, {});
 
       expect(result).toEqual([
@@ -473,7 +485,7 @@ describe('QueryResultsDataSource', () => {
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results', method: 'POST' }))
         .mockReturnValue(createFetchResponse({ results: mockResults, totalCount: 1 }));
 
-      const query = { properties: 'PROGRAM_NAME', queryBy } as ResultsVariableQuery;
+      const query = { properties: 'PROGRAM_NAME', queryBy, resultsTake: 1000 } as ResultsVariableQuery;
       const options = { scopedVars: { var: { value: 'ReplacedValue' } } };
       const result = await datastore.metricFindQuery(query, options);
 

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -667,19 +667,19 @@ describe('QueryStepsDataSource', () => {
           queryType: QueryType.Steps,
           queryByResults: undefined,
           queryBySteps: undefined,
-          take: 1000,
+          stepsTake: 1000,
         } as unknown as StepsVariableQuery;
         const result = await datastore.metricFindQuery(query);
 
         expect(result).toEqual([]);
       });
 
-      it.each([-1, NaN, 10001])('should return empty array if take value is invalid (%p)', async (invalidTake) => {
+      it.each([-1, NaN, 10001])('should return empty array if stepsTake value is invalid (%p)', async (invalidStepsTake) => {
         const query = {
           refId: 'A',
           queryType: QueryType.Steps,
           queryByResults: 'PartNumber = "partNumber1"',
-          take: invalidTake,
+          stepsTake: invalidStepsTake,
         } as unknown as StepsVariableQuery;
         const result = await datastore.metricFindQuery(query);
 
@@ -696,7 +696,7 @@ describe('QueryStepsDataSource', () => {
             totalCount: 2
           } as QueryStepsResponse));
 
-        const query = { queryByResults: 'PartNumber = "partNumber1"', take: 1000 } as StepsVariableQuery;
+        const query = { queryByResults: 'PartNumber = "partNumber1"', stepsTake: 1000 } as StepsVariableQuery;
         const result = await datastore.metricFindQuery(query);
 
         expect(result).toEqual([
@@ -712,7 +712,7 @@ describe('QueryStepsDataSource', () => {
             totalCount: 0
           } as QueryStepsResponse));
 
-        const query = { queryByResults: 'PartNumber = "partNumber1"', take: 1000 } as StepsVariableQuery;
+        const query = { queryByResults: 'PartNumber = "partNumber1"', stepsTake: 1000 } as StepsVariableQuery;
         const result = await datastore.metricFindQuery(query);
 
         expect(result).toEqual([]);
@@ -721,7 +721,7 @@ describe('QueryStepsDataSource', () => {
       it('should return empty array if API throws error', async () => {
         backendServer.fetch.mockImplementationOnce(() => { throw new Error('API error'); });
 
-        const query = { queryByResults: 'PartNumber = "partNumber1"', take: 1000 } as StepsVariableQuery;
+        const query = { queryByResults: 'PartNumber = "partNumber1"', stepsTake: 1000 } as StepsVariableQuery;
         const result = await datastore.metricFindQuery(query);
 
         expect(result).toEqual([]);
@@ -736,7 +736,7 @@ describe('QueryStepsDataSource', () => {
           totalCount: 1
         } as QueryStepsResponse));
 
-        const query = { queryByResults: resultsQuery, queryBySteps: stepsQuery, take: 1000 } as StepsVariableQuery;
+        const query = { queryByResults: resultsQuery, queryBySteps: stepsQuery, stepsTake: 1000 } as StepsVariableQuery;
         await datastore.metricFindQuery(query, { scopedVars: { var: { value: 'replaced' } } } as any);
 
         expect(templateSrv.replace).toHaveBeenCalledTimes(2);

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -256,7 +256,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
   }
 
   async metricFindQuery(query: StepsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
-    if (query.queryByResults !== undefined && this.isTakeValid(query.take!)) {
+    if (query.queryByResults !== undefined && this.isTakeValid(query.stepsTake!)) {
       const resultsQuery = query.queryByResults ? transformComputedFieldsQuery(
         this.templateSrv.replace(query.queryByResults, options?.scopedVars),
         this.resultsComputedDataFields
@@ -273,7 +273,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
           stepsQuery,
           'UPDATED_AT',
           [StepsPropertiesOptions.NAME as StepsProperties],
-          query.take,
+          query.stepsTake,
           true,
           resultsQuery,
         );

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -14,12 +14,13 @@ export interface QueryResults extends ResultsQuery {
 export interface ResultsVariableQuery extends ResultsQuery {
   properties?: string;
   queryBy?: string;
+  resultsTake?: number;
 }
 
 export interface StepsVariableQuery extends ResultsQuery {
   queryByResults: string;
   queryBySteps?: string;
-  take?: number;
+  stepsTake?: number;
 }
 
 export const ResultsVariableProperties = [


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As part of [Task 3136437](https://dev.azure.com/ni/DevCentral/_workitems/edit/3136437): Add Take input for Results query in Results Variable Query Editor, this pull request adds the take control into the Results Query of the Results Variable Editor

## 👩‍💻 Implementation

-  Renamed `take` to `stepsTake` and introduced `resultsTake` for results queries to improve clarity and differentiation between the two query types.
- Added validation logic for `stepsTake` and `resultsTake` to ensure values are numeric, greater than 0, and within the defined limit (`TAKE_LIMIT`). 
- Updated the `ResultsVariableQueryEditor` component to include separate input fields for `stepsTake` and `resultsTake`, each with validation and error handling.

## 🧪 Testing

- Added Test cases 

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).