### PR TITLE
feat(results): prevent duplicate API call 

### DIFF
--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
@@ -271,5 +271,17 @@ describe('QueryResultsEditor', () => {
         expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ queryBy: 'workspace = "Workspace1"' }));
       });
     });
+
+    test('should not update queryBy when filter is not changed', async () => {
+      const initialQueryBy = defaultQuery.queryBy;
+      const triggerChangeButton = screen.getByTestId('trigger-change');
+
+      mockHandleQueryChange.mockClear();
+      await userEvent.click(triggerChangeButton);
+      
+      await waitFor(() => {
+        expect(mockHandleQueryChange).not.toHaveBeenCalledWith(expect.objectContaining({ queryBy: initialQueryBy }));
+      });
+    });
   });
 });

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -96,6 +96,7 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
 
   const onParameterChange = (value: string) => {
     if (query.queryBy !== value) {
+      query.queryBy = value;
       handleQueryChange({ ...query, queryBy: value });
     }
   }

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
@@ -292,6 +292,7 @@ describe('QueryStepsEditor', () => {
 
     test('should not update results query when filter doesnt change', () => {
       const resultsQueryInput = screen.getByTestId('results-query');
+      fireEvent.change(resultsQueryInput, { target: { value: 'partNumber = "PN1"' } });// ensure initial value is set
       mockHandleQueryChange.mockClear();
 
       fireEvent.change(resultsQueryInput, { target: { value: 'partNumber = "PN1"' } });
@@ -313,6 +314,7 @@ describe('QueryStepsEditor', () => {
 
     test('should not update steps query when filter doesnt change', () => {
       const stepsQueryInput = screen.getByTestId('steps-query');
+      fireEvent.change(stepsQueryInput, { target: { value: 'stepName = "Step1"' } });// ensure initial value is set
       mockHandleQueryChange.mockClear();
 
       fireEvent.change(stepsQueryInput, { target: { value: 'stepName = "Step1"' } });

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
@@ -290,6 +290,17 @@ describe('QueryStepsEditor', () => {
       );
     });
 
+    test('should not update results query when filter doesnt change', () => {
+      const resultsQueryInput = screen.getByTestId('results-query');
+      mockHandleQueryChange.mockClear();
+
+      fireEvent.change(resultsQueryInput, { target: { value: 'partNumber = "PN1"' } });
+
+      expect(mockHandleQueryChange).not.toHaveBeenCalledWith(
+        expect.objectContaining({ resultsQuery: 'partNumber = "PN1"' })
+      );
+    });
+
     test('should update steps query when user triggers steps query change', () => {
       const stepsQueryInput = screen.getByTestId('steps-query');
 
@@ -299,6 +310,17 @@ describe('QueryStepsEditor', () => {
         expect.objectContaining({ stepsQuery: 'updated-steps-query' })
       );
     });
+
+    test('should not update steps query when filter doesnt change', () => {
+      const stepsQueryInput = screen.getByTestId('steps-query');
+      mockHandleQueryChange.mockClear();
+
+      fireEvent.change(stepsQueryInput, { target: { value: 'stepName = "Step1"' } });
+
+      expect(mockHandleQueryChange).not.toHaveBeenCalledWith(
+        expect.objectContaining({ stepsQuery: 'stepName = "Step1"' })
+      );
+    })
 
     test('should disable steps query builder when partnumber is empty', async () => {
       cleanup();

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -99,12 +99,14 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
 
   const onResultsFilterChange = (resultsQuery: string) => {
     if (query.resultsQuery !== resultsQuery) {
+      query.resultsQuery = resultsQuery;
       handleQueryChange({ ...query, resultsQuery: resultsQuery });
     }
   };
 
   const onStepsFilterChange = (stepsQuery: string) => {
     if (query.stepsQuery !== stepsQuery) {
+      query.stepsQuery = stepsQuery;
       handleQueryChange({ ...query, stepsQuery: stepsQuery });
     }
   };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
As part of fixing: [Task 3128159](https://dev.azure.com/ni/DevCentral/_workitems/edit/3128159): Duplicate API calls when filter includes workspace and time fields .

This pull request introduces enhancements to the query editors (`QueryResultsEditor` and `QueryStepsEditor`) by ensuring that query changes are only triggered when filters are actually modified.

## 👩‍💻 Implementation

* Modified `onParameterChange` to update `query.queryBy` only when the value changes, preventing unnecessary updates.
* Updated `onResultsFilterChange` and `onStepsFilterChange` to modify `query.resultsQuery` and `query.stepsQuery` only if the values differ, ensuring efficient updates.

## 🧪 Testing

* Added a test to confirm that `queryBy` is not updated when the filter remains unchanged.
* Added tests to verify that `resultsQuery` and `stepsQuery` are not updated when filters are unchanged

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).