### PR TITLE
fix(workorders): Remove user fields from WorkOrdersQueryBuilderStaticFields

### DIFF
--- a/src/datasources/work-orders/constants/WorkOrdersQueryBuilder.constants.ts
+++ b/src/datasources/work-orders/constants/WorkOrdersQueryBuilder.constants.ts
@@ -159,9 +159,5 @@ export const WorkOrdersQueryBuilderStaticFields = [
   WorkOrdersQueryBuilderFields.WORK_ORDER_ID,
   WorkOrdersQueryBuilderFields.STATE,
   WorkOrdersQueryBuilderFields.TYPE,
-  WorkOrdersQueryBuilderFields.ASSIGNED_TO,
-  WorkOrdersQueryBuilderFields.REQUESTED_BY,
-  WorkOrdersQueryBuilderFields.CREATED_BY,
-  WorkOrdersQueryBuilderFields.UPDATED_BY,
   WorkOrdersQueryBuilderFields.PROPERTIES,
 ];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To remove user fields from WorkOrdersQueryBuilderStaticFields so they are not duplicated

## 👩‍💻 Implementation

- Removed user fields from WorkOrdersQueryBuilderStaticFields

## 🧪 Testing

- Manually verified

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).