### PR TITLE
fix(results,products): multiple API calls when editing panels

### DIFF
--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -33,17 +33,6 @@ describe('ProductsQueryEditor', () => {
     expect(descending).toBeChecked();
     expect(recordCount).toBeInTheDocument();
     expect(recordCount).toHaveValue(1000);
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        refId: 'A',
-        properties: [],
-        orderBy: undefined,
-        descending: true,
-        recordCount: 1000,
-        queryBy: ''
-      }));
-    expect(onRunQuery).toHaveBeenCalledTimes(1);
   });
 
   it('renders the query builder', async () => {
@@ -53,8 +42,8 @@ describe('ProductsQueryEditor', () => {
   });
 
   it('should not call `onChange` when queryBy filter is not changed', async () => {
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onRunQuery).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(0);
+    expect(onRunQuery).toHaveBeenCalledTimes(0);
     onChange.mockClear();
     onRunQuery.mockClear();
 

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -21,9 +21,13 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
   const [familyNames, setFamilyNames] = useState<string[]>([]);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
   const [isPropertiesValid, setIsPropertiesValid] = useState<boolean>(true);
+  const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
 
   useEffect(() => {
-      handleQueryChange(query, true);
+    if(!isInitialLoad) {
+      handleQueryChange(query);
+      setIsInitialLoad(false);
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run on mount
   

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -21,15 +21,6 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
   const [familyNames, setFamilyNames] = useState<string[]>([]);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
   const [isPropertiesValid, setIsPropertiesValid] = useState<boolean>(true);
-  const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
-
-  useEffect(() => {
-    if(!isInitialLoad) {
-      handleQueryChange(query);
-      setIsInitialLoad(false);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run on mount
   
   useEffect(() => {
     const loadWorkspaces = async () => {

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
@@ -116,7 +116,6 @@ describe('QueryResultsEditor', () => {
     expect(screen.getAllByText('Updated').length).toBe(1);
     expect(productName).toBeInTheDocument();
     expect(screen.getAllByText('ProductName1 (PartNumber1)').length).toBe(1);
-    expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining(defaultQuery));
   });
 
   describe('Properties', () => {

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -32,15 +32,6 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
   const [productNameOptions, setProductNameOptions] = useState<Array<SelectableValue<string>>>([]);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
   const [isPropertiesValid, setIsPropertiesValid] = useState<boolean>(true);
-  const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
-
-  useEffect(() => {
-    if(!isInitialLoad) {
-      handleQueryChange(query);
-      setIsInitialLoad(false);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run on mount
 
   useEffect(() => {
     const loadWorkspaces = async () => {

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -32,9 +32,13 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
   const [productNameOptions, setProductNameOptions] = useState<Array<SelectableValue<string>>>([]);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
   const [isPropertiesValid, setIsPropertiesValid] = useState<boolean>(true);
+  const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
 
   useEffect(() => {
-    handleQueryChange(query);
+    if(!isInitialLoad) {
+      handleQueryChange(query);
+      setIsInitialLoad(false);
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run on mount
 

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
@@ -120,7 +120,6 @@ describe('QueryStepsEditor', () => {
       expect(showMeasurements).not.toBeChecked();
       expect(productName).toBeInTheDocument();
       expect(screen.getAllByText('ProductName1 (PartNumber1)').length).toBe(1);
-      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining(defaultQuery));
     });
 
     test('should display placeholders for properties and orderBy when default values are not provided', async () => {

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -31,9 +31,13 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
   const [isProductSelectionValid, setIsProductSelectionValid] = useState(true);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
   const [isPropertiesValid, setIsPropertiesValid] = useState<boolean>(true);
+  const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
 
   useEffect(() => {
-    handleQueryChange(query);
+    if(!isInitialLoad) {
+      handleQueryChange(query);
+      setIsInitialLoad(false);
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run on mount
 

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -31,15 +31,6 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
   const [isProductSelectionValid, setIsProductSelectionValid] = useState(true);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
   const [isPropertiesValid, setIsPropertiesValid] = useState<boolean>(true);
-  const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
-
-  useEffect(() => {
-    if(!isInitialLoad) {
-      handleQueryChange(query);
-      setIsInitialLoad(false);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run on mount
 
   useEffect(() => {
     setDisableStepsQueryBuilder(!query.partNumberQuery || query.partNumberQuery.length === 0);

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -53,11 +53,18 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
     query.queryBy = this.buildResultsQuery(options.scopedVars, query.partNumberQuery, query.queryBy);
     const useTimeRangeFilter = this.getTimeRangeFilter(options, query.useTimeRange, query.useTimeRangeFor);
 
+    let properties = query.properties;
+    let recordCount = query.recordCount;
+    if(query.outputType === OutputType.TotalCount) {
+      properties = [];
+      recordCount = 0;
+    }
+
     const responseData = await this.queryResults(
       this.buildQueryFilter(query.queryBy, useTimeRangeFilter),
       query.orderBy,
-      query.properties,
-      query.recordCount,
+      properties,
+      recordCount,
       query.descending,
       true
     );


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Currently, when we open a panel from dashboard, there are 12x the number of API calls required going in which makes it impossible for us to use this datasource plugins to build dashboards

## 👩‍💻 Implementation

The current implementation on running `handleQueryChange` on mount with `useEffect(()=> {}, [])`  is the reason of the 12x API calls due to unhandled promises, removed the implementation. This introduces back the problem of having stale data in the visualization panel when users switch between data sources

> Note: Updated the existing results data source not to use projection/take values when the output type is Total Count as it is not necessary, this should reduce the load on the service for such queries

## 🧪 Testing

- Updated the existing tests, verified manually

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).