### PR TITLE
feat(results): Add "has children" property in steps query builder

### DIFF
--- a/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.test.tsx
+++ b/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.test.tsx
@@ -90,6 +90,16 @@ describe('StepsQueryBuilder', () => {
       expect(filterContainer.item(0)?.textContent).toContain("keyword1"); //value
     });
 
+    it('should select "has children" property in query builder', () => {
+      const { renderResult } = renderElement('hasChildren = "True"', [], [], [], [], false);
+      const filterContainer = renderResult.container.getElementsByClassName('smart-filter-group-condition-container');
+
+      expect(filterContainer?.length).toBe(1);
+      expect(filterContainer.item(0)?.textContent).toContain('Has children'); //label
+      expect(filterContainer.item(0)?.textContent).toContain('Equals'); //operator
+      expect(filterContainer.item(0)?.textContent).toContain('True'); //value
+    })
+
     it('should select global variable option', () => {
       const globalVariableOption = { label: 'Global variable', value: 'global_variable' };
       const { renderResult } = renderElement('path = "global_variable"', [], [], [], [globalVariableOption], false);

--- a/src/datasources/results/constants/StepsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/StepsQueryBuilder.constants.ts
@@ -10,6 +10,7 @@ export enum StepsQueryBuilderFieldNames {
   TYPE = 'stepType',
   UPDATED_AT = 'updatedAt',
   WORKSPACE = 'workspace',
+  HASCHILDREN = 'hasChildren',
 }
 
 export const StepsQueryBuilderFields: Record<string, QBField> = {
@@ -102,6 +103,20 @@ export const StepsQueryBuilderFields: Record<string, QBField> = {
       dataSource: [],
     },
   },
+  HASCHILDREN: {
+    label: 'Has children',
+    dataField: StepsQueryBuilderFieldNames.HASCHILDREN,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+    ],
+    lookup: {
+      dataSource: [
+        { label: 'True', value: 'True' },
+        { label: 'False', value: 'False' },
+      ],
+    },
+  },
 };
 
 export const StepsQueryBuilderStaticFields = [
@@ -109,4 +124,5 @@ export const StepsQueryBuilderStaticFields = [
   StepsQueryBuilderFields.KEYWORDS,
   StepsQueryBuilderFields.PROPERTIES,
   StepsQueryBuilderFields.TYPE,
+  StepsQueryBuilderFields.HASCHILDREN,
 ];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Task link: [Task 3160722](https://dev.azure.com/ni/DevCentral/_workitems/edit/3160722): Add hasChildren Toggle as part of step filter
This PR introduces the "Has children" property to the steps query builder.

## 👩‍💻 Implementation

- Added the corresponding label, value, filter operations, and a true/false lookup for the "Has children" field in `StepsQueryBuilder.constants.ts`.
![image](https://github.com/user-attachments/assets/cdd41b67-edfe-480c-a91e-b90e290fec10)

## 🧪 Testing

- Added test case

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).