### PR TITLE
fix(results): Enable "return count" by default

### DIFF
--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -483,7 +483,6 @@ describe('QueryStepsDataSource', () => {
           100,
           undefined,
           undefined,
-          true
         );
         const response = await responsePromise;
   
@@ -520,7 +519,6 @@ describe('QueryStepsDataSource', () => {
             10000,
             undefined,
             undefined,
-            true
           );
           const response = await responsePromise;
     
@@ -580,7 +578,6 @@ describe('QueryStepsDataSource', () => {
           2000,
           undefined,
           undefined,
-          true
         );
 
         await jest.advanceTimersByTimeAsync(0);
@@ -632,7 +629,6 @@ describe('QueryStepsDataSource', () => {
           3000,
           undefined,
           undefined,
-          true
         );
   
         expect(response.steps).toHaveLength(500);
@@ -665,7 +661,6 @@ describe('QueryStepsDataSource', () => {
           1500,
           false,
           undefined,
-          true
         );
         
         await expect(batchPromise)
@@ -718,7 +713,6 @@ describe('QueryStepsDataSource', () => {
           2000,
           undefined,
           undefined,
-          true
         );
 
         const response = await responsePromise;

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -106,7 +106,6 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
     take?: number,
     descending?: boolean,
     resultFilter?: string,
-    returnCount = false,
   ): Promise<QueryStepsResponse> {
     const queryRecord = async (currentTake: number, token?: string): Promise<QueryResponse<StepsResponseProperties>> => {
       const response = await this.querySteps(
@@ -117,7 +116,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
         descending,
         resultFilter,
         token,
-        returnCount
+        true
       );
 
       return {
@@ -212,7 +211,6 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
         query.recordCount,
         query.descending,
         query.resultsQuery,
-        true
       );
 
       if (responseData.steps.length === 0) {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To resolve the issue of indefinite `query-steps` API calls in the results query variable editor, ensure that `returnCount` is always set to true, as batching relies on the `totalCount` value.

## 👩‍💻 Implementation

- Updated `queryStepsInBatches` to always call the `query-steps` API with `returnCount` set to `true`.

## 🧪 Testing

- Updated impacted test cases

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).