### PR TITLE
feat(query-editor): Fix Duplicate API calls in query builder for Workspace and Updated At

### DIFF
--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -16,7 +16,7 @@ let recordCount: HTMLElement
 
 describe('ProductsQueryEditor', () => {
   beforeEach(async () => {
-    [onChange, onRunQuery] = render({ refId: '', properties: [], orderBy: undefined } as ProductQuery);
+    [onChange, onRunQuery] = render({ refId: '', properties: [], orderBy: undefined, queryBy: 'PartNumber = "partNumber1"' } as ProductQuery);
     await waitFor(() => properties = screen.getAllByRole('combobox')[0]);
     orderBy = screen.getAllByRole('combobox')[1];
     descending = screen.getByRole('checkbox');
@@ -40,7 +40,7 @@ describe('ProductsQueryEditor', () => {
         orderBy: undefined,
         descending: true,
         recordCount: 1000,
-        queryBy: ''
+        queryBy: 'PartNumber = \"partNumber1\"'
       }));
     expect(onRunQuery).toHaveBeenCalledTimes(1);
   });
@@ -49,6 +49,17 @@ describe('ProductsQueryEditor', () => {
     await waitFor(() => expect(screen.getAllByText('Property').length).toBe(1));
     await waitFor(() => expect(screen.getAllByText('Operator').length).toBe(1));
     await waitFor(() => expect(screen.getAllByText('Value').length).toBe(1));
+  });
+
+  it('should not call onRunQuery when query is not changed', async () => {
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onRunQuery).toHaveBeenCalledTimes(1);
+    onChange.mockReset();
+    onRunQuery.mockReset();
+
+    render({ refId: '', properties: [], orderBy: undefined, queryBy: 'PartNumber = "partNumber1"' } as ProductQuery);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onRunQuery).not.toHaveBeenCalled();
   });
 
   it('updates when user makes changes', async () => {
@@ -90,4 +101,7 @@ describe('ProductsQueryEditor', () => {
       expect(recordCount).toHaveValue(500);
     });
   });
+
+
+
 });

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -70,10 +70,11 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
   }
 
   const onParameterChange = (value: string) => {
-    if (query.queryBy !== value) {
+   if (query.queryBy !== value) {
+      query.queryBy = value;
       handleQueryChange({ ...query, queryBy: value });
     }
-  }
+  } 
 
   return (
     <>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To fix : [Bug 3108637](https://dev.azure.com/ni/DevCentral/_workitems/edit/3108637): Duplicate API Calls in Products Datasource When Workspace Filter is Applied. The issue was due to the `queryBy` triggering multiple internal `onChange` calls due to queryBy not updated internally.

## 👩‍💻 Implementation

- Updated the `query.queryBy` to the new value from the query Builder to retain is from triggering onChange.

## 🧪 Testing

- Added Test case to check

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).