### PR TITLE
feat(results): update measurements to be listed as separate columns

### DIFF
--- a/src/datasources/results/constants/stepMeasurements.constants.ts
+++ b/src/datasources/results/constants/stepMeasurements.constants.ts
@@ -1,0 +1,36 @@
+export enum MeasurementProperties {
+    NAME = 'name',
+    STATUS = 'status',
+    UNITS = 'units',
+    MEASUREMENT = 'measurement',
+    LOW_LIMIT = 'lowLimit',
+    HIGH_LIMIT = 'highLimit'
+};
+
+export const measurementProperties: MeasurementProperties[] = [
+    MeasurementProperties.NAME,
+    MeasurementProperties.STATUS,
+    MeasurementProperties.UNITS,
+    MeasurementProperties.LOW_LIMIT,
+    MeasurementProperties.HIGH_LIMIT
+];
+
+export const measurementColumnLabelSuffix: Record<MeasurementProperties, string> = {
+    [MeasurementProperties.NAME]: '',
+    [MeasurementProperties.STATUS]: 'Status',
+    [MeasurementProperties.UNITS]: 'Unit',
+    [MeasurementProperties.MEASUREMENT]: '',
+    [MeasurementProperties.LOW_LIMIT]: 'Low Limit',
+    [MeasurementProperties.HIGH_LIMIT]: 'High Limit'
+};
+
+export const MEASUREMENT_NAME_COLUMN = MeasurementProperties.NAME;
+
+const COLUMN_NAME_FORMAT = '{name}-{suffix}';
+
+export function formatMeasurementColumnName(name: string, suffix: string): string {
+    if(!suffix) {
+        return name;
+    }
+    return COLUMN_NAME_FORMAT.replace('{name}', name).replace('{suffix}', suffix);
+};

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -21,6 +21,7 @@ import { QueryResponse } from 'core/types';
 import { queryInBatches } from 'core/utils';
 import { MAX_PATH_TAKE_PER_REQUEST, QUERY_PATH_REQUEST_PER_SECOND } from 'datasources/results/constants/QueryStepPath.constants';
 import { extractErrorInfo } from 'core/errors';
+import { formatMeasurementColumnName, MEASUREMENT_NAME_COLUMN, measurementColumnLabelSuffix, MeasurementProperties, measurementProperties } from 'datasources/results/constants/stepMeasurements.constants';
 
 export class QueryStepsDataSource extends ResultsDataSourceBase {
   queryStepsUrl = this.baseUrl + '/v2/query-steps';
@@ -221,15 +222,10 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
       const stepsResponse = responseData.steps;
       const stepResponseKeys = new Set(Object.keys(stepsResponse[0]));
       const selectedFields = (query.properties || []).filter(field => stepResponseKeys.has(field));
-      const fields = this.processFields(selectedFields, stepsResponse);
-
-      if (query.showMeasurements) {
-        const measurementFields = this.processMeasurementData(stepsResponse);
-        fields.push(...measurementFields);
-      }
+      const fields = this.processFields(selectedFields, stepsResponse, query.showMeasurements || false);
       return {
         refId: query.refId,
-        fields: fields,
+        fields,
       };
     } else {
       const responseData = await this.querySteps(
@@ -305,59 +301,133 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
 
   private processFields(
     selectedFields: StepsProperties[],
-    stepsResponse: StepsResponseProperties[]
-  ): Array<{ name: StepsProperties; values: string[]; type: FieldType }> {
-    return selectedFields.map(field => {
-      const isTimeField = field === StepsPropertiesOptions.UPDATED_AT || field === StepsPropertiesOptions.STARTED_AT;
+    stepsResponse: StepsResponseProperties[],
+    showMeasurements: boolean
+  ): Array<{ name: string; values: string[]; type: FieldType }> {
+    const columns: Array<{ name: string; values: string[]; type: FieldType }> = [];
+    stepsResponse.forEach(step => {
+      // Process selected step fields
+      selectedFields.forEach(field => {
+        const value = this.convertStepPropertyToString(field, step[field]);
+        const fieldType = this.findFieldType(field, value);
+        this.addValueToColumn(columns, field, value, fieldType);
+      });
 
-      const fieldType = isTimeField ? FieldType.time : FieldType.string;
-      const values = stepsResponse.map(data => data[field as keyof StepsResponseProperties]);
+      // Process measurement fields if enabled
+      if (showMeasurements) {
+        // Measurements are defined as the data.parameters which contains a name, else the parameter is ignored.
+        const measurements =
+          step.data?.parameters?.filter(measurement => measurement[MEASUREMENT_NAME_COLUMN]) || [];
 
-      switch (field) {
-        case StepsPropertiesOptions.PROPERTIES:
-        case StepsPropertiesOptions.INPUTS:
-        case StepsPropertiesOptions.OUTPUTS:
-        case StepsPropertiesOptions.DATA:
-          return {
-            name: field,
-            values: values.map(value => (value !== null ? JSON.stringify(value) : '')),
-            type: fieldType,
-          };
-        case StepsPropertiesOptions.STATUS:
-          return { name: field, values: values.map((value: any) => value?.statusType), type: fieldType };
-        default:
-          return { name: field, values, type: fieldType };
+        measurements.forEach(measurement => {
+          const measurementName = measurement[MEASUREMENT_NAME_COLUMN];
+          if (!measurementName) {
+            return;
+          }
+
+          measurementProperties.forEach(property => {
+            const suffix = measurementColumnLabelSuffix[property];
+            const columnName = formatMeasurementColumnName(measurementName, suffix);
+            let value = measurement[property] ?? '';
+            if(!value) {
+              // If the value is empty, skip adding it to the column this is considering
+              // that not all measurements will have high limit, low limit, etc.
+              return;
+            }
+
+            if (property === MEASUREMENT_NAME_COLUMN) {
+              // For the measurement name column, use the measurement values if available
+              value = measurement[MeasurementProperties.MEASUREMENT] ?? '';
+            }
+            const fieldType = this.findFieldType(columnName, value);
+            // normalize the column name to match the previous steps as the current step metadata will be already added
+            this.addValueToColumn(columns, columnName, value, fieldType, true, -1);
+          });
+        });
+      }
+
+      // At the end of processing each step, ensure all columns have the same length
+      // by normalizing the columns.
+      this.normalizeColumns(columns);
+
+    });
+
+    return columns;
+  }
+
+  /**
+   * Adds a value to a column, creating the column if it doesn't exist.
+   * Optionally normalizes columns to the same length before adding.
+   */
+  private addValueToColumn(
+    columns: Array<{ name: string; values: string[]; type: FieldType }>,
+    field: string,
+    value: string,
+    type: FieldType = FieldType.string,
+    normalizeOnAdd = false,
+    relativeLengthToNormalize = 0
+  ): void {
+    let column = columns.find(c => c.name === field);
+
+    if (!column) {
+      column = { name: field, values: [], type };
+      columns.push(column);
+      if (normalizeOnAdd) {
+        this.normalizeColumns(columns, relativeLengthToNormalize);
+      }
+    }
+    column.values.push(value);
+  }
+
+  /**
+   * Ensures all columns have the same number of values by filling with empty strings.
+   * @param columns Columns to normalize.
+   * @param relativeLength Additional length to add to the maximum column length.
+   */
+  private normalizeColumns(
+    columns: Array<{ name: string; values: string[]; type: FieldType }>,
+    relativeLength = 0
+  ): void {
+    const targetLength = Math.max(0, ...columns.map(c => c.values.length)) + relativeLength;
+    columns.forEach(col => {
+      const missing = targetLength - col.values.length;
+      if (missing > 0) {
+        col.values.push(...Array(missing).fill(''));
       }
     });
   }
 
-  private processMeasurementData(stepsResponse: StepsResponseProperties[]): any[] {
-    const fieldToParameterProperty = {
-      'Measurement Name': 'name',
-      'Measurement Value': 'measurement',
-      'Status': 'status',
-      'Unit': 'units',
-      'Low Limit': 'lowLimit',
-      'High Limit': 'highLimit',
-    };
-    const measurementFields = Object.keys(fieldToParameterProperty) as Array<keyof typeof fieldToParameterProperty>;
+  private convertStepPropertyToString(field: string, value: any): string {
+    if (value === undefined || value === null) {
+        return '';
+    }
+    switch (field) {
+        case StepsPropertiesOptions.PROPERTIES:
+        case StepsPropertiesOptions.INPUTS:
+        case StepsPropertiesOptions.OUTPUTS:
+        case StepsPropertiesOptions.DATA:
+            return value !== null ? JSON.stringify(value) : '';
+        case StepsPropertiesOptions.STATUS:
+            return (value as any)?.statusType || '';
+        default:
+            return value.toString();
+    }
+}
 
-    return measurementFields.map(measurementField => {
-      const values = stepsResponse.map(step => {
-        if (!step.data?.parameters) {
-          return [];
-        }
-        return step.data.parameters.map(
-          param => param[fieldToParameterProperty[measurementField]]
-        );
-      });
-
-      return {
-        name: measurementField,
-        values,
-        type: FieldType.string,
-      };
-    });
+  private findFieldType(field: string, value: string): FieldType {
+    const isTimeField =
+      field === StepsPropertiesOptions.UPDATED_AT ||
+      field === StepsPropertiesOptions.STARTED_AT;
+    if(isTimeField) {
+      return FieldType.time;
+    }
+    
+    const isValueANumber = !isNaN(Number(value)) && value.trim() !== '';
+    if (isValueANumber) {
+      return FieldType.number;
+    }
+    
+    return FieldType.string;
   }
 
   /**

--- a/src/datasources/results/query-handlers/query-steps/__snapshots__/QueryStepsDataSource.test.ts.snap
+++ b/src/datasources/results/query-handlers/query-steps/__snapshots__/QueryStepsDataSource.test.ts.snap
@@ -12,72 +12,86 @@ exports[`QueryStepsDataSource query should convert properties to Grafana fields 
 ]
 `;
 
-exports[`QueryStepsDataSource query should convert step measurements to Grafana fields when show measurments is enabled 1`] = `
+exports[`QueryStepsDataSource query should convert step measurements to Grafana fields when show measurements is enabled 1`] = `
 [
   {
-    "name": "Measurement Name",
-    "type": "string",
+    "name": "Voltage",
+    "type": "number",
     "values": [
-      [
-        "Voltage",
-        "Voltage",
-        "Current",
-      ],
+      "3.7",
+      "3.7",
     ],
   },
   {
-    "name": "Measurement Value",
+    "name": "Voltage-Status",
     "type": "string",
     "values": [
-      [
-        "3.7",
-        "3.7",
-        "1.2",
-      ],
+      "Passed",
+      "Passed",
     ],
   },
   {
-    "name": "Status",
+    "name": "Voltage-Unit",
     "type": "string",
     "values": [
-      [
-        "Passed",
-        "Passed",
-        "Failed",
-      ],
+      "V",
+      "V",
     ],
   },
   {
-    "name": "Unit",
-    "type": "string",
+    "name": "Voltage-Low Limit",
+    "type": "number",
     "values": [
-      [
-        "V",
-        "V",
-        "A",
-      ],
+      "3.5",
+      "3.5",
     ],
   },
   {
-    "name": "Low Limit",
-    "type": "string",
+    "name": "Voltage-High Limit",
+    "type": "number",
     "values": [
-      [
-        "3.5",
-        "3.5",
-        "1.0",
-      ],
+      "4.0",
+      "4.0",
     ],
   },
   {
-    "name": "High Limit",
+    "name": "Current",
+    "type": "number",
+    "values": [
+      "",
+      "1.2",
+    ],
+  },
+  {
+    "name": "Current-Status",
     "type": "string",
     "values": [
-      [
-        "4.0",
-        "4.0",
-        "1.5",
-      ],
+      "",
+      "Failed",
+    ],
+  },
+  {
+    "name": "Current-Unit",
+    "type": "string",
+    "values": [
+      "",
+      "A",
+    ],
+  },
+  {
+    "name": "Current-Low Limit",
+    "type": "number",
+    "values": [
+      "",
+      "1.0",
+    ],
+  },
+  {
+    "name": "Current-High Limit",
+    "type": "number",
+    "values": [
+      "",
+      "1.5",
     ],
   },
 ]
@@ -114,6 +128,110 @@ exports[`QueryStepsDataSource query should return total count for valid total co
       },
     ],
     "refId": "A",
+  },
+]
+`;
+
+exports[`QueryStepsDataSource query show measurements is enabled should convert step measurements to Grafana fields as a column 1`] = `
+[
+  {
+    "name": "Voltage",
+    "type": "number",
+    "values": [
+      "3.7",
+      "3.7",
+    ],
+  },
+  {
+    "name": "Voltage-Status",
+    "type": "string",
+    "values": [
+      "Passed",
+      "Passed",
+    ],
+  },
+  {
+    "name": "Voltage-Unit",
+    "type": "string",
+    "values": [
+      "V",
+      "V",
+    ],
+  },
+  {
+    "name": "Voltage-Low Limit",
+    "type": "number",
+    "values": [
+      "3.5",
+      "3.5",
+    ],
+  },
+  {
+    "name": "Voltage-High Limit",
+    "type": "number",
+    "values": [
+      "4.0",
+      "4.0",
+    ],
+  },
+  {
+    "name": "Current",
+    "type": "number",
+    "values": [
+      "",
+      "1.2",
+    ],
+  },
+  {
+    "name": "Current-Status",
+    "type": "string",
+    "values": [
+      "",
+      "Failed",
+    ],
+  },
+  {
+    "name": "Current-Unit",
+    "type": "string",
+    "values": [
+      "",
+      "A",
+    ],
+  },
+  {
+    "name": "Current-Low Limit",
+    "type": "number",
+    "values": [
+      "",
+      "1.0",
+    ],
+  },
+  {
+    "name": "Current-High Limit",
+    "type": "number",
+    "values": [
+      "",
+      "1.5",
+    ],
+  },
+]
+`;
+
+exports[`QueryStepsDataSource query show measurements is enabled should create empty cells when measurements are not available 1`] = `
+[
+  {
+    "name": "Current",
+    "type": "number",
+    "values": [
+      "1.2",
+    ],
+  },
+  {
+    "name": "Voltage",
+    "type": "number",
+    "values": [
+      "3.7",
+    ],
   },
 ]
 `;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Currently the measurements (`data.params` of step data) are shown as comma separated values within the same column - it is not much helpful in dashboards since we cannot visualize the data without relying on tedious Grafana transformations.

After initial discussions to display the measurements in tall format (showing each measurement within a step in a new row) vs wide format (showing each of the measurements in a separate column) - it was decided to display measurements in the wide format which is easy for visualization

Snipped from development branch
![image](https://github.com/user-attachments/assets/b3f7b381-450c-4db2-8d45-5b865d02e110)


## 👩‍💻 Implementation

- Updated the data process to go step by step instead of gathering all the data based on the properties selected. This is to ensure that when the measurement columns are added, they are added to the same row as the metadata columns.
- Before processing a new step, made sure all the current rows are filled to ensure that the new columns created from the next step does not interfere with the subsequent parsing
- Created a constant utility file for measurement related assumptions

Assumptions made
1. When there are duplicate measurements within the same step, they will be added to the new row - with empty cells corresponding to the metadata columns
2. When a new measurement is found in the step, all the previous rows will be marked with empty cells

## 🧪 Testing

- Added unit tests and verified manually

## ✅ Checklist


- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).