### PR TITLE
feat(results): rename resultsFilter to resultFilter

### DIFF
--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -1086,7 +1086,7 @@ describe('QueryStepsDataSource', () => {
       expect.objectContaining({
         url: '/nitestmonitor/v2/query-steps',
         data: expect.objectContaining({
-          resultsFilter: '(PartNumber = \"PartNumber1\" || (PartNumber = \"partNumber2\" || PartNumber = \"partNumber3\")) && (ProgramName = \"name1\" || ProgramName = \"name2\")'
+          resultFilter: '(PartNumber = \"PartNumber1\" || (PartNumber = \"partNumber2\" || PartNumber = \"partNumber3\")) && (ProgramName = \"name1\" || ProgramName = \"name2\")'
         }),
       })
     );
@@ -1106,7 +1106,7 @@ describe('QueryStepsDataSource', () => {
           expect.objectContaining({
             url: '/nitestmonitor/v2/query-steps',
             data: expect.objectContaining({
-              resultsFilter: "(PartNumber = \"partNumber1\") && ProgramName = \"name1\"",
+              resultFilter: "(PartNumber = \"partNumber1\") && ProgramName = \"name1\"",
               filter: "stepType = \"Type1\""
             }),
           })
@@ -1126,7 +1126,7 @@ describe('QueryStepsDataSource', () => {
           expect.objectContaining({
             url: '/nitestmonitor/v2/query-steps',
             data: expect.objectContaining({
-              resultsFilter: "(PartNumber = \"partNumber1\" || PartNumber = \"partNumber2\") && (ProgramName = \"name1\" || ProgramName = \"name2\")"
+              resultFilter: "(PartNumber = \"partNumber1\" || PartNumber = \"partNumber2\") && (ProgramName = \"name1\" || ProgramName = \"name2\")"
             }),
           })
         );
@@ -1148,7 +1148,7 @@ describe('QueryStepsDataSource', () => {
           expect.objectContaining({
             url: '/nitestmonitor/v2/query-steps',
             data: expect.objectContaining({
-              resultsFilter: "(PartNumber = \"partNumber1\") && UpdatedAt = \"2025-01-01T00:00:00.000Z\""
+              resultFilter: "(PartNumber = \"partNumber1\") && UpdatedAt = \"2025-01-01T00:00:00.000Z\""
             }),
           })
         );
@@ -1171,7 +1171,7 @@ describe('QueryStepsDataSource', () => {
           expect.objectContaining({
             url: '/nitestmonitor/v2/query-steps',
             data: expect.objectContaining({
-              resultsFilter:  "(PartNumber = \"partNumber1\") && (PartNumber = \"123\" || Keywords != \"456\") && HostName contains \"Test\"",
+              resultFilter:  "(PartNumber = \"partNumber1\") && (PartNumber = \"123\" || Keywords != \"456\") && HostName contains \"Test\"",
               filter: "(stepType = \"123\" || keywords != \"456\") && name contains \"Test\""
             }),
           })
@@ -1294,7 +1294,7 @@ describe('QueryStepsDataSource', () => {
           expect.objectContaining({
             url: '/nitestmonitor/v2/query-steps',
             data: expect.objectContaining({
-              resultsFilter: "(PartNumber = \"PartNumber1\") && ProgramName = \"name1\""
+              resultFilter: "(PartNumber = \"PartNumber1\") && ProgramName = \"name1\""
             }),
           })
         );
@@ -1332,7 +1332,7 @@ describe('QueryStepsDataSource', () => {
           expect.objectContaining({
             url: '/nitestmonitor/v2/query-steps',
             data: expect.objectContaining({
-              resultsFilter: '(PartNumber = "PartNumber1" || PartNumber = "partNumber2") && ProgramName = "name1"'
+              resultFilter: '(PartNumber = "PartNumber1" || PartNumber = "partNumber2") && ProgramName = "name1"'
             }),
           })
         );

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -43,7 +43,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
     projection?: StepsProperties[],
     take?: number,
     descending?: boolean,
-    resultsFilter?: string,
+    resultFilter?: string,
     continuationToken?: string,
     returnCount = false
   ): Promise<QueryStepsResponse> {
@@ -55,7 +55,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
         descending,
         projection,
         take,
-        resultsFilter,
+        resultFilter,
         continuationToken,
         returnCount,
       });
@@ -104,7 +104,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
     projection?: StepsProperties[],
     take?: number,
     descending?: boolean,
-    resultsFilter?: string,
+    resultFilter?: string,
     returnCount = false,
   ): Promise<QueryStepsResponse> {
     const queryRecord = async (currentTake: number, token?: string): Promise<QueryResponse<StepsResponseProperties>> => {
@@ -114,7 +114,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
         projection,
         currentTake,
         descending,
-        resultsFilter,
+        resultFilter,
         token,
         returnCount
       );


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Currently the results filter provided to the [query-steps](https://dev-api.lifecyclesolutions.ni.com/niapis/?urls.primaryName=Test+Monitor#/steps/query-steps-v2) is provided as `resultsFilter` instead of `resutlFilter` due to which the respective filter is not being applied

## 👩‍💻 Implementation

- updated the filter to `resultFilter` so that the filter will be applied as expected

## 🧪 Testing

- updated the existing unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).