### PR TITLE
feat(test-plans): Add users lookup and map users in test plans data source & query builder

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -11,6 +11,7 @@ import { WorkspaceUtils } from 'shared/workspace.utils';
 import { SystemUtils } from 'shared/system.utils';
 import { QueryBuilderOperations } from 'core/query-builder.constants';
 import { ExpressionTransformFunction, transformComputedFieldsQuery } from 'core/query-builder.utils';
+import { UsersUtils } from 'shared/users.utils';
 
 export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   constructor(
@@ -22,6 +23,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
     this.assetUtils = new AssetUtils(instanceSettings, backendSrv);
     this.workspaceUtils = new WorkspaceUtils(this.instanceSettings, this.backendSrv);
     this.systemUtils = new SystemUtils(instanceSettings, backendSrv);
+    this.usersUtils = new UsersUtils(instanceSettings, backendSrv);
   }
 
   baseUrl = `${this.instanceSettings.url}/niworkorder/v1`;
@@ -30,6 +32,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   assetUtils: AssetUtils;
   workspaceUtils: WorkspaceUtils;
   systemUtils: SystemUtils;
+  usersUtils: UsersUtils;
 
   defaultQuery = {
     outputType: OutputType.Properties,
@@ -54,6 +57,8 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   async runQuery(query: TestPlansQuery, options: DataQueryRequest): Promise<DataFrameDTO> {
     const workspaces = await this.workspaceUtils.getWorkspaces();
     const systemAliases = await this.systemUtils.getSystemAliases();
+    const users = await this.usersUtils.getUsers();
+
     if (query.queryBy) {
       query.queryBy = transformComputedFieldsQuery(
         this.templateSrv.replace(query.queryBy, options.scopedVars),
@@ -116,6 +121,11 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
               case PropertiesProjectionMap.SYSTEM_NAME.label:
                 const system = systemAliases.get(value);
                 return system ? system.alias : value;
+              case PropertiesProjectionMap.ASSIGNED_TO.label:
+              case PropertiesProjectionMap.CREATED_BY.label:
+              case PropertiesProjectionMap.UPDATED_BY.label:
+                const user = users.get(value);
+                return user ? UsersUtils.getUserFullName(user) : '';
               case PropertiesProjectionMap.PROPERTIES.label:
                 return value == null ? '' : JSON.stringify(value);
               default:
@@ -207,7 +217,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   }
 
   async metricFindQuery(query: TestPlansVariableQuery, options: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
-    const filter = query.queryBy? 
+    const filter = query.queryBy ?
       transformComputedFieldsQuery(
         this.templateSrv.replace(query.queryBy, options.scopedVars),
         this.testPlansComputedDataFields

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
@@ -27,6 +27,14 @@ const mockDatasource = {
                 ['2', { id: '2', alias: 'System 2' }],
             ])
         ),
+    },
+    usersUtils: {
+        getUsers: jest.fn().mockResolvedValue(
+            new Map([
+                ['1', { id: '1', firstName: 'User', lastName: '1' }],
+                ['2', { id: '2', firstName: 'User', lastName: '2' }],
+            ])
+        ),
     }
 } as unknown as TestPlansDataSource;
 
@@ -237,6 +245,19 @@ describe('TestPlansQueryEditor', () => {
             new Map([
                 ['1', { id: '1', alias: 'System 1' }],
                 ['2', { id: '2', alias: 'System 2' }],
+            ])
+        );
+    });
+
+    it('should load users', async () => {
+        renderElement();
+
+        const users = await mockDatasource.usersUtils.getUsers();
+        expect(users).toBeDefined();
+        expect(users).toEqual(
+            new Map([
+                ['1', { id: '1', firstName: 'User', lastName: '1' }],
+                ['2', { id: '2', firstName: 'User', lastName: '2' }]
             ])
         );
     });

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -8,6 +8,7 @@ import { TestPlansQueryBuilder } from './query-builder/TestPlansQueryBuilder';
 import { recordCountErrorMessages, TAKE_LIMIT } from '../constants/QueryEditor.constants';
 import { Workspace } from 'core/types';
 import { SystemAlias } from 'shared/types/QuerySystems.types';
+import { User } from 'shared/types/QueryUsers.types';
 
 type Props = QueryEditorProps<TestPlansDataSource, TestPlansQuery>;
 
@@ -16,6 +17,7 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
 
   const [workspaces, setWorkspaces] = useState<Workspace[] | null>(null);
+  const [users, setUsers] = useState<User[] | null>(null);
 
   useEffect(() => {
     const loadWorkspaces = async () => {
@@ -24,6 +26,13 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
     };
 
     loadWorkspaces();
+
+    const loadUsers = async () => {
+      const users = await datasource.usersUtils.getUsers();
+      setUsers(Array.from(users.values()));
+    };
+
+    loadUsers();
   }, [datasource]);
 
   const [systemAliases, setSystemAliases] = useState<SystemAlias[] | null>(null);
@@ -115,6 +124,7 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
               filter={query.queryBy}
               workspaces={workspaces}
               systemAliases={systemAliases}
+              users={users}
               globalVariableOptions={datasource.globalVariableOptions()}
               onChange={(event: any) => onQueryByChange(event.detail.linq)}
             ></TestPlansQueryBuilder>

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
@@ -27,6 +27,14 @@ const mockDatasource = {
         ['2', { id: '2', alias: 'System 2' }],
       ])
     ),
+  },
+  usersUtils: {
+    getUsers: jest.fn().mockResolvedValue(
+      new Map([
+        ['1', { id: '1', firstName: 'User', lastName: '1' }],
+        ['2', { id: '2', firstName: 'User', lastName: '2' }],
+      ])
+    ),
   }
 } as unknown as TestPlansDataSource;
 
@@ -113,6 +121,19 @@ describe('TestPlansVariableQueryEditor', () => {
       new Map([
         ['1', { id: '1', alias: 'System 1' }],
         ['2', { id: '2', alias: 'System 2' }],
+      ])
+    );
+  });
+
+  it('should load users', async () => {
+    renderElement();
+
+    const users = await mockDatasource.usersUtils.getUsers();
+    expect(users).toBeDefined();
+    expect(users).toEqual(
+      new Map([
+        ['1', { id: '1', firstName: 'User', lastName: '1' }],
+        ['2', { id: '2', firstName: 'User', lastName: '2' }]
       ])
     );
   });

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
@@ -8,6 +8,7 @@ import { TestPlansQueryBuilder } from './query-builder/TestPlansQueryBuilder';
 import { recordCountErrorMessages, TAKE_LIMIT } from '../constants/QueryEditor.constants';
 import { Workspace } from 'core/types';
 import { SystemAlias } from 'shared/types/QuerySystems.types';
+import { User } from 'shared/types/QueryUsers.types';
 
 type Props = QueryEditorProps<TestPlansDataSource, TestPlansVariableQuery>;
 
@@ -17,6 +18,7 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
 
   const [workspaces, setWorkspaces] = useState<Workspace[] | null>(null);
   const [systemAliases, setSystemAliases] = useState<SystemAlias[] | null>(null);
+  const [users, setUsers] = useState<User[] | null>(null);
 
   useEffect(() => {
     const loadWorkspaces = async () => {
@@ -32,6 +34,13 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
     };
 
     loadSystemAliases();
+
+    const loadUsers = async () => {
+      const users = await datasource.usersUtils.getUsers();
+      setUsers(Array.from(users.values()));
+    };
+
+    loadUsers();
   }, [datasource]);
 
   const handleQueryChange = useCallback(
@@ -74,6 +83,7 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
           filter={query.queryBy}
           workspaces={workspaces}
           systemAliases={systemAliases}
+          users={users}
           globalVariableOptions={datasource.globalVariableOptions()}
           onChange={(event: any) => onQueryByChange(event.detail.linq)}
         ></TestPlansQueryBuilder>

--- a/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.test.tsx
+++ b/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.test.tsx
@@ -3,6 +3,7 @@ import React, { ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { TestPlansQueryBuilder } from './TestPlansQueryBuilder';
 import { SystemAlias } from 'shared/types/QuerySystems.types';
+import { User } from 'shared/types/QueryUsers.types';
 
 describe('TestPlansQueryBuilder', () => {
     let reactNode: ReactNode;
@@ -12,9 +13,42 @@ describe('TestPlansQueryBuilder', () => {
         id: '1',
         alias: 'System 1'
     };
+    const mockUsers = [
+        {
+            id: '1',
+            firstName: 'User',
+            lastName: '1',
+            email: 'user1@123.com',
+            properties: {},
+            keywords: [],
+            created: '',
+            updated: '',
+            orgId: '',
+        },
+        {
+            id: '2',
+            firstName: 'User',
+            lastName: '2',
+            email: 'user2@123.com',
+            properties: {},
+            keywords: [],
+            created: '',
+            updated: '',
+            orgId: '',
+        }
+    ];
 
-    function renderElement(filter: string, workspaces: Workspace[] | null, systemAliases: SystemAlias[] | null, globalVariableOptions: QueryBuilderOption[] = []) {
-        reactNode = React.createElement(TestPlansQueryBuilder, { filter, workspaces, systemAliases, globalVariableOptions, onChange: jest.fn() });
+    function renderElement(
+        filter: string,
+        workspaces: Workspace[] | null,
+        systemAliases: SystemAlias[] | null,
+        users: User[] | null,
+        globalVariableOptions: QueryBuilderOption[] = []
+    ) {
+        reactNode = React.createElement(
+            TestPlansQueryBuilder,
+            { filter, workspaces, systemAliases, users, globalVariableOptions, onChange: jest.fn() }
+        );
         const renderResult = render(reactNode);
         return {
             renderResult,
@@ -23,55 +57,74 @@ describe('TestPlansQueryBuilder', () => {
     }
 
     it('should render empty query builder', () => {
-        const { renderResult, conditionsContainer } = renderElement('', [], []);
+        const { renderResult, conditionsContainer } = renderElement('', [], [], []);
 
         expect(conditionsContainer.length).toBe(1);
         expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
     });
 
     it('should select workspace in query builder', () => {
-        const { conditionsContainer } = renderElement('workspace = "1"', [workspace], []);
+        const { conditionsContainer } = renderElement('workspace = "1"', [workspace], [], []);
 
         expect(conditionsContainer?.length).toBe(1);
         expect(conditionsContainer.item(0)?.textContent).toContain(workspace.name);
     });
 
     it('should select system alias in query builder', () => {
-        const { conditionsContainer } = renderElement('systemAliasName = "1"', [], [systemAlias]);
+        const { conditionsContainer } = renderElement('systemAliasName = "1"', [], [systemAlias], []);
 
         expect(conditionsContainer?.length).toBe(1);
         expect(conditionsContainer.item(0)?.textContent).toContain(systemAlias.alias);
     });
 
+    it('should select assigned to in query builder', () => {
+        const { conditionsContainer } = renderElement('assignedTo = "1"', [], [], mockUsers);
 
-    
-  [['${__from:date}', 'From'], ['${__to:date}', 'To'], ['${__now:date}', 'Now']].forEach(([value, label]) => {
-    it(`should select user friendly value for updated date`, () => {
-      const { conditionsContainer } = renderElement(`updatedAt > \"${value}\"`, [], []);
-
-      expect(conditionsContainer?.length).toBe(1);
-      expect(conditionsContainer.item(0)?.textContent).toContain(label);
-    });
-
-    it(`should select user friendly value for created date`, () => {
-        const { conditionsContainer } = renderElement(`created > \"${value}\"`, [], []);
-  
         expect(conditionsContainer?.length).toBe(1);
-        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        expect(conditionsContainer.item(0)?.textContent).toContain("User 1");
     });
 
-    it(`should select user friendly value for estimated end date`, () => {
-        const { conditionsContainer } = renderElement(`estimatedEndDate > \"${value}\"`, [], []);
-  
+    it('should select created by in query builder', () => {
+        const { conditionsContainer } = renderElement('createdBy = "2"', [], [], mockUsers);
+
         expect(conditionsContainer?.length).toBe(1);
-        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        expect(conditionsContainer.item(0)?.textContent).toContain("User 2");
     });
 
-    it(`should select user friendly value for planned start date date`, () => {
-        const { conditionsContainer } = renderElement(`plannedStartDate > \"${value}\"`, [], []);
-  
+    it('should select updated by in query builder', () => {
+        const { conditionsContainer } = renderElement('updatedBy = "2"', [], [], mockUsers);
+
         expect(conditionsContainer?.length).toBe(1);
-        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        expect(conditionsContainer.item(0)?.textContent).toContain("User 2");
     });
-  });
+
+    [['${__from:date}', 'From'], ['${__to:date}', 'To'], ['${__now:date}', 'Now']].forEach(([value, label]) => {
+        it(`should select user friendly value for updated date`, () => {
+            const { conditionsContainer } = renderElement(`updatedAt > \"${value}\"`, [], [], []);
+
+            expect(conditionsContainer?.length).toBe(1);
+            expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        });
+
+        it(`should select user friendly value for created date`, () => {
+            const { conditionsContainer } = renderElement(`created > \"${value}\"`, [], [], []);
+
+            expect(conditionsContainer?.length).toBe(1);
+            expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        });
+
+        it(`should select user friendly value for estimated end date`, () => {
+            const { conditionsContainer } = renderElement(`estimatedEndDate > \"${value}\"`, [], [], []);
+
+            expect(conditionsContainer?.length).toBe(1);
+            expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        });
+
+        it(`should select user friendly value for planned start date date`, () => {
+            const { conditionsContainer } = renderElement(`plannedStartDate > \"${value}\"`, [], [], []);
+
+            expect(conditionsContainer?.length).toBe(1);
+            expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        });
+    });
 });

--- a/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
+++ b/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
@@ -235,8 +235,6 @@ export const TestPlansQueryBuilderFields: Record<string, QBField> = {
 }
 
 export const TestPlansQueryBuilderStaticFields = [
-    TestPlansQueryBuilderFields.ASSIGNED_TO,
-    TestPlansQueryBuilderFields.CREATED_BY,
     TestPlansQueryBuilderFields.DESCRIPTION,
     TestPlansQueryBuilderFields.DUT_IDENTIFIER,
     TestPlansQueryBuilderFields.ESTIMATED_DURATION_IN_DAYS,
@@ -248,6 +246,5 @@ export const TestPlansQueryBuilderStaticFields = [
     TestPlansQueryBuilderFields.STATE,
     TestPlansQueryBuilderFields.TEST_PLAN_ID,
     TestPlansQueryBuilderFields.TEST_PROGRAM,
-    TestPlansQueryBuilderFields.UPDATED_BY,
     TestPlansQueryBuilderFields.WORK_ORDER_ID
 ];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To show users names in the response & query builder for test plan data source

## 👩‍💻 Implementation
- Use `UsersUtils` class object to show the user names
- Pass the list to the query builder

## 🧪 Testing
- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).