### PR TITLE
feat(workorders): add query by change

### DIFF
--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
@@ -64,6 +64,17 @@ describe('WorkOrdersQueryEditor', () => {
     const descending = container.getByRole('checkbox');
     expect(descending).toBeInTheDocument();
     expect(descending).not.toBeChecked();
+
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refId: 'A',
+        properties: [],
+        orderBy: undefined,
+        descending: true,
+        recordCount: 1000,
+        queryBy: ''
+      }));
+    expect(mockOnRunQuery).toHaveBeenCalledTimes(1);
   });
 
   describe('output type is total count', () => {
@@ -210,6 +221,44 @@ describe('WorkOrdersQueryEditor', () => {
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ descending: true }));
         expect(mockOnRunQuery).toHaveBeenCalled();
+      });
+    });
+
+    it('should call onChange when query by changes', async () => {
+      const container = renderElement();
+
+      const queryBuilder = container.getByRole('dialog');
+      expect(queryBuilder).toBeInTheDocument();
+
+      // Simulate a change event
+      const event = { detail: { linq: 'new-query' } };
+      queryBuilder?.dispatchEvent(new CustomEvent('change', event));
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ queryBy: 'new-query' }));
+        expect(mockOnRunQuery).toHaveBeenCalled();
+      });
+    });
+
+    it('should not call onChange when query by changes with same value', async () => {
+      const container = renderElement();
+      mockOnChange.mockClear();
+      mockOnRunQuery.mockClear();
+
+      const queryBuilder = container.getByRole('dialog');
+      expect(queryBuilder).toBeInTheDocument();
+
+      // Simulate a change event
+      let event = { detail: { linq: 'new-query' } };
+      queryBuilder?.dispatchEvent(new CustomEvent('change', event));
+
+      // Simulate a change event with the same value
+      event = { detail: { linq: 'new-query' } };
+      queryBuilder?.dispatchEvent(new CustomEvent('change', event));
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+        expect(mockOnRunQuery).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
@@ -5,7 +5,7 @@ import { OutputType, WorkOrderProperties, WorkOrderPropertiesOptions, WorkOrders
 import { QueryEditorProps } from '@grafana/data';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { select } from 'react-select-event';
+import selectEvent, { select } from 'react-select-event';
 
 const mockOnChange = jest.fn();
 const mockOnRunQuery = jest.fn();
@@ -139,6 +139,13 @@ describe('WorkOrdersQueryEditor', () => {
     it('should render order by', async () => {
       const orderBy = container.getAllByRole('combobox')[1];
       expect(orderBy).toBeInTheDocument();
+
+     selectEvent.openMenu(orderBy);
+
+     expect(screen.getByText('ID')).toBeInTheDocument();
+     expect(screen.getByText('ID of the work order')).toBeInTheDocument();
+     expect(screen.getByText('Updated At')).toBeInTheDocument();
+     expect(screen.getByText('Latest update at time of the work order')).toBeInTheDocument();
     });
 
     it('should render descending', async () => {

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
@@ -67,12 +67,8 @@ describe('WorkOrdersQueryEditor', () => {
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        refId: 'A',
-        properties: [],
-        orderBy: undefined,
-        descending: true,
-        recordCount: 1000,
-        queryBy: ''
+        outputType: OutputType.Properties,
+        refId: 'A'
       }));
     expect(mockOnRunQuery).toHaveBeenCalledTimes(1);
   });

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { WorkOrdersDataSource } from '../WorkOrdersDataSource';
-import { OutputType, WorkOrderProperties, WorkOrderPropertiesOptions, WorkOrdersQuery } from '../types';
+import { OrderBy, OutputType, WorkOrderProperties, WorkOrderPropertiesOptions, WorkOrdersQuery } from '../types';
 import { WorkOrdersQueryBuilder } from './query-builder/WorkOrdersQueryBuilder';
 import {
   HorizontalGroup,
@@ -10,13 +10,17 @@ import {
   Select,
   VerticalGroup
 } from '@grafana/ui';
-import { OrderBy } from 'datasources/products/types';
 import './WorkOrdersQueryEditor.scss';
 
 type Props = QueryEditorProps<WorkOrdersDataSource, WorkOrdersQuery>;
 
 export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   query = datasource.prepareQuery(query);
+
+  useEffect(() => {
+    handleQueryChange(query, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Only run on mount
 
   const handleQueryChange = useCallback(
     (query: WorkOrdersQuery, runQuery = true): void => {
@@ -43,6 +47,13 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
 
   const onDescendingChange = (isDescendingChecked: boolean) => {
     handleQueryChange({ ...query, descending: isDescendingChecked });
+  };
+
+  const onQueryByChange = (queryBy: string) => {
+    if(query.queryBy !== queryBy) {
+      query.queryBy = queryBy;
+      handleQueryChange({ ...query, queryBy });
+    }
   };
 
   return (
@@ -78,7 +89,11 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
           </InlineField>
         )}
         <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
-            <WorkOrdersQueryBuilder globalVariableOptions={[]}></WorkOrdersQueryBuilder>
+            <WorkOrdersQueryBuilder
+              filter={query.queryBy} 
+              globalVariableOptions={[]}
+              onChange={(event: any) => onQueryByChange(event.detail.linq)}
+            ></WorkOrdersQueryBuilder>
           </InlineField>
         </VerticalGroup>
         <VerticalGroup>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To add the functionality to handle query change when query filter changes

## 👩‍💻 Implementation

- Added function to handle query by change
- Fixed the options of order by
- Called query change on mount

## 🧪 Testing

- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).