### PR TITLE
feat(results): revert partNumber field for results query

### DIFF
--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -26,7 +26,6 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
   private static _productCache: Promise<QueryProductResponse> | null = null;
   private static _partNumbersCache: Promise<string[]> | null = null;
 
-
   readonly globalVariableOptions = (): QueryBuilderOption[] => getVariableOptions(this);
 
 
@@ -92,10 +91,8 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
         }
         return [];
     });
-
     return ResultsDataSourceBase._partNumbersCache;
   }
-
 
   async queryResultsValues(fieldName: string, filter?: string): Promise<string[]> {
     return await this.post<string[]>(this.queryResultsValuesUrl, {

--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -53,7 +53,7 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
     return this.loadProducts();
   }
 
-   get partNumbersCache(): Promise<string[]> {
+  get partNumbersCache(): Promise<string[]> {
     return this.getPartNumbers();
   }
 
@@ -87,8 +87,10 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
 
     ResultsDataSourceBase._partNumbersCache = this.queryResultsValues(ResultsPropertiesOptions.PART_NUMBER, undefined)
     .catch(error => {
-      console.error('Error in loading part numbers:', error);
-      return [];
+       if (!this.errorTitle) {
+          this.handleQueryValuesError(error, 'result');
+        }
+        return [];
     });
 
     return ResultsDataSourceBase._partNumbersCache;

--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -6,6 +6,7 @@ import { getVariableOptions } from "core/utils";
 import { ExpressionTransformFunction } from "core/query-builder.utils";
 import { QueryBuilderOperations } from "core/query-builder.constants";
 import { extractErrorInfo } from "core/errors";
+import { ResultsPropertiesOptions } from "./types/QueryResults.types";
 
 export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery> {
   errorTitle = '';
@@ -23,6 +24,8 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
   private toDateString = '${__to:date}';
   private static _workspacesCache: Promise<Map<string, Workspace>> | null = null;
   private static _productCache: Promise<QueryProductResponse> | null = null;
+  private static _partNumbersCache: Promise<string[]> | null = null;
+
 
   readonly globalVariableOptions = (): QueryBuilderOption[] => getVariableOptions(this);
 
@@ -50,6 +53,10 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
     return this.loadProducts();
   }
 
+   get partNumbersCache(): Promise<string[]> {
+    return this.getPartNumbers();
+  }
+
   async loadWorkspaces(): Promise<Map<string, Workspace>> {
     if (ResultsDataSourceBase._workspacesCache) {
       return ResultsDataSourceBase._workspacesCache;
@@ -72,6 +79,21 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
 
     return ResultsDataSourceBase._workspacesCache;
   }
+
+   async getPartNumbers(): Promise<string[]> {
+    if (ResultsDataSourceBase._partNumbersCache) {
+      return ResultsDataSourceBase._partNumbersCache;
+    }
+
+    ResultsDataSourceBase._partNumbersCache = this.queryResultsValues(ResultsPropertiesOptions.PART_NUMBER, undefined)
+    .catch(error => {
+      console.error('Error in loading part numbers:', error);
+      return [];
+    });
+
+    return ResultsDataSourceBase._partNumbersCache;
+  }
+
 
   async queryResultsValues(fieldName: string, filter?: string): Promise<string[]> {
     return await this.post<string[]>(this.queryResultsValuesUrl, {

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
@@ -10,10 +10,11 @@ import { recordCountErrorMessages } from 'datasources/results/constants/ResultsQ
 import { ResultsProperties } from 'datasources/results/types/QueryResults.types';
 
 jest.mock('../../query-builders/query-results/ResultsQueryBuilder', () => ({
-  ResultsQueryBuilder: jest.fn(({ filter, workspaces, status, globalVariableOptions, onChange }) => {
+  ResultsQueryBuilder: jest.fn(({ filter, partNumbers, workspaces, status, globalVariableOptions, onChange }) => {
     return (
       <div data-testid="results-query-builder">
         <div data-testid="filter">{filter}</div>
+        <div data-testid="part-numbers">{JSON.stringify(partNumbers)}</div>
         <div data-testid="workspaces">{JSON.stringify(workspaces)}</div>
         <div data-testid="status">{JSON.stringify(status)}</div>
         <div data-testid="global-vars">{JSON.stringify(globalVariableOptions)}</div>
@@ -38,17 +39,12 @@ const mockWorkspaces: Workspace[] = [
   { id: '2', name: 'Workspace2', default: false, enabled: true },
 ];
 const mockGlobalVars = [{ label: '$var1', value: '$var1' }];
-const mockProducts = {
-  products: [
-    { partNumber: 'PartNumber1', name: 'ProductName1' },
-    { partNumber: 'PartNumber2', name: 'ProductName2' },
-    { partNumber: 'PartNumber3', name: null },
-  ],
-};
+const mockPartNumbers = ['PN1', 'PN2', 'PN3'];
+
 
 const mockDatasource = {
   workspacesCache: Promise.resolve(new Map(mockWorkspaces.map(workspace => [workspace.id, workspace]))),
-  productCache: Promise.resolve(mockProducts),
+  partNumbersCache: Promise.resolve(mockPartNumbers),
   globalVariableOptions: jest.fn(() => mockGlobalVars),
 } as unknown as QueryResultsDataSource;
 
@@ -71,7 +67,6 @@ let dataOutput: HTMLElement;
 let totalCountOutput: HTMLElement;
 let useTimeRange: HTMLElement;
 let useTimeRangeFor: HTMLElement;
-let productName: HTMLElement;
 
 describe('QueryResultsEditor', () => {
   beforeEach(async () => {
@@ -90,7 +85,6 @@ describe('QueryResultsEditor', () => {
     recordCount = screen.getByDisplayValue(1000);
     useTimeRange = screen.getAllByRole('checkbox')[0];
     useTimeRangeFor = screen.getAllByRole('combobox')[1];
-    productName = screen.getAllByRole('combobox')[2];
   });
 
   test('should render with default query when default values are provided', async () => {
@@ -104,8 +98,6 @@ describe('QueryResultsEditor', () => {
     expect(useTimeRange).toBeChecked();
     expect(useTimeRangeFor).toBeInTheDocument();
     expect(screen.getAllByText('Updated').length).toBe(1);
-    expect(productName).toBeInTheDocument();
-    expect(screen.getAllByText('ProductName1 (PartNumber1)').length).toBe(1);
   });
 
   describe('Properties', () => {
@@ -123,27 +115,6 @@ describe('QueryResultsEditor', () => {
       }
   
       expect(screen.getByText('You must select at least one property.')).toBeInTheDocument();
-    });
-  });
-
-  test('should update part number query when user changes a product name', async () => {
-    await select(productName, 'ProductName2 (PartNumber2)', { container: document.body });
-    await waitFor(() => {
-      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ partNumberQuery: ["PartNumber1", "PartNumber2"] }));
-    });
-  });
-
-  test('should update part number query when user selects a variable in product name field', async () => {
-    await select(productName, '$var1', { container: document.body });
-    await waitFor(() => {
-      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ partNumberQuery: ["PartNumber1", "$var1"] }));
-    });
-  });
-
-  test('should update part number query when product name is not available', async () => {
-    await select(productName, 'PartNumber3', { container: document.body });
-    await waitFor(() => {
-      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ partNumberQuery: ["PartNumber1", "PartNumber3"] }));
     });
   });
 
@@ -215,7 +186,7 @@ describe('QueryResultsEditor', () => {
 
       const emptyDatasource = {
         workspacesCache: Promise.resolve(new Map()),
-        productCache: Promise.resolve({ products: [] }),
+        partNumbersCache: Promise.resolve(mockPartNumbers),
         globalVariableOptions: jest.fn(() => []),
       } as unknown as QueryResultsDataSource;
 
@@ -237,12 +208,40 @@ describe('QueryResultsEditor', () => {
       expect(screen.getByTestId('workspaces')).toHaveTextContent('[]');
     })
 
+    test('should render empty part numbers when cache is empty', async () => {
+      cleanup();
+
+      const emptyDatasource = {
+        workspacesCache: Promise.resolve(new Map(mockWorkspaces.map(workspace => [workspace.id, workspace]))),
+        partNumbersCache: Promise.resolve([]),
+        globalVariableOptions: jest.fn(() => mockGlobalVars),
+      } as unknown as QueryResultsDataSource;
+
+      await act(async () => {
+        render(
+          <QueryResultsEditor
+            query={{
+              refId: 'A',
+              queryType: QueryType.Results,
+              outputType: OutputType.Data,
+            }}
+            handleQueryChange={mockHandleQueryChange}
+            datasource={emptyDatasource}
+          />
+        );
+      });
+
+      expect(screen.getByTestId('results-query-builder')).toBeInTheDocument();
+      expect(screen.getByTestId('part-numbers')).toHaveTextContent('[]');
+    });
+
     test('should render ResultsQueryBuilder with default props when component is loaded', () => {
       const resultsQueryBuilder = screen.getByTestId('results-query-builder');
       expect(resultsQueryBuilder).toBeInTheDocument();
       expect(screen.getByTestId('filter')).toHaveTextContent('programName = "name1"');
       expect(screen.getByTestId('workspaces')).toHaveTextContent(JSON.stringify(mockWorkspaces));
       expect(screen.getByTestId('status')).toHaveTextContent(JSON.stringify(['PASSED', 'FAILED']));
+      expect(screen.getByTestId('part-numbers')).toHaveTextContent(JSON.stringify(mockPartNumbers));
       expect(screen.getByTestId('global-vars')).toHaveTextContent(JSON.stringify(mockGlobalVars));
     });
 

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -27,7 +27,7 @@ type Props = {
 
 export function QueryResultsEditor({ query, handleQueryChange, datasource }: Props) {
   const [workspaces, setWorkspaces] = useState<Workspace[] | null>(null);
-  const [productNameOptions, setProductNameOptions] = useState<Array<SelectableValue<string>>>([]);
+  const [partNumbers, setPartNumbers] = useState<string[]>([]);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
   const [isPropertiesValid, setIsPropertiesValid] = useState<boolean>(true);
 
@@ -36,15 +36,11 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
       const workspaces = await datasource.workspacesCache;
       setWorkspaces(Array.from(workspaces.values()));
     };
-    const loadProductNameOptions = async () => {
-      const response = await datasource.productCache;
-      const productOptions = response.products.map(product => ({
-        label: product.name ? `${product.name} (${product.partNumber})`: product.partNumber,
-        value: product.partNumber,
-      }));
-      setProductNameOptions([...datasource.globalVariableOptions(), ...productOptions]);
-    }
-    loadProductNameOptions();
+    const loadPartNumbers = async () => {
+      const partNumbers = await datasource.partNumbersCache;
+      setPartNumbers(partNumbers);
+    };
+    loadPartNumbers();
     loadWorkspaces();
   }, [datasource]);
 
@@ -86,16 +82,6 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
     }
   }
 
-  const onProductNameChange = (productNames: Array<SelectableValue<string>>) => {
-    handleQueryChange({ ...query, partNumberQuery: productNames.map(product => product.value as string) });
-  }
-
-  const formatOptionLabel = (option: SelectableValue<string>) => (
-    <div style={{ maxWidth: 500, whiteSpace: 'normal' }}>
-      {option.label}
-    </div>
-  );
-
   return (
     <>
       <VerticalGroup>
@@ -135,30 +121,16 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           }}
         />
         <div className="results-horizontal-control-group">
-          <div>
-            <InlineField label="Product (part number)" labelWidth={26} tooltip={tooltips.productName}>
-              <MultiSelect
-                maxVisibleValues={5}
-                width={65}
-                onChange={onProductNameChange}
-                placeholder='Select part numbers to use in a query'
-                noMultiValueWrap={true}
-                closeMenuOnSelect={false}
-                value={query.partNumberQuery}
-                formatOptionLabel={formatOptionLabel}
-                options={productNameOptions}
-              />
-            </InlineField>
-            <InlineField label="Query By" labelWidth={26} tooltip={tooltips.queryBy}>
-              <ResultsQueryBuilder
-                filter={query.queryBy}
-                workspaces={workspaces}
-                status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
-                globalVariableOptions={datasource.globalVariableOptions()}
-                onChange={(event: any) => onParameterChange(event.detail.linq)}>
-              </ResultsQueryBuilder>
-            </InlineField>
-          </div>
+          <InlineField label="Query By" labelWidth={26} tooltip={tooltips.queryBy}>
+            <ResultsQueryBuilder
+              filter={query.queryBy}
+              workspaces={workspaces}
+              status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
+              partNumbers={partNumbers}
+              globalVariableOptions={datasource.globalVariableOptions()}
+              onChange={(event: any) => onParameterChange(event.detail.linq)}>
+            </ResultsQueryBuilder>
+          </InlineField>
           {query.outputType === OutputType.Data && (
             <div className="results-right-query-controls">
               <InlineField 

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.test.tsx
@@ -10,9 +10,10 @@ describe('ResultsQueryBuilder', () => {
     const containerClass = 'smart-filter-group-condition-container';
     const workspace = { id: '1', name: 'Selected workspace' } as Workspace;
     const status = ['PASSED', 'FAILED'];
+    const partNumber = ['PN1', 'PN2', 'PN3'];
 
-    function renderElement(workspaces: Workspace[] | null, status: string[], filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
-      reactNode = React.createElement(ResultsQueryBuilder, { filter, workspaces, status, globalVariableOptions, onChange: jest.fn(), });
+    function renderElement(workspaces: Workspace[] | null, status: string[], filter: string, globalVariableOptions: QueryBuilderOption[] = [], partNumbers: string[] | null = partNumber) {
+      reactNode = React.createElement(ResultsQueryBuilder, { filter, workspaces, status, partNumbers, globalVariableOptions, onChange: jest.fn(), });
       const renderResult = render(reactNode);
       return {
         renderResult,
@@ -43,6 +44,15 @@ describe('ResultsQueryBuilder', () => {
       expect(conditionsContainer.item(0)?.textContent).toContain("Status"); //label
       expect(conditionsContainer.item(0)?.textContent).toContain("Equals"); //operator
       expect(conditionsContainer.item(0)?.textContent).toContain("PASSED"); //value
+    });
+
+    it('should select part number in query builder', () => {
+      const { conditionsContainer } = renderElement([workspace], status, 'PartNumber = "PN1"');
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain("Part number"); //label
+      expect(conditionsContainer.item(0)?.textContent).toContain("Equals"); //operator
+      expect(conditionsContainer.item(0)?.textContent).toContain("PN1"); //value
     });
 
     it('should select keyword in query builder', () => {
@@ -102,6 +112,15 @@ describe('ResultsQueryBuilder', () => {
 
     it('should not set workspace field when workspace is null', () => {
       const { conditionsContainer } = renderElement(null, status, 'Workspace = "1"');
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain("Property"); //label
+      expect(conditionsContainer.item(0)?.textContent).toContain("Operator"); //operator
+      expect(conditionsContainer.item(0)?.textContent).toContain("Value"); //value
+    })
+
+    it('should not set part number field when part numbers are empty', () => {
+      const { conditionsContainer } = renderElement([workspace], status, 'PartNumber = "PN1"', [], null);
 
       expect(conditionsContainer?.length).toBe(1);
       expect(conditionsContainer.item(0)?.textContent).toContain("Property"); //label

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -21,7 +21,7 @@ type ResultsQueryBuilderProps = QueryBuilderProps &
   React.HTMLAttributes<Element> & {
     filter?: string;
     workspaces: Workspace[] | null;
-    partNumbers: string[];
+    partNumbers: string[] | null;
     status: string[];
     globalVariableOptions: QueryBuilderOption[];
   };
@@ -109,6 +109,10 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
   }, []);
 
   const partNumberField = useMemo(() => {
+    if (!partNumbers) {
+      return null;
+    }
+
     const partNumberField = ResultsQueryBuilderFields.PARTNUMBER;
     return {
       ...partNumberField,
@@ -123,7 +127,7 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
   }, [partNumbers]);
 
   useEffect(() => {
-    if(!workspaceField) {
+    if(!workspaceField || !partNumberField) {
       return;
     }
 

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -21,6 +21,7 @@ type ResultsQueryBuilderProps = QueryBuilderProps &
   React.HTMLAttributes<Element> & {
     filter?: string;
     workspaces: Workspace[] | null;
+    partNumbers: string[];
     status: string[];
     globalVariableOptions: QueryBuilderOption[];
   };
@@ -29,6 +30,7 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
   filter,
   onChange,
   workspaces,
+  partNumbers,
   status,
   globalVariableOptions,
 }) => {
@@ -106,12 +108,27 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
     };
   }, []);
 
+  const partNumberField = useMemo(() => {
+    const partNumberField = ResultsQueryBuilderFields.PARTNUMBER;
+    return {
+      ...partNumberField,
+      lookup: {
+        ...partNumberField.lookup,
+        dataSource: [
+          ...(partNumberField.lookup?.dataSource || []),
+          ...partNumbers.map(partNumber => ({ label: partNumber, value: partNumber })),
+        ],
+      },
+    };
+  }, [partNumbers]);
+
   useEffect(() => {
     if(!workspaceField) {
       return;
     }
 
     const updatedFields = [
+      partNumberField,
       ...ResultsQueryBuilderStaticFields!,
       updatedAtField,
       workspaceField,
@@ -186,7 +203,7 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
     ];
 
     setOperations([...customOperations, ...keyValueOperations]);
-  }, [workspaceField, startedAtField, updatedAtField, globalVariableOptions, statusField]);
+  }, [workspaceField, startedAtField, updatedAtField, partNumberField, globalVariableOptions, statusField]);
 
   return (
     <QueryBuilder

--- a/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.test.tsx
+++ b/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.test.tsx
@@ -6,11 +6,12 @@ import userEvent from '@testing-library/user-event';
 import { Workspace } from 'core/types';
 
 jest.mock('../query-results/ResultsQueryBuilder', () => ({
-  ResultsQueryBuilder: jest.fn(({ filter, workspaces, status, globalVariableOptions, onChange }) => {
+  ResultsQueryBuilder: jest.fn(({ filter, workspaces, status, partNumbers, globalVariableOptions, onChange }) => {
     return (
       <div data-testid="results-query-builder">
         <div data-testid="results-filter">{filter}</div>
         <div data-testid="results-workspaces">{JSON.stringify(workspaces)}</div>
+        <div data-testid="results-part-numbers">{JSON.stringify(partNumbers)}</div>
         <div data-testid="results-status">{JSON.stringify(status)}</div>
         <div data-testid="results-global-vars">{JSON.stringify(globalVariableOptions)}</div>
         <button
@@ -64,6 +65,7 @@ const mockDatasource = {
   setStepsPathChangeCallback: jest.fn(),
   getStepPaths: jest.fn().mockReturnValue([]),
   workspacesCache: Promise.resolve(new Map(mockWorkspaces.map(ws => [ws.id, ws]))),
+  partNumbersCache: Promise.resolve(['PN1', 'PN2']),
 } as unknown as QueryStepsDataSource;
 
 jest.mock('core/utils', () => ({
@@ -115,6 +117,23 @@ describe('StepsQueryBuilderWrapper', () => {
     expect(screen.getByTestId('steps-workspaces').textContent).toBe('[]');
   });
 
+  test('should render empty part numbers when promise resolves to empty value', async () => {
+    cleanup();
+    const emptyDatasource = {
+      globalVariableOptions: jest.fn().mockReturnValue([]),
+      workspacesCache: Promise.resolve(new Map(mockWorkspaces.map(ws => [ws.id, ws]))),
+      partNumbersCache: Promise.resolve([]),
+      setStepsPathChangeCallback: jest.fn(),
+      getStepPaths: jest.fn().mockReturnValue([]),
+    } as unknown as QueryStepsDataSource;
+
+    await act(async () => {
+      render(<StepsQueryBuilderWrapper {...defaultProps} datasource={emptyDatasource} />);
+    })
+
+    expect(screen.getByTestId('results-part-numbers').textContent).toBe('[]');
+  });
+
   test('should pass default properties to result and steps query builder', () => {
     expect(screen.getByTestId('results-filter').textContent).toBe('partNumber = "PN1"');
     expect(screen.getByTestId('results-workspaces').textContent).toEqual(
@@ -123,6 +142,7 @@ describe('StepsQueryBuilderWrapper', () => {
         { id: '2', name: 'workspace2', default: false, enabled: true },
       ])
     );
+    expect(screen.getByTestId('results-part-numbers').textContent).toEqual(JSON.stringify(['PN1', 'PN2']));
     expect(screen.getByTestId('results-global-vars').textContent).toEqual(JSON.stringify(['var1', 'var2']));
     expect(screen.getByTestId('results-status').textContent).toEqual(JSON.stringify(['PASS', 'FAIL']));
 

--- a/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
+++ b/src/datasources/results/components/query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper.tsx
@@ -28,6 +28,7 @@ export const StepsQueryBuilderWrapper = (
     disableStepsQueryBuilder
   }: Props) => {
   const [workspaces, setWorkspaces] = useState<Workspace[] | null>(null);
+  const [partNumbers, setPartNumbers] = useState<string[]>([]);
   const [stepsPath, setStepsPath] = useState<string[]>([]);
 
   useEffect(() => {
@@ -35,12 +36,17 @@ export const StepsQueryBuilderWrapper = (
       const workspaces = await datasource.workspacesCache;
       setWorkspaces(Array.from(workspaces.values()));
     };
+    const loadPartNumbers = async () => {
+      const partNumbers = await datasource.partNumbersCache;
+      setPartNumbers(partNumbers);
+    };
     const loadStepsPath = () => {
       setStepsPath(datasource.getStepPaths());
       datasource.setStepsPathChangeCallback(() => {
         setStepsPath(datasource.getStepPaths());
       });
     };
+    loadPartNumbers();
     loadStepsPath();
     loadWorkspaces();
   }, [datasource]);
@@ -53,6 +59,7 @@ export const StepsQueryBuilderWrapper = (
           onChange={(event) => onResultsQueryChange((event as CustomEvent<{ linq: string }>).detail.linq)}
           workspaces={workspaces}
           status={enumToOptions(TestMeasurementStatus).map(option => option.value?.toString() || '')}
+          partNumbers={partNumbers}
           globalVariableOptions={datasource.globalVariableOptions()}>
         </ResultsQueryBuilder>
       </InlineField>

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -2,7 +2,7 @@ import { act, cleanup, fireEvent, screen, waitFor } from '@testing-library/react
 import { ResultsVariableQueryEditor } from './ResultsVariableQueryEditor';
 import { setupRenderer } from 'test/fixtures';
 import { ResultsDataSource } from 'datasources/results/ResultsDataSource';
-import { QueryProductResponse, QueryType, ResultsQuery } from 'datasources/results/types/types';
+import { QueryType, ResultsQuery } from 'datasources/results/types/types';
 import { Workspace } from 'core/types';
 import { QueryResultsDataSource } from 'datasources/results/query-handlers/query-results/QueryResultsDataSource';
 import { ResultsVariableProperties } from 'datasources/results/types/QueryResults.types';
@@ -25,7 +25,7 @@ const fakeWorkspaces: Workspace[] = [
   },
 ];
 
-const fakePartNumbers = [ "part1", "part2", "part3" ];
+const fakePartNumbers = [ "PN1", "PN2", "PN3" ];
 
 class FakeQueryResultsSource extends QueryResultsDataSource {
   getWorkspaces(): Promise<Workspace[]> {
@@ -33,14 +33,6 @@ class FakeQueryResultsSource extends QueryResultsDataSource {
   }
   queryResultsValues(): Promise<string[]> {
     return Promise.resolve(fakePartNumbers);
-  }
-  queryProducts(): Promise<QueryProductResponse> {
-    return Promise.resolve({
-      products: fakePartNumbers.map(partNumber => ({
-        partNumber,
-        name: "Product",
-      })),
-    });
   }
   globalVariableOptions = () => [
     { label: "$var1", value: "$var1" },
@@ -68,10 +60,11 @@ class FakeResultsDataSource extends ResultsDataSource {
 }
 
 jest.mock('../query-builders/query-results/ResultsQueryBuilder', () => ({
-  ResultsQueryBuilder: jest.fn(({ workspaces }) => {
+  ResultsQueryBuilder: jest.fn(({ workspaces, partNumber }) => {
     return (
       <div data-testid="results-query-builder">
         <div data-testid="results-workspaces">{JSON.stringify(workspaces)}</div>
+        <div data-testid="results-part-number">{JSON.stringify(partNumber)}</div>
       </div>
     );
   }),
@@ -102,7 +95,6 @@ let propertiesSelect: HTMLElement;
 let queryBy: HTMLElement;
 let queryByResults: HTMLElement;
 let queryBySteps: HTMLElement;
-let productNameSelect: HTMLElement;
 
 describe('Results Query Type', () => {
   beforeEach(async () => {
@@ -126,7 +118,6 @@ describe('Results Query Type', () => {
 
   it('should render properties select and results query builder progressively', async () => {
     propertiesSelect = screen.getAllByRole('combobox')[0];
-    productNameSelect = screen.getAllByRole('combobox')[1];
 
     expect(propertiesSelect).toBeInTheDocument();
 
@@ -138,31 +129,6 @@ describe('Results Query Type', () => {
     expect(queryBy).toBeInTheDocument();
 
     expect(screen.queryByTestId('results-query-builder')).toBeInTheDocument();
-    expect(productNameSelect).toBeInTheDocument();
-  });
-
-  it('should select the product name from the product name dropdown', async () => {
-    productNameSelect = screen.getAllByRole('combobox')[1];
-
-    expect(productNameSelect).toBeInTheDocument();
-
-    fireEvent.keyDown(productNameSelect, { key: 'ArrowDown' });
-    const option = await screen.findByText("Product (part1)");
-    fireEvent.click(option);
-
-    expect(screen.getByText("Product (part1)")).toBeInTheDocument();
-  });
-
-  it('should select variable from product name dropdown', async () => {
-    productNameSelect = screen.getAllByRole('combobox')[1];
-
-    expect(productNameSelect).toBeInTheDocument();
-
-    fireEvent.keyDown(productNameSelect, { key: 'ArrowDown' });
-    const option = await screen.findByText('$var1');
-    fireEvent.click(option);
-
-    expect(screen.getByText('$var1')).toBeInTheDocument();
   });
 
   describe('Take input field', () => {
@@ -210,14 +176,13 @@ describe('Steps Query Type', () => {
     expect(queryBySteps).toBeInTheDocument();
   });
 
-  it('should disable the steps query builder when product name is empty', async () => {
+  it('should disable the steps query builder when resultQuery is empty', async () => {
     await act(async () => {
       renderEditor({
         refId: '',
         queryType: QueryType.Steps,
-        queryByResults: 'resultsQuery',
+        queryByResults: '',
         queryBySteps: '',
-        partNumberQueryInSteps: []
       } as unknown as ResultsQuery);
     });
     const stepsQueryInput = screen.getByTestId('Query by steps properties');
@@ -225,99 +190,18 @@ describe('Steps Query Type', () => {
     expect(stepsQueryInput).toBeDisabled();
   });
 
-  it('should disable the steps query builder when product name is undefined', async () => {
+  it('should enable the steps query builder when resultQuery has value', async () => {
     await act(async () => {
       renderEditor({
         refId: '',
         queryType: QueryType.Steps,
         queryByResults: 'resultsQuery',
         queryBySteps: '',
-        partNumberQueryInSteps: undefined
-      } as unknown as ResultsQuery);
-    });
-    const stepsQueryInput = screen.getByTestId('Query by steps properties');
-    expect(stepsQueryInput).toBeInTheDocument();
-    expect(stepsQueryInput).toBeDisabled();
-  });
-
-  it('should enable the steps query builder when product name has value', async () => {
-    await act(async () => {
-      renderEditor({
-        refId: '',
-        queryType: QueryType.Steps,
-        queryByResults: 'resultsQuery',
-        queryBySteps: '',
-        partNumberQueryInSteps: ['PN1']
       } as unknown as ResultsQuery);
     });
     const stepsQueryInput = screen.getByTestId('Query by steps properties');
     expect(stepsQueryInput).toBeInTheDocument();
     expect(stepsQueryInput).not.toBeDisabled();
-  });
-
-  it('should select the product name from the product name dropdown', async () => {
-    await act(async () => {
-      renderEditor({
-        refId: '',
-        queryType: QueryType.Steps,
-        queryByResults: 'resultsQuery',
-        queryBySteps: '',
-      } as unknown as ResultsQuery);
-    });
-
-    const productNameSelectInSteps = screen.getAllByRole('combobox')[0];
-
-    expect(productNameSelectInSteps).toBeInTheDocument();
-
-    fireEvent.keyDown(productNameSelectInSteps, { key: 'ArrowDown' });
-    const option = await screen.findByText("Product (part1)");
-    fireEvent.click(option);
-
-    expect(screen.getByText("Product (part1)")).toBeInTheDocument();
-  });
-
-  it('should show error when no product partNumber is selected', async () => {
-    await act(async () => {
-      renderEditor({
-        refId: '',
-        queryType: QueryType.Steps,
-        queryByResults: 'resultsQuery',
-        queryBySteps: '',
-      } as unknown as ResultsQuery);
-    });
-
-    const productNameSelectInSteps = screen.getAllByRole('combobox')[0];
-    fireEvent.keyDown(productNameSelectInSteps, { key: 'ArrowDown' });
-    const option = await screen.findByText("Product (part1)");
-    fireEvent.click(option);
-    expect(screen.getByText("Product (part1)")).toBeInTheDocument();
-
-    // Remove the selected product using the remove button (if present)
-    const removeButtons = screen.queryAllByRole('button', { name: 'Remove' });
-    expect(removeButtons.length).toBeGreaterThan(0);
-    fireEvent.click(removeButtons[0]);
-
-    expect(screen.getByText('You must select at least one product in this field.')).toBeInTheDocument();
-  })
-
-  it('should select variable from product name dropdown', async () => {
-    await act(async () => {
-      renderEditor({
-        refId: '',
-        queryType: QueryType.Steps,
-        queryByResults: 'resultsQuery',
-        queryBySteps: '',
-      } as unknown as ResultsQuery);
-    });
-    const productNameSelectInSteps = screen.getAllByRole('combobox')[0];
-
-    expect(productNameSelectInSteps).toBeInTheDocument();
-
-    fireEvent.keyDown(productNameSelectInSteps, { key: 'ArrowDown' });
-    const option = await screen.findByText('$var1');
-    fireEvent.click(option);
-
-    expect(screen.getByText('$var1')).toBeInTheDocument();
   });
 
   describe('Take input field', () => {
@@ -399,9 +283,9 @@ describe('Dependencies', () => {
       get workspacesCache() {
         return Promise.resolve(new Map());
       },
-      get productCache() {
-        return Promise.resolve({ products: [] });
-      },
+      get partNumbersCache() {
+        return Promise.resolve(new Map());
+      }
     } as unknown as QueryResultsDataSource;
 
     Object.defineProperty(FakeResultsDataSource.prototype, 'queryResultsDataSource', {
@@ -419,4 +303,31 @@ describe('Dependencies', () => {
 
     expect(screen.getByTestId('results-workspaces').textContent).toBe('[]');
   });
+
+  it('should not render product part numbers when promise resolves to undefined', async () => {
+    cleanup();
+    const emptyDatasource = {
+      globalVariableOptions: jest.fn().mockReturnValue([]),
+      get workspacesCache() {
+        return Promise.resolve(new Map());
+      },
+      get partNumbersCache() {
+        return Promise.resolve(new Map());
+      }
+    } as unknown as QueryResultsDataSource;
+
+    Object.defineProperty(FakeResultsDataSource.prototype, 'queryResultsDataSource', {
+      get: () => emptyDatasource,
+    });
+
+    await act(async () => {
+      renderEditor({ refId: '', properties: '', queryBy: '' } as unknown as ResultsQuery);
+    });
+
+    fireEvent.keyDown(screen.getAllByRole('combobox')[0], { key: 'ArrowDown' });
+    const option = await screen.findByText(ResultsVariableProperties[0].label);
+    fireEvent.click(option);
+
+    expect(screen.getByTestId('results-part-number').textContent).toBe('');
+  })
 });

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -62,8 +62,8 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
   }, [datasource]);
 
   useEffect(() => {
-    disableStepsQueryBuilder(!stepsVariableQuery.partNumberQueryInSteps || stepsVariableQuery.partNumberQueryInSteps.length === 0);
-  }, [stepsVariableQuery.partNumberQueryInSteps]);
+    disableStepsQueryBuilder(stepsVariableQuery.queryByResults === '');
+  }, [stepsVariableQuery.queryByResults]);
 
   const onQueryTypeChange = (queryType: QueryType) => {
     if (queryType === QueryType.Results) {

--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -51,6 +51,23 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
       QueryBuilderOperations.IS_NOT_BLANK.name,
     ],
   },
+  PARTNUMBER: {
+    label: 'Part number',
+    dataField: ResultsQueryBuilderFieldNames.PART_NUMBER,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.STARTS_WITH.name,
+      QueryBuilderOperations.ENDS_WITH.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+    lookup: {
+      dataSource: [],
+    },
+  },
   PROPERTIES: {
     label: 'Properties',
     dataField: ResultsQueryBuilderFieldNames.PROPERTIES,

--- a/src/datasources/results/defaultQueries.ts
+++ b/src/datasources/results/defaultQueries.ts
@@ -20,7 +20,6 @@ export const defaultResultsQuery: Omit<QueryResults, 'refId'> = {
   recordCount: 1000,
   useTimeRange: false,
   useTimeRangeFor: undefined,
-  partNumberQuery: [],
   queryBy: '',
 };
 

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -306,6 +306,17 @@ describe('QueryResultsDataSource', () => {
       expect(datastore.errorDescription).toContain('Some values may not be available in the query builder lookups due to an unknown error.');
     });
 
+    it('should handle errors in getPartNumbers', async () => {
+      (ResultsDataSourceBase as any)._partNumbersCache = null;
+      const error = new Error('API failed');
+      jest.spyOn(QueryResultsDataSource.prototype, 'queryResultsValues').mockRejectedValue(error);
+
+      await datastore.getPartNumbers();
+
+      expect(datastore.errorTitle).toBe('Warning during result value query');
+      expect(datastore.errorDescription).toContain('Some values may not be available in the query builder lookups due to an unknown error.');
+    });
+
     it('should contain error details when error contains additional information', async () => {
       (ResultsDataSourceBase as any)._workspacesCache = null;
       const error = new Error(`API failed Error message: ${JSON.stringify({ message: 'Detailed error message', statusCode: 500 })}`);

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -20,6 +20,8 @@ const mockQueryResultsResponse: QueryResultsResponse = {
   ],
   totalCount: 1
 };
+const mockQueryResultsValuesResponse = ["partNumber1", "partNumber2"];
+
 
 let datastore: QueryResultsDataSource, backendServer: MockProxy<BackendSrv>, templateSrv: MockProxy<TemplateSrv>;
 
@@ -238,162 +240,33 @@ describe('QueryResultsDataSource', () => {
         ]);
     });
 
-    describe('part number query', () => {
-      test('should transform part number query into filter', async () => {
-        const partNumberQuery = ['PartNumber1', 'PartNumber2'];
-        const query = buildQuery(
-          {
-            refId: 'A',
-            outputType: OutputType.Data,
-            partNumberQuery,
-            queryBy: '',
-          },
-        );
-
-        await datastore.query(query);
-
-        expect(backendServer.fetch).toHaveBeenCalledWith(
-          expect.objectContaining({
-            url: '/nitestmonitor/v2/query-results',
-            data: expect.objectContaining({
-              filter: '(PartNumber = "PartNumber1" || PartNumber = "PartNumber2")'
-            }),
-          })
-        );
-      });
-
-      test('should handle empty part number query and empty query from query builder', async () => {
-        const query = buildQuery(
-          {
-            refId: 'A',
-            outputType: OutputType.Data,
-            partNumberQuery: [],
-            queryBy: '',
-          },
-        );
-
-        await datastore.query(query);
-
-        expect(backendServer.fetch).toHaveBeenCalledWith(
-          expect.objectContaining({
-            url: '/nitestmonitor/v2/query-results',
-            data: expect.objectContaining({
-              filter: undefined
-            }),
-          })
-        );
-      });
-
-      test('should handle part number query with template variables', async () => {
-        const partNumberQuery = ['PartNumber1', '${var}'];
-        const templateSrvCalledWith = '(PartNumber = "PartNumber1" || PartNumber = "${var}")';
-        const replacedPartNumberQuery = '(PartNumber = "PartNumber1" || PartNumber = "ReplacedValue")';
-        templateSrv.replace.calledWith(templateSrvCalledWith).mockReturnValue(replacedPartNumberQuery);
-
-        const query = buildQuery(
-          {
-            refId: 'A',
-            outputType: OutputType.Data,
-            partNumberQuery,
-            queryBy: '',
-          },
-        );
-
-        await datastore.query(query);
-
-        expect(templateSrv.replace).toHaveBeenCalledWith("(PartNumber = \"PartNumber1\" || PartNumber = \"${var}\")", expect.anything());
-        expect(backendServer.fetch).toHaveBeenCalledWith(
-          expect.objectContaining({
-            url: '/nitestmonitor/v2/query-results',
-            data: expect.objectContaining({
-              filter: '(PartNumber = "PartNumber1" || PartNumber = "ReplacedValue")'
-            }),
-          })
-        );
-      });
-
-      test('should handle multiple part numbers and query variables', async () => {
-        const resultsQuery = `${ResultsQueryBuilderFieldNames.PROGRAM_NAME} = "{name1,name2}"`;
-        const partNumberQuery = ['PartNumber1', '${var}'];
-
-        const templateSrvCalledWith = '(PartNumber = "PartNumber1" || PartNumber = "${var}") && ProgramName = "{name1,name2}"';
-        const replacedPartNumberQuery = '(PartNumber = "PartNumber1" || PartNumber = "{partNumber2,partNumber3}") && ProgramName = "{name1,name2}"';
-        templateSrv.replace.calledWith(templateSrvCalledWith).mockReturnValue(replacedPartNumberQuery);
-
-        const query = buildQuery(
-          {
-            refId: 'A',
-            outputType: OutputType.Data,
-            partNumberQuery,
-            queryBy: resultsQuery
-          },
-        );
-
-        await datastore.query(query);
-
-        expect(templateSrv.replace).toHaveBeenCalledWith("(PartNumber = \"PartNumber1\" || PartNumber = \"${var}\") && ProgramName = \"{name1,name2}\"", expect.anything());
-        expect(backendServer.fetch).toHaveBeenCalledWith(
-          expect.objectContaining({
-            url: '/nitestmonitor/v2/query-results',
-            data: expect.objectContaining({
-              filter: '(PartNumber = \"PartNumber1\" || (PartNumber = \"partNumber2\" || PartNumber = \"partNumber3\")) && (ProgramName = \"name1\" || ProgramName = \"name2\")'
-            }),
-          })
-        );
-      });
-    })
-
     describe('Dependencies', () => {
     afterEach(() => {
+      (ResultsDataSourceBase as any)._partNumbersCache = null;
       (ResultsDataSourceBase as any)._workspacesCache = null;
-      (ResultsDataSourceBase as any)._productCache = null;
     });
 
-    test('should return the same promise instance when product promise already exists', async () => {
-      const mockProducts = {
-        products: [
-          {partNumber: 'PartNumber1', name: 'ProductName1'},
-          {partNumber: 'PartNumber2', name: 'ProductName2'}
-        ]
-      };
-      const mockPromise = Promise.resolve(mockProducts);
-      (ResultsDataSourceBase as any)._productCache = mockPromise;
+     test('should return the same promise instance when partnumber promise already exists', async () => {
+      const mockPromise = Promise.resolve(['partNumber1', 'partNumber2']);
+      (ResultsDataSourceBase as any)._partNumbersCache = mockPromise;
       backendServer.fetch.mockClear();
-
-      const productPromise = datastore.productCache;
-
-      expect(productPromise).toEqual(mockPromise);
-      expect(await productPromise).toEqual(mockProducts);
-      expect(backendServer.fetch).not.toHaveBeenCalledWith(expect.objectContaining({ url: '/nitestmonitor/v2/query-products' }));
+      const partNumbersPromise = datastore.getPartNumbers();
+      expect(partNumbersPromise).toEqual(mockPromise);
+      expect(datastore.partNumbersCache).toEqual(mockPromise);
+      expect(backendServer.fetch).not.toHaveBeenCalledWith(expect.objectContaining({ url: '/nitestmonitor/v2/query-result-values' }));
     });
-
-    test('should create and return a new promise when product promise does not exist', async () => {
-      const mockProducts = {
-        products: [
-          {partNumber: 'PartNumber1', name: 'ProductName1'},
-          {partNumber: 'PartNumber2', name: 'ProductName2'}
-        ]
-      };
+    
+    test('should create and return a new promise when partnumber promise does not exist', async () => {
+      (ResultsDataSourceBase as any)._partNumbersCache = null;
       backendServer.fetch
-      .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-products', method: 'POST' }))
-      .mockReturnValue(createFetchResponse(mockProducts));
-
-      const promise = datastore.loadProducts();
-
+      .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-result-values', method: 'POST' }))
+      .mockReturnValue(createFetchResponse(mockQueryResultsValuesResponse));
+      const promise = datastore.getPartNumbers();
       expect(promise).not.toBeNull();
       expect(backendServer.fetch).toHaveBeenCalledWith(
-        expect.objectContaining({ url: '/nitestmonitor/v2/query-products' })
-      );
-    });
+        expect.objectContaining({ url: '/nitestmonitor/v2/query-result-values' })
 
-    it('should handle errors in loadProducts', async () => {
-      const error = new Error('API failed');
-      jest.spyOn(QueryResultsDataSource.prototype, 'queryProducts').mockRejectedValue(error);
-
-      await datastore.loadProducts();
-
-      expect(datastore.errorTitle).toBe('Warning during product value query');
-      expect(datastore.errorDescription).toContain('Some values may not be available in the query builder lookups due to an unknown error.');
+        );
     });
 
     test('should return the same promise instance when workspacePromise already exists', async () => {
@@ -718,76 +591,6 @@ describe('QueryResultsDataSource', () => {
 
       expect(templateSrv.replace).toHaveBeenCalledWith(queryBy, options.scopedVars);
       expect(result).toEqual([{ text: 'TestProgram', value: 'TestProgram' }]);
-    });
-
-    it('should merge partnumber and queryBy filters', async () => {
-      const partNumberQuery = ['PartNumber1', 'PartNumber2'];
-      const query = {
-        properties: 'PART_NUMBER',
-        queryBy: 'ProgramName = "Program1"',
-        partNumberQuery,
-        resultsTake: 1000
-      } as ResultsVariableQuery;
-      const options = { scopedVars: { var: { value: 'ReplacedValue' } } };
-
-      await datastore.metricFindQuery(query, options);
-
-      expect(backendServer.fetch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: '/nitestmonitor/v2/query-results',
-          data: expect.objectContaining({
-            filter: '(PartNumber = "PartNumber1" || PartNumber = "PartNumber2") && ProgramName = "Program1"'
-          }),
-        })
-      );
-    });
-
-    it('should handle empty part number query and empty query from query builder', async () => {
-      const partNumberQuery: string[] = [];
-      const query = {
-        properties: 'PART_NUMBER',
-        queryBy: '',
-        partNumberQuery,
-        resultsTake: 1000
-      } as ResultsVariableQuery;
-
-      await datastore.metricFindQuery(query, {});
-
-      expect(backendServer.fetch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: '/nitestmonitor/v2/query-results',
-          data: expect.objectContaining({
-            filter: undefined
-          }),
-        })
-      );
-    });
-
-    it('should handle part number query with template variables', async () => {
-      const partNumberQuery = ['PartNumber1', '${var}'];
-      const templateSrvCalledWith = '(PartNumber = "PartNumber1" || PartNumber = "${var}")';
-      const replacedPartNumberQuery = '(PartNumber = "PartNumber1" || PartNumber = "ReplacedValue")';
-      templateSrv.replace.calledWith(templateSrvCalledWith).mockReturnValue(replacedPartNumberQuery);
-      const options = { scopedVars: { var: { value: 'ReplacedValue' } } };
-
-      const query = {
-        properties: 'PART_NUMBER',
-        queryBy: '',
-        partNumberQuery,
-        resultsTake: 1000
-      } as ResultsVariableQuery;
-
-      await datastore.metricFindQuery(query, options);
-
-      expect(templateSrv.replace).toHaveBeenCalledWith("(PartNumber = \"PartNumber1\" || PartNumber = \"${var}\")", expect.anything());
-      expect(backendServer.fetch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: '/nitestmonitor/v2/query-results',
-          data: expect.objectContaining({
-            filter: '(PartNumber = "PartNumber1" || PartNumber = "ReplacedValue")'
-          }),
-        })
-      );
     });
   });
 

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -9,7 +9,6 @@ export interface QueryResults extends ResultsQuery {
   useTimeRangeFor?: string;
   recordCount?: number;
   queryBy?: string;
-  partNumberQuery?: string[];
 }
 
 export interface ResultsVariableQuery extends ResultsQuery {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
This pull request contains changes to replace the previous product-based querying to the query builder part-number-based querying. 

## 👩‍💻 Implementation

* Added caching (`_partNumbersCache`) and a new method (`getPartNumbers`) to manage and query part numbers using `ResultsPropertiesOptions.PART_NUMBER`.
* Replaced the product name field with part numbers, added state management for part numbers, and updated the query builder to pass part numbers.
*  Added support for part numbers in the query builder by introducing a new field (`partNumberField`) and updating operations.


## 🧪 Testing

- Updated tests to validate part number functionality, removed tests related to product names, and added new tests for rendering part numbers and handling empty caches.
## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).