### PR TITLE
feat(system-utils): create system reusable to remove duplicate methods of loading system alias in data sources

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -6,6 +6,7 @@ import { queryInBatches } from 'core/utils';
 import { QueryResponse } from 'core/types';
 import { isTimeField } from './utils';
 import { QUERY_TEST_PLANS_MAX_TAKE, QUERY_TEST_PLANS_REQUEST_PER_SECOND } from './constants/QueryTestPlans.constants';
+import { SystemUtils } from 'shared/system.utils';
 
 export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   constructor(
@@ -14,10 +15,12 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
     readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings, backendSrv, templateSrv);
+    this.systemUtils = new SystemUtils(instanceSettings, backendSrv);
   }
 
   baseUrl = `${this.instanceSettings.url}/niworkorder/v1`;
   queryTestPlansUrl = `${this.baseUrl}/query-testplans`;
+  systemUtils: SystemUtils;
 
   defaultQuery = {
     outputType: OutputType.Properties,
@@ -38,6 +41,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   };
 
   async runQuery(query: TestPlansQuery, { range }: DataQueryRequest): Promise<DataFrameDTO> {
+    const systemAliases = await this.systemUtils.systemAliasCache;
 
     if (query.outputType === OutputType.Properties) {
       const projectionAndFields = query.properties?.map(property => PropertiesProjectionMap[property]);
@@ -54,14 +58,24 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
 
       if (testPlans.length > 0) {
         const fields = projectionAndFields?.map((data) => {
+          const label = data.label;
           const field = data.field[0];
           const fieldType = isTimeField(field)
             ? FieldType.time
             : FieldType.string;
-          const fieldValues = testPlans
+          const values = testPlans
             .map(data => data[field as unknown as keyof TestPlanResponseProperties] as string);
 
           // TODO: AB#3133188 Add support for other field mapping
+          const fieldValues = values.map(value => {
+            switch (label) {
+              case PropertiesProjectionMap.SYSTEM_NAME.label:
+                const system = systemAliases.get(value);
+                return system ? system.alias : value;
+              default:
+                return value == null ? '' : value;
+            }
+          });
 
           return {
             name: data.label,

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -1,15 +1,27 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { TestPlansDataSource } from '../TestPlansDataSource';
 import { OrderBy, OutputType, Properties, PropertiesProjectionMap, TestPlansQuery } from '../types';
 import { AutoSizeInput, HorizontalGroup, InlineField, InlineSwitch, MultiSelect, RadioButtonGroup, Select, VerticalGroup } from '@grafana/ui';
 import { validateNumericInput } from 'core/utils';
 import { TestPlansQueryBuilder } from './query-builder/TestPlansQueryBuilder';
+import { systemAlias } from 'shared/types/QuerySystems.types';
 
 type Props = QueryEditorProps<TestPlansDataSource, TestPlansQuery>;
 
 export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   query = datasource.prepareQuery(query);
+
+  const [systemAliases, setSystemAliases] = useState<systemAlias[] | null>(null);
+
+  useEffect(() => {
+    const loadSystemAliases = async () => {
+      const systemAliases = await datasource.systemUtils.systemAliasCache;
+      setSystemAliases(Array.from(systemAliases.values()));
+    };
+
+    loadSystemAliases();
+  }, [datasource]);
 
   const handleQueryChange = useCallback(
     (query: TestPlansQuery, runQuery = true): void => {
@@ -87,6 +99,7 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
           <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
             <TestPlansQueryBuilder
               filter={query.queryBy}
+              systemAliases={systemAliases}
               globalVariableOptions={[]}
               onChange={(event: any) => onQueryByChange(event.detail.linq)}
             ></TestPlansQueryBuilder>

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
@@ -1,15 +1,28 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { OrderBy, TestPlansVariableQuery } from '../types';
 import { AutoSizeInput, InlineField, InlineSwitch, Select, VerticalGroup } from '@grafana/ui';
 import { validateNumericInput } from 'core/utils';
 import { TestPlansDataSource } from '../TestPlansDataSource';
 import { TestPlansQueryBuilder } from './query-builder/TestPlansQueryBuilder';
+import { systemAlias } from 'shared/types/QuerySystems.types';
 
 type Props = QueryEditorProps<TestPlansDataSource, TestPlansVariableQuery>;
 
 export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Props) {
   query = datasource.prepareQuery(query);
+
+
+  const [systemAliases, setSystemAliases] = useState<systemAlias[] | null>(null);
+
+  useEffect(() => {
+    const loadSystemAliases = async () => {
+      const systemAliases = await datasource.systemUtils.systemAliasCache;
+      setSystemAliases(Array.from(systemAliases.values()));
+    };
+
+    loadSystemAliases();
+  }, [datasource]);
 
   const handleQueryChange = useCallback(
     (query: TestPlansVariableQuery): void => {
@@ -49,6 +62,7 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
       <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
         <TestPlansQueryBuilder
           filter={query.queryBy}
+          systemAliases={systemAliases}
           globalVariableOptions={[]}
           onChange={(event: any) => onQueryByChange(event.detail.linq)}
         ></TestPlansQueryBuilder>

--- a/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.test.tsx
+++ b/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.test.tsx
@@ -2,13 +2,18 @@ import { QueryBuilderOption } from 'core/types';
 import React, { ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { TestPlansQueryBuilder } from './TestPlansQueryBuilder';
+import { systemAlias } from 'shared/types/QuerySystems.types';
 
 describe('TestPlansQueryBuilder', () => {
     let reactNode: ReactNode;
     const containerClass = 'smart-filter-group-condition-container';
+    const systemAlias: systemAlias = {
+        id: '1',
+        alias: 'System 1'
+    };
 
-    function renderElement(filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
-        reactNode = React.createElement(TestPlansQueryBuilder, { filter, globalVariableOptions, onChange: jest.fn() });
+    function renderElement(filter: string, systemAliases: systemAlias[] | null, globalVariableOptions: QueryBuilderOption[] = []) {
+        reactNode = React.createElement(TestPlansQueryBuilder, { filter, systemAliases, globalVariableOptions, onChange: jest.fn() });
         const renderResult = render(reactNode);
         return {
             renderResult,
@@ -17,9 +22,17 @@ describe('TestPlansQueryBuilder', () => {
     }
 
     it('should render empty query builder', () => {
-        const { renderResult, conditionsContainer } = renderElement('');
+        const { renderResult, conditionsContainer } = renderElement('', []);
 
         expect(conditionsContainer.length).toBe(1);
         expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
     });
+
+    it('should select system alis in query builder', () => {
+        const { conditionsContainer } = renderElement('systemAliasName = "1"', [systemAlias]);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(systemAlias.alias);
+    });
+
 });

--- a/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
+++ b/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
@@ -170,7 +170,10 @@ export const TestPlansQueryBuilderFields: Record<string, QBField> = {
             QueryBuilderOperations.DOES_NOT_EQUAL.name,
             QueryBuilderOperations.IS_BLANK.name,
             QueryBuilderOperations.IS_NOT_BLANK.name
-        ]
+        ],
+        lookup: {
+            dataSource: []
+        }
     },
     TEST_PLAN_ID: {
         label: 'Test plan ID',
@@ -243,7 +246,6 @@ export const TestPlansQueryBuilderStaticFields = [
     TestPlansQueryBuilderFields.PRODUCT,
     TestPlansQueryBuilderFields.PROPERTIES,
     TestPlansQueryBuilderFields.STATE,
-    TestPlansQueryBuilderFields.SYSTEM_ALIAS_NAME,
     TestPlansQueryBuilderFields.TEST_PLAN_ID,
     TestPlansQueryBuilderFields.TEST_PROGRAM,
     TestPlansQueryBuilderFields.UPDATED_AT,

--- a/src/shared/constants/QuerySystems.constants.ts
+++ b/src/shared/constants/QuerySystems.constants.ts
@@ -1,0 +1,3 @@
+export const QUERY_SYSTEMS_REQUEST_PER_SECOND = 15;
+export const QUERY_SYSTEMS_MAX_TAKE = 1000;
+export const QUERY_SYSTEMS_ALIAS_PROJECTION = 'new(id, alias)';

--- a/src/shared/system.utils.test.ts
+++ b/src/shared/system.utils.test.ts
@@ -1,0 +1,73 @@
+import { SystemUtils } from './system.utils';
+import { BackendSrv } from '@grafana/runtime';
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { systemAlias } from './types/QuerySystems.types';
+import { queryUsingSkip } from 'core/utils';
+
+const systemAliases: systemAlias[] = [
+    {
+        id: '1',
+        alias: 'System 1',
+    },
+    {
+        id: '2',
+        alias: 'System 2',
+    }
+];
+
+jest.mock('core/utils', () => ({
+    queryUsingSkip: jest.fn(() => {
+        return Promise.resolve({ data: systemAliases, totalCount: 2 });
+    })
+}));
+
+describe('SystemUtils', () => {
+    let instanceSettings: DataSourceInstanceSettings;
+    let backendSrv: BackendSrv;
+    let systemUtils: SystemUtils;
+
+    beforeEach(() => {
+        instanceSettings = { url: 'http://localhost' } as DataSourceInstanceSettings;
+        backendSrv = {
+            post: jest.fn()
+        } as unknown as BackendSrv;
+
+        systemUtils = new SystemUtils(instanceSettings, backendSrv);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should load system aliases and cache them', async () => {
+        const result = await systemUtils.systemAliasCache;
+
+        expect(result.size).toEqual(systemAliases.length);
+        expect(result.get('1')).toEqual(systemAliases[0]);
+        expect(result.get('2')).toEqual(systemAliases[1]);
+    });
+
+    it('should handle errors when loading system aliases', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const error = new Error('Failed to fetch systems');
+        (queryUsingSkip as jest.Mock).mockImplementationOnce(() => {
+            return Promise.reject(error);
+        });
+
+        const result = await systemUtils.systemAliasCache;
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('Error in loading systems:', error);
+        expect(result).toEqual(new Map<string, systemAlias>());
+    });
+
+    it('should return cached system aliases if already loaded', async () => {
+        await systemUtils.systemAliasCache;
+        const cachedResult = await systemUtils.systemAliasCache;
+
+        expect(queryUsingSkip).toHaveBeenCalledTimes(1);
+        expect(cachedResult.size).toEqual(systemAliases.length);
+        expect(cachedResult.get('1')).toEqual(systemAliases[0]);
+        expect(cachedResult.get('2')).toEqual(systemAliases[1]);
+    });
+});

--- a/src/shared/system.utils.ts
+++ b/src/shared/system.utils.ts
@@ -1,0 +1,76 @@
+import { DataSourceInstanceSettings } from "@grafana/data";
+import { BackendSrv } from "@grafana/runtime";
+import { QUERY_SYSTEMS_ALIAS_PROJECTION, QUERY_SYSTEMS_MAX_TAKE, QUERY_SYSTEMS_REQUEST_PER_SECOND } from "./constants/QuerySystems.constants";
+import { QueryResponse, QuerySystemsResponse } from "core/types";
+import { queryUsingSkip } from "core/utils";
+import { systemAlias } from "./types/QuerySystems.types";
+
+export class SystemUtils {
+    private _systemAliasCache: Promise<Map<string, systemAlias>> | null = null;
+
+    private readonly querySystemsUrl = `${this.instanceSettings.url}/nisysmgmt/v1/query-systems`;
+
+    constructor(
+        readonly instanceSettings: DataSourceInstanceSettings,
+        readonly backendSrv: BackendSrv
+    ) {}
+
+    get systemAliasCache(): Promise<Map<string, systemAlias>> {
+        return this.loadSystems()
+    }
+
+    private async loadSystems(): Promise<Map<string, systemAlias>> {
+        if (this._systemAliasCache) {
+            return this._systemAliasCache;
+        }
+
+        this._systemAliasCache = this.querySystemsInBatches()
+            .then(systems => {
+                const systemMap = new Map<string, systemAlias>();
+                if (systems) {
+                    systems.forEach(system => systemMap.set(system.id, system));
+                }
+                return systemMap;
+            })
+            .catch(error => {
+                console.error('Error in loading systems:', error);
+                return new Map<string, systemAlias>();
+            });
+
+        return this._systemAliasCache;
+    }
+
+    private async querySystemsInBatches(): Promise<systemAlias[]> {
+        const queryRecord = async (take: number, skip: number): Promise<QueryResponse<systemAlias>> => {
+            const response = await this.querySystems(take, skip);
+            return {
+                data: response.data as systemAlias[],
+                totalCount: response.count
+            };
+        };
+
+        const batchQueryConfig = {
+            maxTakePerRequest: QUERY_SYSTEMS_MAX_TAKE,
+            requestsPerSecond: QUERY_SYSTEMS_REQUEST_PER_SECOND
+        };
+        const response = await queryUsingSkip(queryRecord, batchQueryConfig);
+
+        return response.data;
+    }
+
+    private async querySystems(
+        take?: number,
+        skip?: number
+    ): Promise<QuerySystemsResponse> {
+        try {
+            const response = await this.backendSrv.post<QuerySystemsResponse>(this.querySystemsUrl, {
+                projection: QUERY_SYSTEMS_ALIAS_PROJECTION,
+                skip,
+                take
+            });
+            return response;
+        } catch (error) {
+            throw new Error(`An error occurred while querying systems: ${error}`);
+        }
+    }
+}

--- a/src/shared/types/QuerySystems.types.ts
+++ b/src/shared/types/QuerySystems.types.ts
@@ -1,0 +1,4 @@
+export interface systemAlias {
+    id: string;
+    alias: string;
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We need to query the system alias to map the id to its name in test plans data source.
So created a reusable class SystemUtils to provide property & method needed for data sources

## 👩‍💻 Implementation


## 🧪 Testing

Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).