### PR TITLE
feat(workorders): Add users lookup and map users in workorders data

### DIFF
--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -143,7 +143,6 @@ describe('WorkOrdersDataSource', () => {
       const fields = response.fields as Field[];
       expect(fields).toMatchSnapshot();
     });
-
     
     it('should convert user Ids to user names for assigned to field', async () => {
       const query = {

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -2,7 +2,7 @@ import { BackendSrv } from '@grafana/runtime';
 import { MockProxy } from 'jest-mock-extended';
 import { setupDataSource, requestMatching, createFetchResponse, createFetchError } from 'test/fixtures';
 import { WorkOrdersDataSource } from './WorkOrdersDataSource';
-import { OrderByOptions, OutputType, State, Type, WorkOrderPropertiesOptions, WorkOrdersVariableQuery } from './types';
+import { OrderByOptions, OutputType, State, Type, WorkOrder, WorkOrderPropertiesOptions, WorkOrdersVariableQuery } from './types';
 import { DataQueryRequest, Field, LegacyMetricFindQueryOptions } from '@grafana/data';
 import { QUERY_WORK_ORDERS_MAX_TAKE, QUERY_WORK_ORDERS_REQUEST_PER_SECOND } from './constants/QueryWorkOrders.constants';
 import { queryInBatches } from 'core/utils';
@@ -34,6 +34,7 @@ const mockWorkOrders = {
   continuationToken: '',
   totalCount: 2,
 };
+
 jest.mock('core/utils', () => ({
   queryInBatches: jest.fn(() => {
     return Promise.resolve({
@@ -53,6 +54,37 @@ describe('WorkOrdersDataSource', () => {
       .mockReturnValue(createFetchResponse(mockWorkOrders));
 
     jest.spyOn(datastore, 'queryWorkordersData');
+
+    const mockUsers = [
+      {
+        id: '1',
+        firstName: 'User',
+        lastName: '1',
+        email: 'user1@123.com',
+        properties: {},
+        keywords: [],
+        created: '',
+        updated: '',
+        orgId: '',
+      },
+      {
+        id: '2',
+        firstName: 'User',
+        lastName: '2',
+        email: 'user2@123.com',
+        properties: {},
+        keywords: [],
+        created: '',
+        updated: '',
+        orgId: '',
+      }
+    ];
+    jest.spyOn(datastore.usersUtils, 'getUsers').mockResolvedValue(
+      new Map([
+        ['1', mockUsers[0]],
+        ['2', mockUsers[1]]
+      ])
+    );
   });
 
   describe('runQuery', () => {
@@ -110,6 +142,103 @@ describe('WorkOrdersDataSource', () => {
 
       const fields = response.fields as Field[];
       expect(fields).toMatchSnapshot();
+    });
+
+    
+    it('should convert user Ids to user names for assigned to field', async () => {
+      const query = {
+        refId: 'A',
+        outputType: OutputType.Properties,
+        properties: [WorkOrderPropertiesOptions.ASSIGNED_TO],
+        orderBy: OrderByOptions.UPDATED_AT,
+        recordCount: 10,
+        descending: true,
+      };
+
+      const workOrdersResponse = [
+        { id: '1', assignedTo: '0' },
+        { id: '2', assignedTo: '2' },
+      ];
+
+      jest.spyOn(datastore, 'queryWorkordersData').mockResolvedValue(workOrdersResponse as WorkOrder[]);
+
+      const result = await datastore.runQuery(query, {} as DataQueryRequest);
+
+      expect(result.fields).toHaveLength(1);
+      expect(result.fields[0].name).toEqual('Assigned to');
+      expect(result.fields[0].values).toEqual(['0', 'User 2']);
+    });
+
+    it('should convert user Ids to user names for created by field', async () => {
+      const query = {
+        refId: 'A',
+        outputType: OutputType.Properties,
+        properties: [WorkOrderPropertiesOptions.CREATED_BY],
+        orderBy: OrderByOptions.UPDATED_AT,
+        recordCount: 10,
+        descending: true,
+      };
+
+      const workOrdersResponse = [
+        { id: '1', createdBy: '2' },
+        { id: '2', createdBy: '3' },
+      ];
+
+      jest.spyOn(datastore, 'queryWorkordersData').mockResolvedValue(workOrdersResponse as WorkOrder[]);
+
+      const result = await datastore.runQuery(query, {} as DataQueryRequest);
+
+      expect(result.fields).toHaveLength(1);
+      expect(result.fields[0].name).toEqual('Created by');
+      expect(result.fields[0].values).toEqual(['User 2', '3']);
+    });
+
+    it('should convert user Ids to user names for requested by field', async () => {
+      const query = {
+        refId: 'A',
+        outputType: OutputType.Properties,
+        properties: [WorkOrderPropertiesOptions.REQUESTED_BY],
+        orderBy: OrderByOptions.UPDATED_AT,
+        recordCount: 10,
+        descending: true,
+      };
+
+      const workOrdersResponse = [
+        { id: '1', requestedBy: '1' },
+        { id: '2', requestedBy: '4' },
+      ];
+
+      jest.spyOn(datastore, 'queryWorkordersData').mockResolvedValue(workOrdersResponse as WorkOrder[]);
+
+      const result = await datastore.runQuery(query, {} as DataQueryRequest);
+
+      expect(result.fields).toHaveLength(1);
+      expect(result.fields[0].name).toEqual('Requested by');
+      expect(result.fields[0].values).toEqual(['User 1', '4']);
+    });
+
+    it('should convert user Ids to user names for updated by field', async () => {
+      const query = {
+        refId: 'A',
+        outputType: OutputType.Properties,
+        properties: [WorkOrderPropertiesOptions.UPDATED_BY],
+        orderBy: OrderByOptions.UPDATED_AT,
+        recordCount: 10,
+        descending: true,
+      };
+
+      const workOrdersResponse = [
+        { id: '1', updatedBy: '4' },
+        { id: '2', updatedBy: '1' },
+      ];
+
+      jest.spyOn(datastore, 'queryWorkordersData').mockResolvedValue(workOrdersResponse as WorkOrder[]);
+
+      const result = await datastore.runQuery(query, {} as DataQueryRequest);
+
+      expect(result.fields).toHaveLength(1);
+      expect(result.fields[0].name).toEqual('Updated by');
+      expect(result.fields[0].values).toEqual(['4', 'User 1']);
     });
 
     test('should replace variables', async () => {

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -118,7 +118,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
             case WorkOrderPropertiesOptions.UPDATED_BY:
               const userId = workOrder[field.field] as string ?? '';
               const user = users.get(userId);
-              return user? UsersUtils.getUserFullName(user) : '';
+              return user? UsersUtils.getUserFullName(user) : userId;
             case WorkOrderPropertiesOptions.PROPERTIES:
               const properties = workOrder.properties || {};
               return JSON.stringify(properties);

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -118,7 +118,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
             case WorkOrderPropertiesOptions.UPDATED_BY:
               const userId = workOrder[field.field] as string ?? '';
               const user = users.get(userId);
-              return user? UsersUtils.getUserFullName(user) : userId;
+              return user ? UsersUtils.getUserFullName(user) : userId;
             case WorkOrderPropertiesOptions.PROPERTIES:
               const properties = workOrder.properties || {};
               return JSON.stringify(properties);

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
@@ -199,13 +199,13 @@ describe('WorkOrdersQueryEditor', () => {
   it('should load users and set them in state', async () => {
     renderElement();
 
-    const workspaces = await mockDatasource.usersUtils.getUsers();
-    expect(workspaces).toBeDefined();
-    expect(workspaces).toEqual(
-        new Map([
-            ['1', { id: '1', firstName: 'User', lastName: '1' }],
-            ['2', { id: '2', firstName: 'User', lastName: '2' }]
-        ])
+    const users = await mockDatasource.usersUtils.getUsers();
+    expect(users).toBeDefined();
+    expect(users).toEqual(
+      new Map([
+        ['1', { id: '1', firstName: 'User', lastName: '1' }],
+        ['2', { id: '2', firstName: 'User', lastName: '2' }],
+      ])
     );
   });
 

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
@@ -12,6 +12,14 @@ const mockOnRunQuery = jest.fn();
 const mockDatasource = {
   prepareQuery: jest.fn((query: WorkOrdersQuery) => query),
   globalVariableOptions: jest.fn(() => []),
+  usersUtils: {
+    getUsers: jest.fn().mockResolvedValue(
+      new Map([
+        ['1', { id: '1', firstName: 'User', lastName: '1' }],
+        ['2', { id: '2', firstName: 'User', lastName: '2' }],
+      ])
+    ),
+  },
 } as unknown as WorkOrdersDataSource;
 
 const defaultProps: QueryEditorProps<WorkOrdersDataSource, WorkOrdersQuery> = {
@@ -186,6 +194,19 @@ describe('WorkOrdersQueryEditor', () => {
     await waitFor(() => {
       expect(recordCountInput).toHaveValue(500);
     });
+  });
+
+  it('should load users and set them in state', async () => {
+    renderElement();
+
+    const workspaces = await mockDatasource.usersUtils.getUsers();
+    expect(workspaces).toBeDefined();
+    expect(workspaces).toEqual(
+        new Map([
+            ['1', { id: '1', firstName: 'User', lastName: '1' }],
+            ['2', { id: '2', firstName: 'User', lastName: '2' }]
+        ])
+    );
   });
 
   describe('onChange', () => {

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
@@ -14,12 +14,23 @@ import {
 import './WorkOrdersQueryEditor.scss';
 import { TAKE_LIMIT, takeErrorMessages, tooltips } from '../constants/QueryEditor.constants';
 import { validateNumericInput } from 'core/utils';
+import { User } from 'shared/types/QueryUsers.types';
 
 type Props = QueryEditorProps<WorkOrdersDataSource, WorkOrdersQuery>;
 
 export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   query = datasource.prepareQuery(query);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
+
+  const [users, setUsers] = useState<User[]|null>(null);
+  useEffect(() => {
+    const loadUsers = async () => {
+      const users = await datasource.usersUtils.getUsers();
+      setUsers(Array.from(users.values()));
+    };
+
+    loadUsers();
+  }, [datasource]);
 
   useEffect(() => {
     handleQueryChange(query, true);
@@ -112,6 +123,7 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
         <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
             <WorkOrdersQueryBuilder
               filter={query.queryBy} 
+              users={users}
               globalVariableOptions={datasource.globalVariableOptions()}
               onChange={(event: any) => onQueryByChange(event.detail.linq)}
             ></WorkOrdersQueryBuilder>

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
@@ -22,7 +22,7 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
   query = datasource.prepareQuery(query);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
 
-  const [users, setUsers] = useState<User[]|null>(null);
+  const [users, setUsers] = useState<User[] | null>(null);
   useEffect(() => {
     const loadUsers = async () => {
       const users = await datasource.usersUtils.getUsers();

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
@@ -12,6 +12,14 @@ const mockOnRunQuery = jest.fn();
 const mockDatasource = {
   prepareQuery: jest.fn((query: WorkOrdersVariableQuery) => query),
   globalVariableOptions: jest.fn(() => []),
+  usersUtils: {
+    getUsers: jest.fn().mockResolvedValue(
+      new Map([
+        ['1', { id: '1', firstName: 'User', lastName: '1' }],
+        ['2', { id: '2', firstName: 'User', lastName: '2' }],
+      ])
+    ),
+  },
 } as unknown as WorkOrdersDataSource;
 
 const defaultProps: QueryEditorProps<WorkOrdersDataSource, WorkOrdersVariableQuery> = {
@@ -82,6 +90,19 @@ describe('WorkOrdersVariableQueryEditor', () => {
     await waitFor(() => {
       expect(recordCountInput).toHaveValue(500);
     });
+  });
+
+  it('should load users and set them in state', async () => {
+    renderElement();
+
+    const workspaces = await mockDatasource.usersUtils.getUsers();
+    expect(workspaces).toBeDefined();
+    expect(workspaces).toEqual(
+        new Map([
+            ['1', { id: '1', firstName: 'User', lastName: '1' }],
+            ['2', { id: '2', firstName: 'User', lastName: '2' }]
+        ])
+    );
   });
 
   describe('onChange', () => {

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
@@ -95,13 +95,13 @@ describe('WorkOrdersVariableQueryEditor', () => {
   it('should load users and set them in state', async () => {
     renderElement();
 
-    const workspaces = await mockDatasource.usersUtils.getUsers();
-    expect(workspaces).toBeDefined();
-    expect(workspaces).toEqual(
-        new Map([
-            ['1', { id: '1', firstName: 'User', lastName: '1' }],
-            ['2', { id: '2', firstName: 'User', lastName: '2' }]
-        ])
+    const users = await mockDatasource.usersUtils.getUsers();
+    expect(users).toBeDefined();
+    expect(users).toEqual(
+      new Map([
+        ['1', { id: '1', firstName: 'User', lastName: '1' }],
+        ['2', { id: '2', firstName: 'User', lastName: '2' }],
+      ])
     );
   });
 

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
@@ -14,7 +14,7 @@ export function WorkOrdersVariableQueryEditor({ query, onChange, datasource }: P
   query = datasource.prepareQuery(query);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
 
-  const [users, setUsers] = useState<User[]|null>(null);
+  const [users, setUsers] = useState<User[] | null>(null);
   useEffect(() => {
     const loadUsers = async () => {
       const users = await datasource.usersUtils.getUsers();

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
@@ -16,7 +16,6 @@ export function WorkOrdersVariableQueryEditor({ query, onChange, datasource }: P
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
 
   const [workspaces, setWorkspaces] = useState<Workspace[] | null>(null);
-
   useEffect(() => {
     const loadWorkspaces = async () => {
       const workspaces = await datasource.workspaceUtils.getWorkspaces();

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
@@ -1,17 +1,28 @@
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { VerticalGroup, InlineField, Select, InlineSwitch, AutoSizeInput } from '@grafana/ui';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { OrderBy, WorkOrdersVariableQuery } from '../types';
 import { WorkOrdersDataSource } from '../WorkOrdersDataSource';
 import { WorkOrdersQueryBuilder } from './query-builder/WorkOrdersQueryBuilder';
 import { TAKE_LIMIT, takeErrorMessages, tooltips } from '../constants/QueryEditor.constants';
 import { validateNumericInput } from 'core/utils';
+import { User } from 'shared/types/QueryUsers.types';
 
 type Props = QueryEditorProps<WorkOrdersDataSource, WorkOrdersVariableQuery>;
 
 export function WorkOrdersVariableQueryEditor({ query, onChange, datasource }: Props) {
   query = datasource.prepareQuery(query);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
+
+  const [users, setUsers] = useState<User[]|null>(null);
+  useEffect(() => {
+    const loadUsers = async () => {
+      const users = await datasource.usersUtils.getUsers();
+      setUsers(Array.from(users.values()));
+    };
+
+    loadUsers();
+  }, [datasource]);
 
   const handleQueryChange = useCallback(
     (query: WorkOrdersVariableQuery): void => {
@@ -55,6 +66,7 @@ export function WorkOrdersVariableQueryEditor({ query, onChange, datasource }: P
       <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
         <WorkOrdersQueryBuilder
           filter={query.queryBy}
+          users={users}
           globalVariableOptions={datasource.globalVariableOptions()}
           onChange={(event: any) => onQueryByChange(event.detail.linq)}
         ></WorkOrdersQueryBuilder>

--- a/src/datasources/work-orders/components/query-builder/WorkOrdersQueryBuilder.test.tsx
+++ b/src/datasources/work-orders/components/query-builder/WorkOrdersQueryBuilder.test.tsx
@@ -2,13 +2,38 @@ import { QueryBuilderOption } from 'core/types';
 import React, { ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { WorkOrdersQueryBuilder } from './WorkOrdersQueryBuilder';
+import { User } from 'shared/types/QueryUsers.types';
 
 describe('WorkOrdersQueryBuilder', () => {
   let reactNode: ReactNode;
   const containerClass = 'smart-filter-group-condition-container';
+  const mockUsers = [
+    {
+      id: '1',
+      firstName: 'User',
+      lastName: '1',
+      email: 'user1@123.com',
+      properties: {},
+      keywords: [],
+      created: '',
+      updated: '',
+      orgId: '',
+    },
+    {
+      id: '2',
+      firstName: 'User',
+      lastName: '2',
+      email: 'user2@123.com',
+      properties: {},
+      keywords: [],
+      created: '',
+      updated: '',
+      orgId: '',
+    }
+  ];
 
-  function renderElement(filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
-    reactNode = React.createElement(WorkOrdersQueryBuilder, { filter, globalVariableOptions, onChange: jest.fn() });
+  function renderElement(filter: string, users: User[]=[], globalVariableOptions: QueryBuilderOption[] = []) {
+    reactNode = React.createElement(WorkOrdersQueryBuilder, { filter, users, globalVariableOptions, onChange: jest.fn() });
     const renderResult = render(reactNode);
     return {
       renderResult,
@@ -41,7 +66,7 @@ describe('WorkOrdersQueryBuilder', () => {
 
   it('should select global variable option', () => {
     const globalVariableOption = { label: 'Global variable', value: '$global_variable' };
-    const { conditionsContainer } = renderElement('state = \"$global_variable\"', [globalVariableOption]);
+    const { conditionsContainer } = renderElement('state = \"$global_variable\"', [], [globalVariableOption]);
 
     expect(conditionsContainer?.length).toBe(1);
     expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
@@ -64,5 +89,34 @@ describe('WorkOrdersQueryBuilder', () => {
       expect(conditionsContainer?.length).toBe(1);
       expect(conditionsContainer.item(0)?.textContent).toContain(label);
     });
+  });
+
+  
+  it('should select assigned to in query builder', () => {
+    const { conditionsContainer } = renderElement('assignedTo = "1"', mockUsers);
+
+    expect(conditionsContainer?.length).toBe(1);
+    expect(conditionsContainer.item(0)?.textContent).toContain("User 1");
+  });
+
+  it('should select created by in query builder', () => {
+    const { conditionsContainer } = renderElement('createdBy = "2"', mockUsers);
+
+    expect(conditionsContainer?.length).toBe(1);
+    expect(conditionsContainer.item(0)?.textContent).toContain("User 2");
+  });
+
+  it('should select requested by in query builder', () => {
+    const { conditionsContainer } = renderElement('requestedBy = "1"', mockUsers);
+
+    expect(conditionsContainer?.length).toBe(1);
+    expect(conditionsContainer.item(0)?.textContent).toContain("User 1");
+  });
+
+  it('should select updated by in query builder', () => {
+    const { conditionsContainer } = renderElement('updatedBy = "2"', mockUsers);
+
+    expect(conditionsContainer?.length).toBe(1);
+    expect(conditionsContainer.item(0)?.textContent).toContain("User 2");
   });
 });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To add lookup for user related fields and to convert userId in workorders response to username

## 👩‍💻 Implementation

- Use obj of user utils class to map user id to name
- Pass the list to users to query builder and use it for create lookup

## 🧪 Testing

- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).