### PR TITLE
fix(results): Enable steps query builder when product name field has value

### DIFF
--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -77,6 +77,26 @@ jest.mock('../query-builders/query-results/ResultsQueryBuilder', () => ({
   }),
 }));
 
+jest.mock('../query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper', () => ({
+  StepsQueryBuilderWrapper: jest.fn(({ resultsQuery, stepsQuery, onResultsQueryChange, onStepsQueryChange, disableStepsQueryBuilder }) => {
+    return (
+      <div data-testid="steps-query-builder-container">
+        <input 
+          data-testid="Query by results properties"
+          value={resultsQuery}
+          onChange={(e) => onResultsQueryChange(e.target.value)}
+        />
+        <input 
+          data-testid="Query by steps properties"
+          value={stepsQuery}
+          onChange={(e) => onStepsQueryChange(e.target.value)}
+          disabled={disableStepsQueryBuilder} 
+        />
+      </div>
+    );
+  }),
+}));
+
 const renderEditor = setupRenderer(ResultsVariableQueryEditor, FakeResultsDataSource, () => {});
 let propertiesSelect: HTMLElement;
 let queryBy: HTMLElement;
@@ -181,11 +201,58 @@ describe('Steps Query Type', () => {
       queryBySteps: '',
     } as unknown as ResultsQuery);
 
-    queryByResults = screen.getByText('Query by results properties');
-    queryBySteps = screen.getByText('Query by steps properties');
+    const stepsQueryBuilderWrapper = screen.getByTestId('steps-query-builder-container');
+    queryByResults = screen.getByTestId('Query by results properties');
+    queryBySteps = screen.getByTestId('Query by steps properties');
 
+    expect(stepsQueryBuilderWrapper).toBeInTheDocument();
     expect(queryByResults).toBeInTheDocument();
     expect(queryBySteps).toBeInTheDocument();
+  });
+
+  it('should disable the steps query builder when product name is empty', async () => {
+    await act(async () => {
+      renderEditor({
+        refId: '',
+        queryType: QueryType.Steps,
+        queryByResults: 'resultsQuery',
+        queryBySteps: '',
+        partNumberQueryInSteps: []
+      } as unknown as ResultsQuery);
+    });
+    const stepsQueryInput = screen.getByTestId('Query by steps properties');
+    expect(stepsQueryInput).toBeInTheDocument();
+    expect(stepsQueryInput).toBeDisabled();
+  });
+
+  it('should disable the steps query builder when product name is undefined', async () => {
+    await act(async () => {
+      renderEditor({
+        refId: '',
+        queryType: QueryType.Steps,
+        queryByResults: 'resultsQuery',
+        queryBySteps: '',
+        partNumberQueryInSteps: undefined
+      } as unknown as ResultsQuery);
+    });
+    const stepsQueryInput = screen.getByTestId('Query by steps properties');
+    expect(stepsQueryInput).toBeInTheDocument();
+    expect(stepsQueryInput).toBeDisabled();
+  });
+
+  it('should enable the steps query builder when product name has value', async () => {
+    await act(async () => {
+      renderEditor({
+        refId: '',
+        queryType: QueryType.Steps,
+        queryByResults: 'resultsQuery',
+        queryBySteps: '',
+        partNumberQueryInSteps: ['PN1']
+      } as unknown as ResultsQuery);
+    });
+    const stepsQueryInput = screen.getByTestId('Query by steps properties');
+    expect(stepsQueryInput).toBeInTheDocument();
+    expect(stepsQueryInput).not.toBeDisabled();
   });
 
   it('should select the product name from the product name dropdown', async () => {

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -65,6 +65,10 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
     loadWorkspaces();
   }, [datasource]);
 
+  useEffect(() => {
+    disableStepsQueryBuilder(!stepsVariableQuery.partNumberQueryInSteps || stepsVariableQuery.partNumberQueryInSteps.length === 0);
+  }, [stepsVariableQuery.partNumberQueryInSteps]);
+
   const onQueryTypeChange = (queryType: QueryType) => {
     if (queryType === QueryType.Results) {
       onChange({ ...queryResultsquery, queryType } as ResultsVariableQuery);
@@ -116,7 +120,6 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
   }
 
   const onProductNameChangesinSteps = (productNames: Array<SelectableValue<string>>) => {
-    disableStepsQueryBuilder(productNames.length === 0);
     onChange({ ...stepsVariableQuery, partNumberQueryInSteps: productNames.map(product => product.value as string) } as StepsVariableQuery );
   }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As a part of this task [Task 3141101](https://ni.visualstudio.com/DevCentral/_workitems/edit/3141101): Steps query builder should be enabled when resultsQuery has valid query on save,

this PR ensures that the steps query builder is enabled when a valid part number is present after saving.

## 👩‍💻 Implementation

- Updated `ResultsVariableQueryEditor` to have `useEffect` that sets the disabled state of the steps query builder based on the product name value, rather than only updating when the product name changes. This ensures that the query builder’s disabled state is correctly set on load as well as after changes.

## 🧪 Testing

- Added unit test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).