### PR TITLE
feat(test-plans): Add state property lookup in the query builder

### DIFF
--- a/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.test.tsx
+++ b/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.test.tsx
@@ -98,6 +98,31 @@ describe('TestPlansQueryBuilder', () => {
         expect(conditionsContainer.item(0)?.textContent).toContain("User 2");
     });
 
+    it('should select state option', () => {
+        const { conditionsContainer } = renderElement('state = "PendingApproval"', [], [], []);
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain('State');
+        expect(conditionsContainer.item(0)?.textContent).toContain('Equals');
+        expect(conditionsContainer.item(0)?.textContent).toContain('Pending approval');
+    });
+    it('should select global variable option', () => {
+        const globalVariableOption = { label: 'Global variable', value: '$global_variable' };
+        const { conditionsContainer } = renderElement('state = \"$global_variable\"', [], [], [], [globalVariableOption]);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
+    });
+
+    it('should support key value operations', () => {
+        const { conditionsContainer } = renderElement("properties[\"key\"] = \"value\"", [], [], []);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain('Properties');
+        expect(conditionsContainer.item(0)?.textContent).toContain('matches');
+        expect(conditionsContainer.item(0)?.textContent).toContain('key');
+        expect(conditionsContainer.item(0)?.textContent).toContain('value');
+    });
+
     [['${__from:date}', 'From'], ['${__to:date}', 'To'], ['${__now:date}', 'Now']].forEach(([value, label]) => {
         it(`should select user friendly value for updated date`, () => {
             const { conditionsContainer } = renderElement(`updatedAt > \"${value}\"`, [], [], []);

--- a/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
+++ b/src/datasources/test-plans/constants/TestPlansQueryBuilder.constants.ts
@@ -160,7 +160,19 @@ export const TestPlansQueryBuilderFields: Record<string, QBField> = {
         filterOperations: [
             QueryBuilderOperations.EQUALS.name,
             QueryBuilderOperations.DOES_NOT_EQUAL.name
-        ]
+        ],
+        lookup: {
+            dataSource: [
+                { label: 'New', value: 'New' },
+                { label: 'Defined', value: 'Defined' },
+                { label: 'Reviewed', value: 'Reviewed' },
+                { label: 'Scheduled', value: 'Scheduled' },
+                { label: 'In progress', value: 'InProgress' },
+                { label: 'Pending approval', value: 'PendingApproval' },
+                { label: 'Closed', value: 'Closed' },
+                { label: 'Canceled', value: 'Canceled' }
+            ]
+        }
     },
     SYSTEM_ALIAS_NAME: {
         label: 'System alias name',


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To show list of states in the test plan querybuilder

## 👩‍💻 Implementation
- Added lookup with list of states that test plans API supports

## 🧪 Testing
- Added unit tests


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).