### PR TITLE
feat(results): add Result ID field to Results Query Builder

### DIFF
--- a/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
+++ b/src/datasources/results/constants/ResultsQueryBuilder.constants.ts
@@ -2,6 +2,7 @@ import { QueryBuilderOperations } from 'core/query-builder.constants';
 import { QBField } from 'core/types';
 
 export enum ResultsQueryBuilderFieldNames {
+  RESULT_ID = 'Id',
   HOSTNAME = 'HostName',
   KEYWORDS = 'Keywords',
   OPERATOR = 'Operator',
@@ -17,6 +18,14 @@ export enum ResultsQueryBuilderFieldNames {
 }
 
 export const ResultsQueryBuilderFields: Record<string, QBField> = {
+   RESULTID: {
+    label: 'Result ID',
+    dataField: ResultsQueryBuilderFieldNames.RESULT_ID,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+    ],
+  },
   HOSTNAME: {
     label: 'Host name',
     dataField: ResultsQueryBuilderFieldNames.HOSTNAME,
@@ -165,6 +174,7 @@ export const ResultsQueryBuilderFields: Record<string, QBField> = {
 };
 
 export const ResultsQueryBuilderStaticFields = [
+  ResultsQueryBuilderFields.RESULTID,
   ResultsQueryBuilderFields.PROGRAMNAME,
   ResultsQueryBuilderFields.PROPERTIES,
   ResultsQueryBuilderFields.SYSTEMID,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This pull request adds support for a new `Result ID` field in the query builder functionality of the `ResultsQueryBuilder.constants.ts` file. 

## 👩‍💻 Implementation

### Addition of `Result ID` field:

* Added `RESULT_ID` to the `ResultsQueryBuilderFieldNames` enum to define the field name.
* Added `RESULTID` to the `ResultsQueryBuilderFields` object with its label, data field, and filter operations (`EQUALS` and `DOES_NOT_EQUAL`).
* Included `ResultsQueryBuilderFields.RESULTID` in the `ResultsQueryBuilderStaticFields` array to make it a static field.


## 🧪 Testing

Manually verified

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).