### PR TITLE
fix(workorders): multiple API calls when editing panels

### DIFF
--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
@@ -87,13 +87,6 @@ describe('WorkOrdersQueryEditor', () => {
     const take = container.getByRole('spinbutton');
     expect(take).toBeInTheDocument();
     expect(take).toHaveDisplayValue('');
-
-    expect(mockOnChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        outputType: OutputType.Properties,
-        refId: 'A'
-      }));
-    expect(mockOnRunQuery).toHaveBeenCalledTimes(1);
   });
 
   describe('output type is total count', () => {

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
@@ -44,11 +44,6 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
     loadUsers();
   }, [datasource]);
 
-  useEffect(() => {
-    handleQueryChange(query, true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run on mount
-
   const handleQueryChange = useCallback(
     (query: WorkOrdersQuery, runQuery = true): void => {
       onChange(query);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Currently, when we open a panel from dashboard, there are 12x the number of API calls required going in which makes it impossible for us to use this datasource plugins to build dashboards


## 👩‍💻 Implementation

The current implementation on running `handleQueryChange` on mount with `useEffect(()=> {}, [])` is the reason of the 12x API calls due to unhandled promises, removed the implementation. This introduces back the problem of having stale data in the visualization panel when users switch between data sources

## 🧪 Testing

- Manually verified
- Updated unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).