### PR TITLE
fix(testplans): Update product filter field in test plans

### DIFF
--- a/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
+++ b/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
@@ -14,7 +14,7 @@ export enum TestPlansQueryBuilderFieldNames {
     FixtureIdentifier = 'fixtureIdentifier',
     Name = 'name',
     PlannedStartDate = 'plannedStartDate',
-    Product = 'product',
+    Product = 'partNumber',
     Properties = 'properties',
     State = 'state',
     SystemAliasName = 'systemAliasName',


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The filter field for product is `partNumber` and this field should be used for quering

## 👩‍💻 Implementation

- Updated the field from `products` to `partNumber`

## 🧪 Testing

- Manually verified

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).