### PR TITLE
fix(testplans): Run query on mount

### DIFF
--- a/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
@@ -100,6 +100,14 @@ describe('TestPlansQueryEditor', () => {
             const queryBuilder = container.getByRole('dialog');
             expect(queryBuilder).toBeInTheDocument();
         });
+
+        expect(mockOnChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            outputType: OutputType.Properties,
+            refId: 'A',
+          })
+        );
+        expect(mockOnRunQuery).toHaveBeenCalledTimes(1);
     });
 
     describe('when output type is properties', () => {

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -61,6 +61,11 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
     }, [onChange, onRunQuery]
   );
 
+  useEffect(() => {
+    handleQueryChange(query, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Only run on mount
+
   const onOutputTypeChange = (value: OutputType) => {
     handleQueryChange({ ...query, outputType: value });
   };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To fix panel not refreshing with default values

## 👩‍💻 Implementation

- Added an `useEffect` which triggers the `HandleQueryChange` to run on mount .

## 🧪 Testing

- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).