### PR TITLE
feat(results): Add product multiselect field in results query editor

### DIFF
--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -152,6 +152,21 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
     return filters.length > 0 ? filters.join(' && ') : undefined;
   };
 
+  /**
+   * Builds a query string for the given field using multiple values,
+   * joining each condition with the logical OR operator
+   *
+   * @param fieldName - The field name to filter on
+   * @param values - Array of values to include in the OR condition.
+   * @returns The constructed query string, or an empty string if no values are provided.
+   */
+  protected buildQueryWithOrOperator = (fieldName: string, values: string[]): string => {
+    if (values.length === 0){
+      return '';
+    } 
+    return values.map(item => `${fieldName} = "${item}"`).join(' || ');
+  };
+
   private isMultiSelectValue(value: string): boolean {
     return value.startsWith('{') && value.endsWith('}');
   }

--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -49,6 +49,10 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
     return this.getPartNumbers();
   }
 
+  get productCache(): Promise<QueryProductResponse> {
+    return this.loadProducts();
+  }
+
   async loadWorkspaces(): Promise<Map<string, Workspace>> {
     if (ResultsDataSourceBase._workspacesCache) {
       return ResultsDataSourceBase._workspacesCache;
@@ -106,10 +110,6 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
     } catch (error) {
       throw new Error(`An error occurred while querying products: ${error}`);
     }
-  }
-
-  get productCache(): Promise<QueryProductResponse> {
-    return this.loadProducts();
   }
 
   async loadProducts(): Promise<QueryProductResponse> {

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
@@ -1,12 +1,11 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { OutputType, QueryType } from '../../../types/types';
-import selectEvent, { select } from 'react-select-event';
+import { select } from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
 import { QueryResultsEditor } from './QueryResultsEditor';
 import React from 'react';
 import { Workspace } from 'core/types';
-import exp from 'constants';
 
 jest.mock('../../query-builders/query-results/ResultsQueryBuilder', () => ({
   ResultsQueryBuilder: jest.fn(({ filter, workspaces, partNumbers, status, globalVariableOptions, onChange }) => {

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
@@ -113,7 +113,7 @@ describe('QueryResultsEditor', () => {
     expect(useTimeRangeFor).toBeInTheDocument();
     expect(screen.getAllByText('Updated').length).toBe(1);
     expect(productName).toBeInTheDocument();
-    expect(screen.getAllByText('PartNumber1').length).toBe(1);
+    expect(screen.getAllByText('ProductName1 (PartNumber1)').length).toBe(1);
   });
 
   test('should update properties when user adds a property', async () => {
@@ -138,6 +138,13 @@ describe('QueryResultsEditor', () => {
   });
 
   test('should update part number query when user changes a product name', async () => {
+    await select(productName, 'ProductName2 (PartNumber2)', { container: document.body });
+    await waitFor(() => {
+      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ partNumberQuery: ["PartNumber1", "PartNumber2"] }));
+    });
+  });
+
+    test('should update part number query when user selects a variable in product name field', async () => {
     await select(productName, '$var1', { container: document.body });
     await waitFor(() => {
       expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ partNumberQuery: ["PartNumber1", "$var1"] }));
@@ -198,6 +205,7 @@ describe('QueryResultsEditor', () => {
       const emptyDatasource = {
         workspacesCache: Promise.resolve(new Map()),
         partNumbersCache: Promise.resolve([]),
+        productCache: Promise.resolve({ products: [] }),
         globalVariableOptions: jest.fn(() => []),
       } as unknown as QueryResultsDataSource;
 

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -84,6 +84,12 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
     handleQueryChange({ ...query, partNumberQuery: productNames.map(product => product.value as string) });
   }
 
+  const formatOptionLabel = (option: SelectableValue<string>) => (
+    <div style={{ maxWidth: 520, whiteSpace: 'normal' }}>
+      {option.label}
+    </div>
+  );
+
   return (
     <>
       <VerticalGroup>
@@ -128,8 +134,8 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
                 noMultiValueWrap={true}
                 closeMenuOnSelect={false}
                 value={query.partNumberQuery}
+                formatOptionLabel={formatOptionLabel}
                 options={productNameOptions}
-                defaultOptions
               />
             </InlineField>
             <InlineField label="Query By" labelWidth={26} tooltip={tooltips.queryBy}>

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -125,12 +125,12 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
         />
         <div className="horizontal-control-group">
           <div>
-            <InlineField label="Product name" labelWidth={26} tooltip={tooltips.productName}>
+            <InlineField label="Product (part number)" labelWidth={26} tooltip={tooltips.productName}>
               <MultiSelect
                 maxVisibleValues={5}
                 width={65}
                 onChange={onProductNameChange}
-                placeholder='Select part numbers to query'
+                placeholder='Select part numbers to use in a query'
                 noMultiValueWrap={true}
                 closeMenuOnSelect={false}
                 value={query.partNumberQuery}

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -126,7 +126,6 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
                 width={65}
                 onChange={onProductNameChange}
                 closeMenuOnSelect={false}
-                menuShouldPortal={false}
                 value={query.partNumberQuery?.map(pn => ({ label: pn, value: pn }))}
                 loadOptions={loadProductNameOptions}
                 defaultOptions

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -76,6 +76,15 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
     handleQueryChange({ ...query, partNumberQuery: productNames.map(product => product.value as string) });
   }
 
+  const loadProductNameOptions = async () => {
+    const response = await datasource.productCache;
+    const productOptions = response.products.map(product => ({
+      label: `${product.name} (${product.partNumber})`,
+      value: product.partNumber,
+    }));
+    return [...datasource.globalVariableOptions(), ...productOptions];
+  };
+
   return (
     <>
       <VerticalGroup>
@@ -111,7 +120,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
         />
         <div className="horizontal-control-group">
           <div>
-            <InlineField label="Product name" labelWidth={26}>
+            <InlineField label="Product name" labelWidth={26} tooltip={tooltips.productName}>
               <AsyncMultiSelect
                 maxVisibleValues={5}
                 width={65}
@@ -119,14 +128,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
                 closeMenuOnSelect={false}
                 menuShouldPortal={false}
                 value={query.partNumberQuery?.map(pn => ({ label: pn, value: pn }))}
-                loadOptions={async () => {
-                  const response = await datasource.productCache;
-                  const productOptions = response.products.map(product => ({
-                    label: `${product.name} (${product.partNumber})`,
-                    value: product.partNumber,
-                  }));
-                  return [...datasource.globalVariableOptions(), ...productOptions];
-                }}
+                loadOptions={loadProductNameOptions}
                 defaultOptions
               />
             </InlineField>
@@ -186,4 +188,5 @@ const tooltips = {
   orderBy: 'This field orders the query results by field.',
   descending: 'This field returns the query results in descending order.',
   queryBy: 'This optional field applies a filter to the query results.',
+  productName: 'This field filters results by part number.',
 };

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -113,6 +113,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           <div>
             <InlineField label="Product name" labelWidth={26}>
               <AsyncMultiSelect
+                maxVisibleValues={5}
                 width={65}
                 onChange={onProductNameChange}
                 closeMenuOnSelect={false}

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -124,6 +124,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
                 maxVisibleValues={5}
                 width={65}
                 onChange={onProductNameChange}
+                placeholder='Select part numbers to query'
                 noMultiValueWrap={true}
                 closeMenuOnSelect={false}
                 value={query.partNumberQuery}

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -124,6 +124,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
                 maxVisibleValues={5}
                 width={65}
                 onChange={onProductNameChange}
+                noMultiValueWrap={true}
                 closeMenuOnSelect={false}
                 value={query.partNumberQuery}
                 options={productNameOptions}

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -116,6 +116,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
                 width={65}
                 onChange={onProductNameChange}
                 closeMenuOnSelect={false}
+                menuShouldPortal={false}
                 value={query.partNumberQuery?.map(pn => ({ label: pn, value: pn }))}
                 loadOptions={async () => {
                   const response = await datasource.productCache;

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -1,5 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import {
+  AsyncMultiSelect,
   AutoSizeInput,
   InlineField,
   InlineSwitch,
@@ -71,6 +72,10 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
     }
   }
 
+  const onProductNameChange = (productNames: Array<SelectableValue<string>>) => {
+    handleQueryChange({ ...query, partNumberQuery: productNames.map(product => product.value as string) });
+  }
+
   return (
     <>
       <VerticalGroup>
@@ -105,6 +110,23 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           }}
         />
         <div className="horizontal-control-group">
+          <div>
+            <InlineField label="Product name" labelWidth={26}>
+              <AsyncMultiSelect
+                width={65}
+                onChange={onProductNameChange}
+                closeMenuOnSelect={false}
+                loadOptions={async () => {
+                  const response = await datasource.productCache;
+                  const productOptions = response.products.map(product => ({
+                    label: `${product.name} (${product.partNumber})`,
+                    value: product.partNumber,
+                  }));
+                  return [...datasource.globalVariableOptions(), ...productOptions];
+                }}
+                defaultOptions
+              />
+            </InlineField>
           <InlineField label="Query By" labelWidth={26} tooltip={tooltips.queryBy}>
             <ResultsQueryBuilder
               filter={query.queryBy}
@@ -115,6 +137,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
               onChange={(event: any) => onParameterChange(event.detail.linq)}>
             </ResultsQueryBuilder>
           </InlineField>
+          </div>
           {query.outputType === OutputType.Data && (
             <div className="right-query-controls">
               <InlineField label="OrderBy" labelWidth={26} tooltip={tooltips.orderBy}>

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -116,6 +116,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
                 width={65}
                 onChange={onProductNameChange}
                 closeMenuOnSelect={false}
+                value={query.partNumberQuery?.map(pn => ({ label: pn, value: pn }))}
                 loadOptions={async () => {
                   const response = await datasource.productCache;
                   const productOptions = response.products.map(product => ({
@@ -127,16 +128,16 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
                 defaultOptions
               />
             </InlineField>
-          <InlineField label="Query By" labelWidth={26} tooltip={tooltips.queryBy}>
-            <ResultsQueryBuilder
-              filter={query.queryBy}
-              workspaces={workspaces}
-              partNumbers={partNumbers}
-              status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
-              globalVariableOptions={datasource.globalVariableOptions()}
-              onChange={(event: any) => onParameterChange(event.detail.linq)}>
-            </ResultsQueryBuilder>
-          </InlineField>
+            <InlineField label="Query By" labelWidth={26} tooltip={tooltips.queryBy}>
+              <ResultsQueryBuilder
+                filter={query.queryBy}
+                workspaces={workspaces}
+                partNumbers={partNumbers}
+                status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
+                globalVariableOptions={datasource.globalVariableOptions()}
+                onChange={(event: any) => onParameterChange(event.detail.linq)}>
+              </ResultsQueryBuilder>
+            </InlineField>
           </div>
           {query.outputType === OutputType.Data && (
             <div className="right-query-controls">

--- a/src/datasources/results/defaultQueries.ts
+++ b/src/datasources/results/defaultQueries.ts
@@ -20,6 +20,7 @@ export const defaultResultsQuery = {
   recordCount: 1000,
   useTimeRange: false,
   useTimeRangeFor: undefined,
+  partNumberQuery: [],
   queryBy: '',
 };
 

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -236,8 +236,8 @@ describe('QueryResultsDataSource', () => {
 
       test('should handle part number query with template variables', async () => {
         const partNumberQuery = ['PartNumber1', '${var}'];
-        const templateSrvCalledWith = 'PartNumber = "PartNumber1" || PartNumber = "${var}"';
-        const replacedPartNumberQuery = 'PartNumber = "PartNumber1" || PartNumber = "ReplacedValue"';
+        const templateSrvCalledWith = '(PartNumber = "PartNumber1" || PartNumber = "${var}")';
+        const replacedPartNumberQuery = '(PartNumber = "PartNumber1" || PartNumber = "ReplacedValue")';
         templateSrv.replace.calledWith(templateSrvCalledWith).mockReturnValue(replacedPartNumberQuery);
 
         const query = buildQuery(
@@ -251,7 +251,7 @@ describe('QueryResultsDataSource', () => {
 
         await datastore.query(query);
 
-        expect(templateSrv.replace).toHaveBeenCalledWith("PartNumber = \"PartNumber1\" || PartNumber = \"${var}\"", expect.anything());
+        expect(templateSrv.replace).toHaveBeenCalledWith("(PartNumber = \"PartNumber1\" || PartNumber = \"${var}\")", expect.anything());
         expect(backendServer.fetch).toHaveBeenCalledWith(
           expect.objectContaining({
             url: '/nitestmonitor/v2/query-results',
@@ -266,8 +266,8 @@ describe('QueryResultsDataSource', () => {
         const resultsQuery = `${ResultsQueryBuilderFieldNames.PROGRAM_NAME} = "{name1,name2}"`;
         const partNumberQuery = ['PartNumber1', '${var}'];
 
-        const templateSrvCalledWith = 'PartNumber = "PartNumber1" || PartNumber = "${var}"';
-        const replacedPartNumberQuery = 'PartNumber = "PartNumber1" || PartNumber = "{partNumber2,partNumber3}"';
+        const templateSrvCalledWith = '(PartNumber = "PartNumber1" || PartNumber = "${var}") && ProgramName = "{name1,name2}"';
+        const replacedPartNumberQuery = '(PartNumber = "PartNumber1" || PartNumber = "{partNumber2,partNumber3}") && ProgramName = "{name1,name2}"';
         templateSrv.replace.calledWith(templateSrvCalledWith).mockReturnValue(replacedPartNumberQuery);
 
         const query = buildQuery(
@@ -281,8 +281,7 @@ describe('QueryResultsDataSource', () => {
 
         await datastore.query(query);
 
-        expect(templateSrv.replace).toHaveBeenNthCalledWith(1, resultsQuery, expect.anything());
-        expect(templateSrv.replace).toHaveBeenNthCalledWith(2, "PartNumber = \"PartNumber1\" || PartNumber = \"${var}\"", expect.anything());
+        expect(templateSrv.replace).toHaveBeenCalledWith("(PartNumber = \"PartNumber1\" || PartNumber = \"${var}\") && ProgramName = \"{name1,name2}\"", expect.anything());
         expect(backendServer.fetch).toHaveBeenCalledWith(
           expect.objectContaining({
             url: '/nitestmonitor/v2/query-results',

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -188,12 +188,167 @@ describe('QueryResultsDataSource', () => {
         ]);
     });
 
+    describe('part number query', () => {
+      test('should transform part number query into filter', async () => {
+        const partNumberQuery = ['PartNumber1', 'PartNumber2'];
+        const query = buildQuery(
+          {
+            refId: 'A',
+            outputType: OutputType.Data,
+            partNumberQuery,
+            queryBy: '',
+          },
+        );
+
+        await datastore.query(query);
+
+        expect(backendServer.fetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: '/nitestmonitor/v2/query-results',
+            data: expect.objectContaining({
+              filter: '(PartNumber = "PartNumber1" || PartNumber = "PartNumber2")'
+            }),
+          })
+        );
+      });
+
+      test('should handle empty part number query and empty query from query builder', async () => {
+        const query = buildQuery(
+          {
+            refId: 'A',
+            outputType: OutputType.Data,
+            partNumberQuery: [],
+            queryBy: '',
+          },
+        );
+
+        await datastore.query(query);
+
+        expect(backendServer.fetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: '/nitestmonitor/v2/query-results',
+            data: expect.objectContaining({
+              filter: undefined
+            }),
+          })
+        );
+      });
+
+      test('should handle part number query with template variables', async () => {
+        const partNumberQuery = ['PartNumber1', '${var}'];
+        const templateSrvCalledWith = 'PartNumber = "PartNumber1" || PartNumber = "${var}"';
+        const replacedPartNumberQuery = 'PartNumber = "PartNumber1" || PartNumber = "ReplacedValue"';
+        templateSrv.replace.calledWith(templateSrvCalledWith).mockReturnValue(replacedPartNumberQuery);
+
+        const query = buildQuery(
+          {
+            refId: 'A',
+            outputType: OutputType.Data,
+            partNumberQuery,
+            queryBy: '',
+          },
+        );
+
+        await datastore.query(query);
+
+        expect(templateSrv.replace).toHaveBeenCalledWith("PartNumber = \"PartNumber1\" || PartNumber = \"${var}\"", expect.anything());
+        expect(backendServer.fetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: '/nitestmonitor/v2/query-results',
+            data: expect.objectContaining({
+              filter: '(PartNumber = "PartNumber1" || PartNumber = "ReplacedValue")'
+            }),
+          })
+        );
+      });
+
+      test('should handle multiple part numbers and query variables', async () => {
+        const resultsQuery = `${ResultsQueryBuilderFieldNames.PROGRAM_NAME} = "{name1,name2}"`;
+        const partNumberQuery = ['PartNumber1', '${var}'];
+
+        const templateSrvCalledWith = 'PartNumber = "PartNumber1" || PartNumber = "${var}"';
+        const replacedPartNumberQuery = 'PartNumber = "PartNumber1" || PartNumber = "{partNumber2,partNumber3}"';
+        templateSrv.replace.calledWith(templateSrvCalledWith).mockReturnValue(replacedPartNumberQuery);
+
+        const query = buildQuery(
+          {
+            refId: 'A',
+            outputType: OutputType.Data,
+            partNumberQuery,
+            queryBy: resultsQuery
+          },
+        );
+
+        await datastore.query(query);
+
+        expect(templateSrv.replace).toHaveBeenNthCalledWith(1, resultsQuery, expect.anything());
+        expect(templateSrv.replace).toHaveBeenNthCalledWith(2, "PartNumber = \"PartNumber1\" || PartNumber = \"${var}\"", expect.anything());
+        expect(backendServer.fetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: '/nitestmonitor/v2/query-results',
+            data: expect.objectContaining({
+              filter: '(PartNumber = \"PartNumber1\" || (PartNumber = \"partNumber2\" || PartNumber = \"partNumber3\")) && (ProgramName = \"name1\" || ProgramName = \"name2\")'
+            }),
+          })
+        );
+      });
+    })
+
     describe('Dependencies', () => {
     afterEach(() => {
       (ResultsDataSourceBase as any)._partNumbersCache = null;
       (ResultsDataSourceBase as any)._workspacesCache = null;
+      (ResultsDataSourceBase as any)._productCache = null;
     });
-    
+
+    test('should return the same promise instance when product promise already exists', async () => {
+      const mockProducts = {
+        products: [
+          {partNumber: 'PartNumber1', name: 'ProductName1'},
+          {partNumber: 'PartNumber2', name: 'ProductName2'}
+        ]
+      };
+      const mockPromise = Promise.resolve(mockProducts);
+      (ResultsDataSourceBase as any)._productCache = mockPromise;
+      backendServer.fetch.mockClear();
+
+      const productPromise = datastore.productCache;
+
+      expect(productPromise).toEqual(mockPromise);
+      expect(await productPromise).toEqual(mockProducts);
+      expect(backendServer.fetch).not.toHaveBeenCalledWith(expect.objectContaining({ url: '/nitestmonitor/v2/query-products' }));
+    });
+
+    test('should create and return a new promise when product promise does not exist', async () => {
+      const mockProducts = {
+        products: [
+          {partNumber: 'PartNumber1', name: 'ProductName1'},
+          {partNumber: 'PartNumber2', name: 'ProductName2'}
+        ]
+      };
+      backendServer.fetch
+      .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-products', method: 'POST' }))
+      .mockReturnValue(createFetchResponse(mockProducts));
+
+      const promise = datastore.loadProducts();
+
+      expect(promise).not.toBeNull();
+      expect(backendServer.fetch).toHaveBeenCalledWith(
+        expect.objectContaining({ url: '/nitestmonitor/v2/query-products' })
+      );
+    });
+
+    it('should handle errors in loadProducts', async () => {
+      const error = new Error('API failed');
+      jest.spyOn(QueryResultsDataSource.prototype, 'queryProducts').mockRejectedValue(error);
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await datastore.loadProducts();
+
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith('Error in loading products:', error);
+    });
+
     test('should return the same promise instance when partnumber promise already exists', async () => {
       const mockPromise = Promise.resolve(['partNumber1', 'partNumber2']);
       (ResultsDataSourceBase as any)._partNumbersCache = mockPromise;

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -42,6 +42,15 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
       );
     }
 
+    if(query.partNumberQuery) {
+      const partNumberFilter = this.buildQueryWithOrOperator(ResultsQueryBuilderFieldNames.PART_NUMBER, query.partNumberQuery);
+      const transformedPartNumberFilter = transformComputedFieldsQuery(
+        this.templateSrv.replace(partNumberFilter, options.scopedVars),
+        this.resultsComputedDataFields,
+      );
+      query.queryBy = this.buildQueryFilter(`(${transformedPartNumberFilter})`, query.queryBy);
+    }
+
     const useTimeRangeFilter = this.getTimeRangeFilter(options, query.useTimeRange, query.useTimeRangeFor);
 
     const responseData = await this.queryResults(

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -1,6 +1,6 @@
 import { QueryResults, QueryResultsResponse, ResultsProperties, ResultsPropertiesOptions, ResultsResponseProperties, ResultsVariableQuery } from "datasources/results/types/QueryResults.types";
 import { ResultsDataSourceBase } from "datasources/results/ResultsDataSourceBase";
-import { DataQueryRequest, DataFrameDTO, FieldType, LegacyMetricFindQueryOptions, MetricFindValue } from "@grafana/data";
+import { DataQueryRequest, DataFrameDTO, FieldType, LegacyMetricFindQueryOptions, MetricFindValue, ScopedVars } from "@grafana/data";
 import { OutputType } from "datasources/results/types/types";
 import { defaultResultsQuery } from "datasources/results/defaultQueries";
 import { ExpressionTransformFunction, transformComputedFieldsQuery } from "core/query-builder.utils";
@@ -35,7 +35,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
   }
 
   async runQuery(query: QueryResults, options: DataQueryRequest): Promise<DataFrameDTO> {
-    query.queryBy = this.buildResultsQuery(options, query.partNumberQuery, query.queryBy);
+    query.queryBy = this.buildResultsQuery(options.scopedVars, query.partNumberQuery, query.queryBy);
     const useTimeRangeFilter = this.getTimeRangeFilter(options, query.useTimeRange, query.useTimeRangeFor);
 
     const responseData = await this.queryResults(
@@ -84,7 +84,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
     }
   }
 
-  private buildResultsQuery( options: DataQueryRequest, partNumberQuery?: string[], resultsQuery?: string): string | undefined {
+  private buildResultsQuery( scopedVars: ScopedVars, partNumberQuery?: string[], resultsQuery?: string): string | undefined {
     const partNumberFilter =
       partNumberQuery && partNumberQuery.length > 0
         ? `(${this.buildQueryWithOrOperator(ResultsQueryBuilderFieldNames.PART_NUMBER, partNumberQuery)})`
@@ -97,7 +97,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
     }
 
     return transformComputedFieldsQuery(
-      this.templateSrv.replace(combinedQuery, options.scopedVars), 
+      this.templateSrv.replace(combinedQuery, scopedVars), 
       this.resultsComputedDataFields
     );
   }

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -42,7 +42,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
       );
     }
 
-    if(query.partNumberQuery) {
+    if(query.partNumberQuery && query.partNumberQuery.length > 0) {
       const partNumberFilter = this.buildQueryWithOrOperator(ResultsQueryBuilderFieldNames.PART_NUMBER, query.partNumberQuery);
       const transformedPartNumberFilter = transformComputedFieldsQuery(
         this.templateSrv.replace(partNumberFilter, options.scopedVars),

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -9,6 +9,7 @@ export interface QueryResults extends ResultsQuery {
   useTimeRangeFor?: string;
   recordCount?: number;
   queryBy?: string;
+  partNumberQuery?: string[];
 }
 
 export interface ResultsVariableQuery extends ResultsQuery {

--- a/src/datasources/results/types/types.ts
+++ b/src/datasources/results/types/types.ts
@@ -46,3 +46,19 @@ export enum TestMeasurementStatus {
   Running = 'Running',
   Waiting = 'Waiting',
 }
+
+export interface QueryProductResponse {
+  products: ProductResponseProperties[],
+  continuationToken?: string,
+  totalCount?: number
+}
+
+export interface ProductResponseProperties {
+  partNumber: string;
+  name?: string;
+}
+
+export enum ProductProperties {
+  partNumber = 'PART_NUMBER',
+  name = 'NAME',
+}

--- a/src/datasources/results/types/types.ts
+++ b/src/datasources/results/types/types.ts
@@ -55,7 +55,7 @@ export interface QueryProductResponse {
 
 export interface ProductResponseProperties {
   partNumber: string;
-  name?: string;
+  name: string;
 }
 
 export enum ProductProperties {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As a part of this [User Story 3141634](https://dev.azure.com/ni/DevCentral/_workitems/edit/3141634): FE | Add Product (Part Number) Multi-Select Field,

This PR introduces the product name as a separate field to generate the part number query. The motivation for this change is to ensure that the part number remains a required field in steps query type. For consistency, the same approach is implemented in the results query type by adding a dedicated product field.

For more context, see the[ PR comment ](https://github.com/ni/systemlink-grafana-plugins/pull/220#issuecomment-2912246558)where this was discussed.

## 👩‍💻 Implementation

- In `ResultsDataSourceBase`
    - Added `loadProducts` and `queryProducts` methods to fetch product names and their associated part numbers from the `query-product` API endpoint.
    - Implemented `buildQueryWithOrOperator` to construct OR-based query.
- In `QueryResultsEditor`
    - Added a MultiSelect field to load product options and capture user input.
    - Included tooltips for better usability.
    - Added `formatOptionLabel` to wrap the label if it exceeds the maximum width; otherwise, the label width will adjust to match the width of the longest label.
- Introduced `buildResultsQuery` in `QueryResultsDataSource` to combine the part number and query from the results query builder and apply necessary transformations. This method is extracted to resuse in `metricFindQuery`.
- Updated and added new types to support the above changes.

![image](https://github.com/user-attachments/assets/50f47a83-0b68-4988-bc3f-b68b850b3bfd)

## 🧪 Testing

- Added unit test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).