### PR TITLE
fix(products, results): Refactor Descending control below the Order by

### DIFF
--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -127,7 +127,7 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
               <AutoSizeInput
                 minWidth={26}
                 maxWidth={26}
-                type="number"
+                type='number'
                 defaultValue={query.recordCount}
                 onCommitChange={recordCountChange}
                 placeholder="Enter record count"
@@ -145,9 +145,9 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
 }
 
 const tooltips = {
-  properties: 'Specifies the properties to be queried.',
-  recordCount: 'Specifies the maximum number of products to return.',
-  orderBy: 'Specifies the field to order the queried products by.',
-  descending: 'Specifies whether to return the products in descending order.',
+  properties: "Specifies the properties to be queried.",
+  recordCount: "Specifies the maximum number of products to return.",
+  orderBy: "Specifies the field to order the queried products by.",
+  descending: "Specifies whether to return the products in descending order.",
   queryBy: 'Specifies the filter to be applied on the queried products. This is an optional field.',
 };

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -131,9 +131,7 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
                 defaultValue={query.recordCount}
                 onCommitChange={recordCountChange}
                 placeholder="Enter record count"
-                onKeyDown={event => {
-                  validateNumericInput(event);
-                }}
+                onKeyDown={event => {validateNumericInput(event)}}
               />
             </InlineField>
           </div>

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -107,33 +107,33 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
         </VerticalGroup>
         <VerticalGroup>
           <div className="right-query-controls">
-            <div className="horizontal-control-group">
-              <InlineField label="OrderBy" labelWidth={18} tooltip={tooltips.orderBy}>
-                <Select
-                  options={OrderBy as SelectableValue[]}
-                  placeholder="Select field to order by"
-                  onChange={onOrderByChange}
-                  value={query.orderBy}
-                  defaultValue={query.orderBy}
-                  width={26}
-                />
-              </InlineField>
-              <InlineField label="Descending" tooltip={tooltips.descending}>
-                <InlineSwitch
-                  onChange={event => onDescendingChange(event.currentTarget.checked)}
-                  value={query.descending}
-                />
-              </InlineField>
-            </div>
+            <InlineField label="OrderBy" labelWidth={18} tooltip={tooltips.orderBy}>
+              <Select
+                options={OrderBy as SelectableValue[]}
+                placeholder="Select field to order by"
+                onChange={onOrderByChange}
+                value={query.orderBy}
+                defaultValue={query.orderBy}
+                width={26}
+              />
+            </InlineField>
+            <InlineField label="Descending" labelWidth={18} tooltip={tooltips.descending}>
+              <InlineSwitch
+                onChange={event => onDescendingChange(event.currentTarget.checked)}
+                value={query.descending}
+              />
+            </InlineField>
             <InlineField label="Take" labelWidth={18} tooltip={tooltips.recordCount}>
               <AutoSizeInput
                 minWidth={26}
                 maxWidth={26}
-                type='number'
+                type="number"
                 defaultValue={query.recordCount}
                 onCommitChange={recordCountChange}
                 placeholder="Enter record count"
-                onKeyDown={(event) => {validateNumericInput(event)}}
+                onKeyDown={event => {
+                  validateNumericInput(event);
+                }}
               />
             </InlineField>
           </div>
@@ -145,9 +145,9 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
 }
 
 const tooltips = {
-  properties: "Specifies the properties to be queried.",
-  recordCount: "Specifies the maximum number of products to return.",
-  orderBy: "Specifies the field to order the queried products by.",
-  descending: "Specifies whether to return the products in descending order.",
+  properties: 'Specifies the properties to be queried.',
+  recordCount: 'Specifies the maximum number of products to return.',
+  orderBy: 'Specifies the field to order the queried products by.',
+  descending: 'Specifies whether to return the products in descending order.',
   queryBy: 'Specifies the filter to be applied on the queried products. This is an optional field.',
-}
+};

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -131,7 +131,7 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
                 defaultValue={query.recordCount}
                 onCommitChange={recordCountChange}
                 placeholder="Enter record count"
-                onKeyDown={event => {validateNumericInput(event)}}
+                onKeyDown={(event) => {validateNumericInput(event)}}
               />
             </InlineField>
           </div>
@@ -148,4 +148,4 @@ const tooltips = {
   orderBy: "Specifies the field to order the queried products by.",
   descending: "Specifies whether to return the products in descending order.",
   queryBy: 'Specifies the filter to be applied on the queried products. This is an optional field.',
-};
+}

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -117,24 +117,22 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           </InlineField>
           {query.outputType === OutputType.Data && (
             <div className="right-query-controls">
-              <div className="horizontal-control-group">
-                <InlineField label="OrderBy" labelWidth={26} tooltip={tooltips.orderBy}>
-                  <Select
-                    width={25}
-                    options={OrderBy as SelectableValue[]}
-                    placeholder="Select field to order by"
-                    onChange={onOrderByChange}
-                    value={query.orderBy}
-                    defaultValue={query.orderBy}
-                  />
-                </InlineField>
-                <InlineField label="Descending" tooltip={tooltips.descending}>
-                  <InlineSwitch
-                    onChange={event => onDescendingChange(event.currentTarget.checked)}
-                    value={query.descending}
-                  />
-                </InlineField>
-              </div>
+              <InlineField label="OrderBy" labelWidth={26} tooltip={tooltips.orderBy}>
+                <Select
+                  width={25}
+                  options={OrderBy as SelectableValue[]}
+                  placeholder="Select field to order by"
+                  onChange={onOrderByChange}
+                  value={query.orderBy}
+                  defaultValue={query.orderBy}
+                />
+              </InlineField>
+              <InlineField label="Descending" labelWidth={26} tooltip={tooltips.descending}>
+                <InlineSwitch
+                  onChange={event => onDescendingChange(event.currentTarget.checked)}
+                  value={query.descending}
+                />
+              </InlineField>
               <InlineField label="Take" labelWidth={26} tooltip={tooltips.recordCount}>
                 <AutoSizeInput
                   minWidth={25}

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -123,24 +123,22 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
           />
 
           <div className="right-query-controls">
-            <div className="horizontal-control-group">
-              <InlineField label="OrderBy" labelWidth={26} tooltip={tooltips.orderBy}>
-                <Select
-                  options={OrderBy as SelectableValue[]}
-                  width={25}
-                  placeholder="Select field to order by"
-                  onChange={onOrderByChange}
-                  value={query.orderBy}
-                  defaultValue={query.orderBy}
-                />
-              </InlineField>
-              <InlineField label="Descending" tooltip={tooltips.descending}>
-                <InlineSwitch
-                  onChange={event => onDescendingChange(event.currentTarget.checked)}
-                  value={query.descending}
-                />
-              </InlineField>
-            </div>
+            <InlineField label="OrderBy" labelWidth={26} tooltip={tooltips.orderBy}>
+              <Select
+                options={OrderBy as SelectableValue[]}
+                width={25}
+                placeholder="Select field to order by"
+                onChange={onOrderByChange}
+                value={query.orderBy}
+                defaultValue={query.orderBy}
+              />
+            </InlineField>
+            <InlineField label="Descending" labelWidth={26} tooltip={tooltips.descending}>
+              <InlineSwitch
+                onChange={event => onDescendingChange(event.currentTarget.checked)}
+                value={query.descending}
+              />
+            </InlineField>
             <InlineField label="Take" labelWidth={26} tooltip={tooltips.recordCount}>
               <AutoSizeInput
                 minWidth={25}


### PR DESCRIPTION

# Pull Request

## 🤨 Rationale

Aligning to the following [comment ](https://ni.visualstudio.com/DevCentral/_workitems/edit/2605755#9933748)in the feature, we need to align the descending control below the orderBy.

Before : 
![image](https://github.com/user-attachments/assets/83a37fb5-fba2-438d-9dec-cd2291318929)

After: 
![image](https://github.com/user-attachments/assets/804ef079-7af5-443c-a17b-0f6c479a96b8)

## 👩‍💻 Implementation

- Removed unnecessary `div` elements with the class `horizontal-control-group` in `ProductsQueryEditor`, `QueryResultsEditor`, and `QueryStepsEditor` to simplify the component structure. 
-  Standardized the `labelWidth` property for `InlineField` components to ensure consistent alignment 

## 🧪 Testing
- Manually verified the UI

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).