### PR TITLE
fix(results): Hide Order by and Take fields when output type is set to total count

### DIFF
--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
@@ -244,4 +244,35 @@ describe('QueryStepsEditor', () => {
       expect(stepsQueryInput).toBeDisabled();
     });
   })
+
+  describe('Total Count outputType', () => {
+    test('should not render orderBy, descending, take when outputType is Total Count', () => {
+      cleanup();
+      render(
+        <QueryStepsEditor
+          query={{ ...defaultQuery, outputType: OutputType.TotalCount }}
+          handleQueryChange={mockHandleQueryChange}
+          datasource={mockDatasource}
+        />
+      );
+
+      expect(screen.queryByText('OrderBy')).not.toBeInTheDocument();
+      expect(screen.queryByText('Descending')).not.toBeInTheDocument();
+      expect(screen.queryByText('Take')).not.toBeInTheDocument();
+    });
+
+    test('should render useTimeRange and useTimeRangeFor when outputType is Total Count', () => {
+      cleanup();
+      render(
+        <QueryStepsEditor
+          query={{ ...defaultQuery, outputType: OutputType.TotalCount }}
+          handleQueryChange={mockHandleQueryChange}
+          datasource={mockDatasource}
+        />
+      );
+
+      expect(screen.queryByText('Use time range')).toBeInTheDocument();
+      expect(screen.queryByText('to filter by')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -121,7 +121,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
             onStepsQueryChange={(value: string) => onStepsFilterChange(value)}
             disableStepsQueryBuilder={disableStepsQueryBuilder}
           />
-
+          {query.outputType === OutputType.Data && (
           <div className="right-query-controls">
             <div className="horizontal-control-group">
               <InlineField label="OrderBy" labelWidth={26} tooltip={tooltips.orderBy}>
@@ -155,6 +155,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
               />
             </InlineField>
           </div>
+          )}
         </div>
       </VerticalGroup>
     </>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
This PR ensures that the Order By, Descending, and Take controls are hidden when the output type is set to Total Count and the query type is Steps.

## 👩‍💻 Implementation

- Added a condition to hide the Order By, Descending, and Take controls only when the output type is Total Count.

## 🧪 Testing

- Added unit test

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).