### PR TITLE
fix(test-plans): transform duration filters in the request body

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -731,6 +731,27 @@ describe('runQuery', () => {
 
     jest.useRealTimers();
   });
+
+  test('should transform field when queryBy contains duration fields', async () => {
+    const mockQuery = {
+      refId: 'C',
+      outputType: OutputType.Properties,
+      queryBy: '(estimatedDurationInDays > "2" && estimatedDurationInHours != "2")',
+    };
+
+    jest.spyOn(datastore, 'queryTestPlansInBatches').mockResolvedValue({ testPlans: [] });
+
+    await datastore.runQuery(mockQuery, {} as DataQueryRequest);
+
+    expect(datastore.queryTestPlansInBatches).toHaveBeenCalledWith(
+      '(estimatedDurationInSeconds > \"172800\" && estimatedDurationInSeconds != \"7200\")',
+      undefined,
+      ["ID"],
+      undefined,
+      undefined,
+      true
+    );
+  });
 });
 
 describe('queryTestPlansInBatches', () => {
@@ -902,5 +923,24 @@ describe('metricFindQuery', () => {
     );
 
     jest.useRealTimers();
+  });
+
+  test('should transform field when queryBy contains duration fields', async () => {
+    const mockQuery = {
+      refId: 'C',
+      queryBy: '(estimatedDurationInDays > "2" && estimatedDurationInHours != "2")',
+    };
+
+    jest.spyOn(datastore, 'queryTestPlansInBatches').mockResolvedValue({ testPlans: [] });
+
+    await datastore.metricFindQuery(mockQuery, {});
+
+    expect(datastore.queryTestPlansInBatches).toHaveBeenCalledWith(
+      '(estimatedDurationInSeconds > \"172800\" && estimatedDurationInSeconds != \"7200\")',
+      undefined,
+      ["ID", "NAME"],
+      undefined,
+      undefined
+    );
   });
 });

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -10,7 +10,7 @@ import { AssetUtils } from './asset.utils';
 import { WorkspaceUtils } from 'shared/workspace.utils';
 import { SystemUtils } from 'shared/system.utils';
 import { QueryBuilderOperations } from 'core/query-builder.constants';
-import { ExpressionTransformFunction, transformComputedFieldsQuery } from 'core/query-builder.utils';
+import { computedFieldsupportedOperations, ExpressionTransformFunction, transformComputedFieldsQuery } from 'core/query-builder.utils';
 import { UsersUtils } from 'shared/users.utils';
 
 export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
@@ -64,6 +64,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
         this.templateSrv.replace(query.queryBy, options.scopedVars),
         this.testPlansComputedDataFields
       );
+      query.queryBy = this.transformDurationFilters(query.queryBy);
     }
 
     if (query.outputType === OutputType.Properties) {
@@ -176,6 +177,21 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
     return true;
   }
 
+  private transformDurationFilters(query: string): string {
+    const daysRegex = new RegExp(`estimatedDurationInDays\\s*(${computedFieldsupportedOperations.join('|')})\\s*"(\\d+)"`, 'g');
+    const hoursRegex = new RegExp(`estimatedDurationInHours\\s*(${computedFieldsupportedOperations.join('|')})\\s*"(\\d+)"`, 'g');
+
+    return query
+      .replace(
+        daysRegex,
+        (_, operator, value) => `estimatedDurationInSeconds ${operator} "${parseInt(value, 10) * 86400}"`
+      )
+      .replace(
+        hoursRegex,
+        (_, operator, value) => `estimatedDurationInSeconds ${operator} "${parseInt(value, 10) * 3600}"`
+      );
+  }
+
   private async getFixtureNames(labels: string[], testPlans: TestPlanResponseProperties[]): Promise<Asset[]> {
     if (labels.find(label => label === PropertiesProjectionMap.FIXTURE_NAMES.label)) {
       const fixtureIds = testPlans
@@ -223,12 +239,14 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   }
 
   async metricFindQuery(query: TestPlansVariableQuery, options: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
-    const filter = query.queryBy ?
-      transformComputedFieldsQuery(
+    let filter;
+    if (query.queryBy) {
+      filter = transformComputedFieldsQuery(
         this.templateSrv.replace(query.queryBy, options.scopedVars),
         this.testPlansComputedDataFields
-      )
-      : undefined;
+      );
+      filter = this.transformDurationFilters(filter);
+    }
 
     const metadata = (await this.queryTestPlansInBatches(
       filter,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
To query the test plans with estimated duration filters

## 👩‍💻 Implementation
- Transform `estimatedDurationInDays` and `estimatedDurationInHours` to `estimatedDurationInSeconds` in the request body

## 🧪 Testing
- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).