### PR TITLE
feat(test-plans): Query variable query editor

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -4,8 +4,8 @@ import { DataSourceBase } from 'core/DataSourceBase';
 import { OrderByOptions, OutputType, Projections, Properties, PropertiesProjectionMap, QueryTestPlansResponse, TestPlanResponseProperties, TestPlansQuery, TestPlansVariableQuery } from './types';
 import { queryInBatches } from 'core/utils';
 import { QueryResponse } from 'core/types';
-import { QUERY_TEST_PLANS_MAX_TAKE, QUERY_TEST_PLANS_REQUEST_PER_SECOND } from './constants/QueryTestPlans.constants';
 import { isTimeField } from './utils';
+import { QUERY_TEST_PLANS_MAX_TAKE, QUERY_TEST_PLANS_REQUEST_PER_SECOND } from './constants/QueryTestPlans.constants';
 
 export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   constructor(
@@ -103,7 +103,13 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   }
 
   async metricFindQuery(query: TestPlansVariableQuery, options: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
-    return [];
+    const metadata = (await this.queryTestPlansInBatches(
+      query.orderBy,
+      [Projections.ID, Projections.NAME],
+      query.recordCount,
+      query.descending
+    )).testPlans;
+    return metadata ? metadata.map(frame => ({ text: `${frame.name} (${frame.id})`, value: frame.id })) : [];
   }
 
   async testDatasource(): Promise<TestDataSourceResponse> {

--- a/src/datasources/test-plans/__snapshots__/TestPlansDataSource.test.ts.snap
+++ b/src/datasources/test-plans/__snapshots__/TestPlansDataSource.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`metricFindQuery should return test plan name with id when orderBy is provided 1`] = `
+[
+  {
+    "text": "testPlan 1 (1)",
+    "value": "1",
+  },
+  {
+    "text": "testPlan 2 (2)",
+    "value": "2",
+  },
+]
+`;
+
+exports[`metricFindQuery should return test plan name with id when queryBy is not provided 1`] = `
+[
+  {
+    "text": "testPlan 1 (1)",
+    "value": "1",
+  },
+  {
+    "text": "testPlan 2 (2)",
+    "value": "2",
+  },
+]
+`;

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
@@ -81,7 +81,6 @@ describe('TestPlansVariableQueryEditor', () => {
 
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ orderBy: 'ID' }));
-        expect(mockOnRunQuery).toHaveBeenCalled();
       });
     });
 
@@ -93,7 +92,6 @@ describe('TestPlansVariableQueryEditor', () => {
 
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ descending: true }));
-        expect(mockOnRunQuery).toHaveBeenCalled();
       });
     });
 
@@ -107,7 +105,6 @@ describe('TestPlansVariableQueryEditor', () => {
 
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: 50 }));
-        expect(mockOnRunQuery).toHaveBeenCalled();
       });
     });
 

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
@@ -8,16 +8,13 @@ import { TestPlansDataSource } from '../TestPlansDataSource';
 
 type Props = QueryEditorProps<TestPlansDataSource, TestPlansVariableQuery>;
 
-export function TestPlansVariableQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Props) {
   query = datasource.prepareQuery(query);
 
   const handleQueryChange = useCallback(
-    (query: TestPlansVariableQuery, runQuery = true): void => {
+    (query: TestPlansVariableQuery): void => {
       onChange(query);
-      if (runQuery) {
-        onRunQuery();
-      }
-    }, [onChange, onRunQuery]
+    }, [onChange]
   );
 
   const onOrderByChange = (item: SelectableValue<string>) => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
[Task 3131192](https://ni.visualstudio.com/DevCentral/_workitems/edit/3131192): Return testplan name(id)
To query test plans and show it in `Test plan name (id)` format from variable page
![image](https://github.com/user-attachments/assets/918bc63a-d340-4ad2-9a5b-adc032eed860)

## 👩‍💻 Implementation

- Queried the test plan with  ID & NAME  projections
- Apply batching when take > 1000

## 🧪 Testing

Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).