### PR TITLE
feat(test-plans): Show Dut serial number in the properties

### DIFF
--- a/src/datasources/test-plans/asset.utils.test.ts
+++ b/src/datasources/test-plans/asset.utils.test.ts
@@ -25,8 +25,8 @@ describe('AssetUtils', () => {
         it('should query all assets in a single request when ids length is less than QUERY_ASSETS_BATCH_SIZE', async () => {
             const mockResponse: QueryAssetNameResponse = {
                 assets: [
-                    { id: '1', name: 'Asset 1' },
-                    { id: '2', name: 'Asset 2' }
+                    { id: '1', name: 'Asset 1', serialNumber: 'SN1' },
+                    { id: '2', name: 'Asset 2', serialNumber: 'SN2' }
                 ],
                 totalCount: 2
             };
@@ -37,8 +37,8 @@ describe('AssetUtils', () => {
             const result = await assetUtils.queryAssetsInBatches(ids);
 
             expect(result).toEqual([
-                { id: '1', name: 'Asset 1' },
-                { id: '2', name: 'Asset 2' },
+                { id: '1', name: 'Asset 1', serialNumber: 'SN1' },
+                { id: '2', name: 'Asset 2', serialNumber: 'SN2' }
             ]);
         });
 

--- a/src/datasources/test-plans/types.ts
+++ b/src/datasources/test-plans/types.ts
@@ -47,6 +47,7 @@ export enum Properties {
     SUBSTATE = 'SUBSTATE',
     FIXTURE_NAMES = 'FIXTURE_NAMES',
     DUT_ID = 'DUT_ID',
+    DUT_SERIAL_NUMBER = 'DUT_SERIAL_NUMBER',
 };
 
 export enum TimeFields {
@@ -212,6 +213,11 @@ export const PropertiesProjectionMap: Record<Properties, {
         projection: [Projections.DUT_ID],
         field: 'dutId',
     },
+    [Properties.DUT_SERIAL_NUMBER]: {
+        label: 'DUT serial number',
+        projection: [Projections.DUT_ID],
+        field: 'dutId',
+    }
 } as const;
 
 export const OrderBy = [
@@ -275,6 +281,7 @@ export interface QueryAssetNameResponse {
 export interface Asset {
     id: string;
     name: string;
+    serialNumber: string;
 }
 
 export interface QueryTemplatesResponse {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To show `DUT serial number` property in the properties dropdown

## 👩‍💻 Implementation
- Add the dut serial number property
- Update `Asset` model to have `serialNumber` proeprty
- Call `getDuts()` when this property is selected

## 🧪 Testing
- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).