### PR TITLE
feat(test-plan): add dummy query builder in test plans editors

### DIFF
--- a/src/core/query-builder.constants.ts
+++ b/src/core/query-builder.constants.ts
@@ -151,6 +151,18 @@ export const QueryBuilderOperations = {
     name: 'listnotcontains',
     expressionTemplate: '{0}.Any(!it.Contains("{1}"))',
   },
+  LIST_IS_EMPTY: {
+    label: 'Is empty',
+    name: 'listisempty',
+    expressionTemplate: '{0}.Count == 0',
+    hideValue: true,
+  },
+  LIST_IS_NOT_EMPTY: {
+    label: 'Is not empty',
+    name: 'listisnotempty',
+    expressionTemplate: '{0}.Count > 0',
+    hideValue: true,
+  },
   // Properties expressions
   PROPERTY_EQUALS: {
     label: 'Equals',

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.scss
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.scss
@@ -1,3 +1,0 @@
-.horizontal-control-group {
-  display: flex;
-}

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
@@ -58,6 +58,9 @@ describe('TestPlansQueryEditor', () => {
             const recordCount = container.getByRole('spinbutton');
             expect(recordCount).toBeInTheDocument();
             expect(recordCount).toHaveDisplayValue('');
+
+            const queryBuilder = container.getByRole('dialog');
+            expect(queryBuilder).toBeInTheDocument();
         });
     });
 
@@ -258,6 +261,22 @@ describe('TestPlansQueryEditor', () => {
 
             await waitFor(() => {
                 expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: 50 }));
+                expect(mockOnRunQuery).toHaveBeenCalled();
+            });
+        });
+
+        it('should call onChange when query by changes', async () => {
+            const container = renderElement();
+
+            const queryBuilder = container.getByRole('dialog');
+            expect(queryBuilder).toBeInTheDocument();
+
+            // Simulate a change event
+            const event = { detail: { linq: 'new-query' } };
+            queryBuilder?.dispatchEvent(new CustomEvent('change', event));
+
+            await waitFor(() => {
+                expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ queryBy: 'new-query' }));
                 expect(mockOnRunQuery).toHaveBeenCalled();
             });
         });

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
@@ -290,7 +290,7 @@ describe('TestPlansQueryEditor', () => {
             userEvent.tab();
 
             await waitFor(() => {
-                expect(container.getByText('Record count must be less than 10000')).toBeInTheDocument();
+                expect(container.queryByText('Record count must be less than 10000')).toBeInTheDocument();
             });
         });
     });

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
@@ -48,6 +48,9 @@ describe('TestPlansVariableQueryEditor', () => {
       const recordCount = container.getByRole('spinbutton');
       expect(recordCount).toBeInTheDocument();
       expect(recordCount).toHaveDisplayValue('');
+
+      const queryBuilder = container.getByRole('dialog');
+      expect(queryBuilder).toBeInTheDocument();
     });
   });
 
@@ -120,7 +123,6 @@ describe('TestPlansVariableQueryEditor', () => {
 
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ queryBy: 'new-query' }));
-        expect(mockOnRunQuery).toHaveBeenCalled();
       });
     });
 
@@ -133,7 +135,7 @@ describe('TestPlansVariableQueryEditor', () => {
       userEvent.tab();
 
       await waitFor(() => {
-        expect(container.getByText('Record count must be less than 10000')).toBeInTheDocument();
+        expect(container.queryByText('Record count must be less than 10000')).toBeInTheDocument();
       });
     });
   });

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
@@ -111,6 +111,22 @@ describe('TestPlansVariableQueryEditor', () => {
       });
     });
 
+    it('should call onChange when query by changes', async () => {
+      const container = renderElement();
+
+      const queryBuilder = container.getByRole('dialog');
+      expect(queryBuilder).toBeInTheDocument();
+
+      // Simulate a change event
+      const event = { detail: { linq: 'new-query' } };
+      queryBuilder?.dispatchEvent(new CustomEvent('change', event));
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ queryBy: 'new-query' }));
+        expect(mockOnRunQuery).toHaveBeenCalled();
+      });
+    });
+
     it('should show error message when record count is invalid', async () => {
       const container = renderElement();
       const recordCountInput = container.getByRole('spinbutton');

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
@@ -54,7 +54,7 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
         ></TestPlansQueryBuilder>
       </InlineField>
       <div>
-        <InlineField label="OrderBy" labelWidth={18} tooltip={tooltips.orderBy}>
+        <InlineField label="OrderBy" labelWidth={25} tooltip={tooltips.orderBy}>
           <Select
             options={[...OrderBy] as SelectableValue[]}
             placeholder="Select a field to set the query order"
@@ -64,7 +64,7 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
             width={26}
           />
         </InlineField>
-        <InlineField label="Descending" labelWidth={18} tooltip={tooltips.descending}>
+        <InlineField label="Descending" labelWidth={25} tooltip={tooltips.descending}>
           <InlineSwitch
             onChange={event => onDescendingChange(event.currentTarget.checked)}
             value={query.descending}
@@ -73,7 +73,7 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
       </div>
       <InlineField
         label="Take"
-        labelWidth={18}
+        labelWidth={25}
         tooltip={tooltips.recordCount}
         invalid={!isRecordCountValid}
         error={errors.recordCount}

--- a/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.test.tsx
+++ b/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.test.tsx
@@ -1,0 +1,25 @@
+import { QueryBuilderOption } from 'core/types';
+import React, { ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { TestPlansQueryBuilder } from './TestPlansQueryBuilder';
+
+describe('TestPlansQueryBuilder', () => {
+    let reactNode: ReactNode;
+    const containerClass = 'smart-filter-group-condition-container';
+
+    function renderElement(filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
+        reactNode = React.createElement(TestPlansQueryBuilder, { filter, globalVariableOptions, onChange: jest.fn() });
+        const renderResult = render(reactNode);
+        return {
+            renderResult,
+            conditionsContainer: renderResult.container.getElementsByClassName(`${containerClass}`),
+        };
+    }
+
+    it('should render empty query builder', () => {
+        const { renderResult, conditionsContainer } = renderElement('');
+
+        expect(conditionsContainer.length).toBe(1);
+        expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
+    });
+});

--- a/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.tsx
+++ b/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.tsx
@@ -1,0 +1,87 @@
+import { SlQueryBuilder } from "core/components/SlQueryBuilder/SlQueryBuilder";
+import { queryBuilderMessages, QueryBuilderOperations } from "core/query-builder.constants";
+import { expressionBuilderCallback, expressionReaderCallback } from "core/query-builder.utils";
+import { QBField, QueryBuilderOption } from "core/types";
+import { TestPlansQueryBuilderStaticFields } from "datasources/test-plans/constants/TestPlansQueryBuilder.constants";
+import React, { useState, useEffect } from "react";
+import { QueryBuilderCustomOperation, QueryBuilderProps } from "smart-webcomponents-react/querybuilder";
+
+type TestPlansQueryBuilderProps = QueryBuilderProps & React.HTMLAttributes<Element> & {
+    filter?: string;
+    globalVariableOptions: QueryBuilderOption[];
+};
+
+export const TestPlansQueryBuilder: React.FC<TestPlansQueryBuilderProps> = ({
+    filter,
+    onChange,
+    globalVariableOptions,
+}) => {
+    const [fields, setFields] = useState<QBField[]>([]);
+    const [operations, setOperations] = useState<QueryBuilderCustomOperation[]>([]);
+
+    useEffect(() => {
+        const updatedFields = TestPlansQueryBuilderStaticFields
+
+        setFields(updatedFields);
+
+        const options = Object.values(updatedFields).reduce((accumulator, fieldConfig) => {
+            if (fieldConfig.lookup) {
+                accumulator[fieldConfig.dataField!] = fieldConfig.lookup.dataSource;
+            }
+
+            return accumulator;
+        }, {} as Record<string, QueryBuilderOption[]>);
+
+        const callbacks = {
+            expressionBuilderCallback: expressionBuilderCallback(options),
+            expressionReaderCallback: expressionReaderCallback(options),
+        };
+
+        const customOperations = [
+            QueryBuilderOperations.EQUALS,
+            QueryBuilderOperations.DOES_NOT_EQUAL,
+            QueryBuilderOperations.STARTS_WITH,
+            QueryBuilderOperations.ENDS_WITH,
+            QueryBuilderOperations.CONTAINS,
+            QueryBuilderOperations.DOES_NOT_CONTAIN,
+            QueryBuilderOperations.LESS_THAN,
+            QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO,
+            QueryBuilderOperations.GREATER_THAN,
+            QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO,
+            QueryBuilderOperations.IS_BLANK,
+            QueryBuilderOperations.IS_NOT_BLANK,
+            QueryBuilderOperations.DATE_TIME_IS_AFTER,
+            QueryBuilderOperations.DATE_TIME_IS_BEFORE,
+            QueryBuilderOperations.LIST_IS_EMPTY,
+            QueryBuilderOperations.LIST_IS_NOT_EMPTY,
+            QueryBuilderOperations.LIST_EQUALS,
+            QueryBuilderOperations.LIST_DOES_NOT_EQUAL,
+        ].map((operation) => {
+            return {
+                ...operation,
+                ...callbacks,
+            };
+        });
+
+        const keyValueOperations = [
+            QueryBuilderOperations.KEY_VALUE_MATCH,
+            QueryBuilderOperations.KEY_VALUE_DOES_NOT_MATCH,
+            QueryBuilderOperations.KEY_VALUE_CONTAINS,
+            QueryBuilderOperations.KEY_VALUE_DOES_NOT_CONTAINS
+        ];
+
+        setOperations([...customOperations, ...keyValueOperations]);
+
+    }, [globalVariableOptions]);
+
+    return (
+        <SlQueryBuilder
+            customOperations={operations}
+            fields={fields}
+            messages={queryBuilderMessages}
+            onChange={onChange}
+            value={filter}
+            showIcons
+        />
+    );
+}

--- a/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
+++ b/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
@@ -1,0 +1,253 @@
+import { QueryBuilderOperations } from "core/query-builder.constants";
+import { QBField } from "core/types";
+
+
+export enum TestPlansQueryBuilderFieldNames {
+    AssignedTo = 'assignedTo',
+    CreatedAt = 'created',
+    CreatedBy = 'createdBy',
+    Description = 'description',
+    DUTIdentifier = 'DUTIdentifier',
+    EstimatedDurationInDays = 'estimatedDurationInDays',
+    EstimatedDurationInHours = 'estimatedDurationInHours',
+    EstimatedEndDate = 'estimatedEndDate',
+    FixtureIdentifier = 'fixtureIdentifier',
+    Name = 'name',
+    PlannedStartDate = 'plannedStartDate',
+    Product = 'product',
+    Properties = 'properties',
+    State = 'state',
+    SystemAliasName = 'systemAliasName',
+    TestPlanID = 'testPlanID',
+    TestProgram = 'testProgram',
+    UpdatedAt = 'updatedAt',
+    UpdatedBy = 'updatedBy',
+    WorkOrderID = 'workOrderID',
+    Workspace = 'workspace',
+}
+
+export const TestPlansQueryBuilderFields: Record<string, QBField> = {
+    ASSIGNED_TO: {
+        label: 'Assigned to',
+        dataField: TestPlansQueryBuilderFieldNames.AssignedTo,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name,
+            QueryBuilderOperations.IS_BLANK.name,
+            QueryBuilderOperations.IS_NOT_BLANK.name
+        ]
+    },
+    CREATED_AT: {
+        label: 'Created',
+        dataField: TestPlansQueryBuilderFieldNames.CreatedAt,
+        filterOperations: [
+            QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+            QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
+        ]
+    },
+    CREATED_BY: {
+        label: 'Created by',
+        dataField: TestPlansQueryBuilderFieldNames.CreatedBy,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name
+        ]
+    },
+    DESCRIPTION: {
+        label: 'Description',
+        dataField: TestPlansQueryBuilderFieldNames.Description,
+        filterOperations: [
+            QueryBuilderOperations.CONTAINS.name,
+            QueryBuilderOperations.DOES_NOT_CONTAIN.name
+        ]
+    },
+    DUT_IDENTIFIER: {
+        label: 'DUT identifier',
+        dataField: TestPlansQueryBuilderFieldNames.DUTIdentifier,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name,
+            QueryBuilderOperations.IS_BLANK.name,
+            QueryBuilderOperations.IS_NOT_BLANK.name
+        ]
+    },
+    ESTIMATED_DURATION_IN_DAYS: {
+        label: 'Estimated duration (days)',
+        dataField: TestPlansQueryBuilderFieldNames.EstimatedDurationInDays,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name,
+            QueryBuilderOperations.GREATER_THAN.name,
+            QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
+            QueryBuilderOperations.LESS_THAN.name,
+            QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name
+        ]
+    },
+    ESTIMATED_DURATION_IN_HOURS: {
+        label: 'Estimated duration (hours)',
+        dataField: TestPlansQueryBuilderFieldNames.EstimatedDurationInHours,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name,
+            QueryBuilderOperations.GREATER_THAN.name,
+            QueryBuilderOperations.GREATER_THAN_OR_EQUAL_TO.name,
+            QueryBuilderOperations.LESS_THAN.name,
+            QueryBuilderOperations.LESS_THAN_OR_EQUAL_TO.name
+        ]
+    },
+    ESTIMATED_END_DATE: {
+        label: 'Estimated end date',
+        dataField: TestPlansQueryBuilderFieldNames.EstimatedEndDate,
+        filterOperations: [
+            QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+            QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
+            QueryBuilderOperations.IS_BLANK.name,
+            QueryBuilderOperations.IS_NOT_BLANK.name
+        ]
+    },
+    FIXTURE_IDENTIFIER: {
+        label: 'Fixture identifier',
+        dataField: TestPlansQueryBuilderFieldNames.FixtureIdentifier,
+        filterOperations: [
+            QueryBuilderOperations.LIST_EQUALS.name,
+            QueryBuilderOperations.LIST_DOES_NOT_EQUAL.name,
+            QueryBuilderOperations.LIST_IS_EMPTY.name,
+            QueryBuilderOperations.LIST_IS_NOT_EMPTY.name
+        ]
+    },
+    NAME: {
+        label: 'Name',
+        dataField: TestPlansQueryBuilderFieldNames.Name,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name,
+            QueryBuilderOperations.CONTAINS.name,
+            QueryBuilderOperations.DOES_NOT_CONTAIN.name
+        ]
+    },
+    PLANNED_START_DATE: {
+        label: 'Planned start date',
+        dataField: TestPlansQueryBuilderFieldNames.PlannedStartDate,
+        filterOperations: [
+            QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+            QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
+            QueryBuilderOperations.IS_BLANK.name,
+            QueryBuilderOperations.IS_NOT_BLANK.name
+        ]
+    },
+    PRODUCT: {
+        label: 'Product name (Part number)',
+        dataField: TestPlansQueryBuilderFieldNames.Product,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name
+        ]
+    },
+    PROPERTIES: {
+        label: 'Properties',
+        dataField: TestPlansQueryBuilderFieldNames.Properties,
+        dataType: 'object',
+        filterOperations: [
+            QueryBuilderOperations.KEY_VALUE_MATCH.name,
+            QueryBuilderOperations.KEY_VALUE_DOES_NOT_MATCH.name,
+            QueryBuilderOperations.KEY_VALUE_CONTAINS.name,
+            QueryBuilderOperations.KEY_VALUE_DOES_NOT_CONTAINS.name
+        ]
+    },
+    STATE: {
+        label: 'State',
+        dataField: TestPlansQueryBuilderFieldNames.State,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name
+        ]
+    },
+    SYSTEM_ALIAS_NAME: {
+        label: 'System alias name',
+        dataField: TestPlansQueryBuilderFieldNames.SystemAliasName,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name,
+            QueryBuilderOperations.IS_BLANK.name,
+            QueryBuilderOperations.IS_NOT_BLANK.name
+        ]
+    },
+    TEST_PLAN_ID: {
+        label: 'Test plan ID',
+        dataField: TestPlansQueryBuilderFieldNames.TestPlanID,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name
+        ]
+    },
+    TEST_PROGRAM: {
+        label: 'Test program',
+        dataField: TestPlansQueryBuilderFieldNames.TestProgram,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name,
+            QueryBuilderOperations.CONTAINS.name,
+            QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+            QueryBuilderOperations.IS_BLANK.name,
+            QueryBuilderOperations.IS_NOT_BLANK.name
+        ]
+    },
+    UPDATED_AT: {
+        label: 'Updated at',
+        dataField: TestPlansQueryBuilderFieldNames.UpdatedAt,
+        filterOperations: [
+            QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+            QueryBuilderOperations.DATE_TIME_IS_BEFORE.name
+        ]
+    },
+    UPDATED_BY: {
+        label: 'Updated by',
+        dataField: TestPlansQueryBuilderFieldNames.UpdatedBy,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name
+        ]
+    },
+    WORK_ORDER_ID: {
+        label: 'Work order ID',
+        dataField: TestPlansQueryBuilderFieldNames.WorkOrderID,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name,
+            QueryBuilderOperations.IS_BLANK.name,
+            QueryBuilderOperations.IS_NOT_BLANK.name
+        ]
+    },
+    WORKSPACE: {
+        label: 'Workspace',
+        dataField: TestPlansQueryBuilderFieldNames.Workspace,
+        filterOperations: [
+            QueryBuilderOperations.EQUALS.name,
+            QueryBuilderOperations.DOES_NOT_EQUAL.name
+        ]
+    }
+}
+
+export const TestPlansQueryBuilderStaticFields = [
+    TestPlansQueryBuilderFields.ASSIGNED_TO,
+    TestPlansQueryBuilderFields.CREATED_AT,
+    TestPlansQueryBuilderFields.CREATED_BY,
+    TestPlansQueryBuilderFields.DESCRIPTION,
+    TestPlansQueryBuilderFields.DUT_IDENTIFIER,
+    TestPlansQueryBuilderFields.ESTIMATED_DURATION_IN_DAYS,
+    TestPlansQueryBuilderFields.ESTIMATED_DURATION_IN_HOURS,
+    TestPlansQueryBuilderFields.ESTIMATED_END_DATE,
+    TestPlansQueryBuilderFields.FIXTURE_IDENTIFIER,
+    TestPlansQueryBuilderFields.NAME,
+    TestPlansQueryBuilderFields.PLANNED_START_DATE,
+    TestPlansQueryBuilderFields.PRODUCT,
+    TestPlansQueryBuilderFields.PROPERTIES,
+    TestPlansQueryBuilderFields.STATE,
+    TestPlansQueryBuilderFields.SYSTEM_ALIAS_NAME,
+    TestPlansQueryBuilderFields.TEST_PLAN_ID,
+    TestPlansQueryBuilderFields.TEST_PROGRAM,
+    TestPlansQueryBuilderFields.UPDATED_AT,
+    TestPlansQueryBuilderFields.UPDATED_BY,
+    TestPlansQueryBuilderFields.WORK_ORDER_ID,
+    TestPlansQueryBuilderFields.WORKSPACE
+];

--- a/src/datasources/test-plans/types.ts
+++ b/src/datasources/test-plans/types.ts
@@ -5,6 +5,7 @@ export interface TestPlansQuery extends DataQuery {
     outputType?: OutputType;
     orderBy?: string;
     descending?: boolean;
+    queryBy?: string;
     recordCount?: number;
 }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
[Task 3105000](https://ni.visualstudio.com/DevCentral/_workitems/edit/3105000): Add query builder for testplans
To add query builder for test plans data source in query editor & variable query editor
![image](https://github.com/user-attachments/assets/0879f6af-4062-47f3-955e-434572a09e73)
![image](https://github.com/user-attachments/assets/e8c8b94e-b3ad-4f77-beb1-153109ecbef7)


## 👩‍💻 Implementation

- Created `TestPlansQueryBuilder` - wrapper of `SlQueryBuilder`
- Use them in `TestPlansQueryEditor` and `TestPLansVariableQueryEditor`
- Add supported filters and their operators
- Added `LIST_IS_EMPTY` and `LIST_IS_NOT_EMPTY` in core 

## 🧪 Testing

- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).