### PR TITLE
fix(results): update default limit of take to 1000

### DIFF
--- a/src/datasources/results/defaultQueries.ts
+++ b/src/datasources/results/defaultQueries.ts
@@ -34,7 +34,7 @@ export const defaultStepsQuery: Omit<QuerySteps, 'refId'> = {
   ] as StepsProperties[],
   orderBy: "STARTED_AT",
   descending: false,
-  recordCount: 10_000,
+  recordCount: 1000,
   useTimeRange: false,
   useTimeRangeFor: undefined,
   partNumberQuery: [],


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

It is decided to reduce the default take of steps query builder to 1000 from 10,000

## 👩‍💻 Implementation

- updated the respective default constant

## 🧪 Testing

- Existing tests cover the test since both the component and the tests refer the same constant, verified manually

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).