### PR TITLE
feat(workorders): Add workorders variable query editor

### DIFF
--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
@@ -11,6 +11,7 @@ import {
   VerticalGroup
 } from '@grafana/ui';
 import './WorkOrdersQueryEditor.scss';
+import { tooltips } from '../constants/QueryEditor.constants';
 
 type Props = QueryEditorProps<WorkOrdersDataSource, WorkOrdersQuery>;
 
@@ -122,11 +123,3 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
     </>
   );
 }
-
-const tooltips = {
-  queryBy: 'This optional field specifies the query filters.',
-  outputType: 'This field specifies the output type to fetch work order properties or total count',
-  properties: 'This field specifies the properties to use in the query.',
-  orderBy: 'This field specifies the query order of the work orders.',
-  descending: 'This toggle returns the work orders query in descending order.',
-};

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
@@ -1,0 +1,65 @@
+import { QueryEditorProps, SelectableValue } from "@grafana/data";
+import { VerticalGroup, InlineField, Select, InlineSwitch } from "@grafana/ui";
+import React, { useCallback } from "react";
+import { OrderBy, WorkOrdersVariableQuery } from "../types";
+import { WorkOrdersDataSource } from "../WorkOrdersDataSource";
+import { WorkOrdersQueryBuilder } from "./query-builder/WorkOrdersQueryBuilder";
+import { tooltips } from "../constants/QueryEditor.constants";
+
+type Props = QueryEditorProps<WorkOrdersDataSource, WorkOrdersVariableQuery>;
+
+export function WorkOrdersVariableQueryEditor({ query, onChange, datasource }: Props) {
+  query = datasource.prepareQuery(query);
+
+  const handleQueryChange = useCallback(
+    (query: WorkOrdersVariableQuery): void => {
+      onChange(query);
+    }, [onChange]
+  );
+
+  const onOrderByChange = (item: SelectableValue<string>) => {
+    handleQueryChange({ ...query, orderBy: item.value });
+  };
+
+  const onDescendingChange = (isDescendingChecked: boolean) => {
+    handleQueryChange({ ...query, descending: isDescendingChecked });
+  };
+
+  const onQueryByChange = (queryBy: string) => {
+    if (query.queryBy !== queryBy) {
+      query.queryBy = queryBy;
+      handleQueryChange({ ...query, queryBy });
+    }
+  };
+
+
+  return (
+    <VerticalGroup>
+      <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
+        <WorkOrdersQueryBuilder
+          filter={query.queryBy}
+          globalVariableOptions={[]}
+          onChange={(event: any) => onQueryByChange(event.detail.linq)}
+        ></WorkOrdersQueryBuilder>
+      </InlineField>
+      <div>
+        <InlineField label="OrderBy" labelWidth={25} tooltip={tooltips.orderBy}>
+          <Select
+            options={[...OrderBy] as SelectableValue[]}
+            placeholder="Select a field to set the query order"
+            onChange={onOrderByChange}
+            value={query.orderBy}
+            defaultValue={query.orderBy}
+            width={26}
+          />
+        </InlineField>
+        <InlineField label="Descending" labelWidth={25} tooltip={tooltips.descending}>
+          <InlineSwitch
+            onChange={event => onDescendingChange(event.currentTarget.checked)}
+            value={query.descending}
+          />
+        </InlineField>
+      </div>
+    </VerticalGroup >
+  );
+}

--- a/src/datasources/work-orders/constants/QueryEditor.constants.ts
+++ b/src/datasources/work-orders/constants/QueryEditor.constants.ts
@@ -1,0 +1,7 @@
+export const tooltips = {
+    queryBy: 'This optional field specifies the query filters.',
+    outputType: 'This field specifies the output type to fetch work order properties or total count',
+    properties: 'This field specifies the properties to use in the query.',
+    orderBy: 'This field specifies the query order of the work orders.',
+    descending: 'This toggle returns the work orders query in descending order.',
+};

--- a/src/datasources/work-orders/module.ts
+++ b/src/datasources/work-orders/module.ts
@@ -2,7 +2,9 @@ import { DataSourcePlugin } from '@grafana/data';
 import { WorkOrdersDataSource } from './WorkOrdersDataSource';
 import { WorkOrdersQueryEditor } from './components/WorkOrdersQueryEditor';
 import { HttpConfigEditor } from 'core/components/HttpConfigEditor';
+import { WorkOrdersVariableQueryEditor } from './components/WorkOrdersVariableQueryEditor';
 
 export const plugin = new DataSourcePlugin(WorkOrdersDataSource)
   .setConfigEditor(HttpConfigEditor)
-  .setQueryEditor(WorkOrdersQueryEditor);
+  .setQueryEditor(WorkOrdersQueryEditor)
+  .setVariableQueryEditor(WorkOrdersVariableQueryEditor);

--- a/src/datasources/work-orders/types.ts
+++ b/src/datasources/work-orders/types.ts
@@ -2,11 +2,17 @@ import { DataQuery } from '@grafana/schema';
 
 export interface WorkOrdersQuery extends DataQuery {
   queryBy?: string;
-  outputType: OutputType;
+  outputType?: OutputType;
   properties?: WorkOrderPropertiesOptions[];
   orderBy?: string;
   descending?: boolean;
   take?: number;
+}
+
+export interface WorkOrdersVariableQuery extends DataQuery {
+  orderBy?: string;
+  descending?: boolean;
+  queryBy?: string;
 }
 
 export enum OutputType {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

![image](https://github.com/user-attachments/assets/9f7be399-648d-4a4c-97eb-ab6d459628e5)


## 👩‍💻 Implementation

- Copied and pasted control from `WorkOrdersQueryEditor` except output & properities
- Added `metricFindQuery` in datasource
- Queried workorders name and id

## 🧪 Testing

- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).