### PR TITLE
feat(products, results): handle 504 timeout errors in product and result queries

### DIFF
--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -91,6 +91,16 @@ describe('queryProducts', () => {
       .toThrow('The query failed due to the following error: (status 400) "Error".');
   });
 
+  it('should throw timeOut error when API returns 504 status', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-products' }))
+      .mockReturnValue(createFetchError(504));
+
+    await expect(datastore.queryProducts())
+      .rejects
+      .toThrow('The query to fetch products timed out. Please try again with a smaller record count or a more specific filter.');
+  })
+
   it('should throw error with unknown error when API returns error without status', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-products' }))
@@ -186,6 +196,18 @@ describe('getFamilyNames', () => {
 
     expect(datastore.errorTitle).toBe('Warning during product value query');
     expect(datastore.errorDescription).toContain('Some values may not be available in the query builder lookups due to the following error: \"Error\".');
+  })
+
+  test('should throw timeOut error when API returns 504 status', async () => {
+    datastore.errorTitle = '';
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-product-values' }))
+      .mockReturnValue(createFetchError(504));
+
+    await datastore.getFamilyNames();
+
+    expect(datastore.errorTitle).toBe('Warning during product value query');
+    expect(datastore.errorDescription).toContain('Some values may not be available in the query builder lookups due to the following error: The query to fetch product values timed out. Please try again with a more specific filter.');
   })
 
 });

--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -98,7 +98,7 @@ describe('queryProducts', () => {
 
     await expect(datastore.queryProducts())
       .rejects
-      .toThrow('The query to fetch products timed out. Please try again with a smaller record count or a more specific filter.');
+      .toThrow('The query to fetch products experienced a timeout error. Narrow your query with a more specific filter and try again.');
   })
 
   it('should throw error with unknown error when API returns error without status', async () => {
@@ -207,7 +207,7 @@ describe('getFamilyNames', () => {
     await datastore.getFamilyNames();
 
     expect(datastore.errorTitle).toBe('Warning during product value query');
-    expect(datastore.errorDescription).toContain(`Some values may not be available in the query builder lookups due to a timeout error. Please try again with a more specific filter.`);
+    expect(datastore.errorDescription).toContain(`The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`);
   })
 
 });

--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -207,7 +207,7 @@ describe('getFamilyNames', () => {
     await datastore.getFamilyNames();
 
     expect(datastore.errorTitle).toBe('Warning during product value query');
-    expect(datastore.errorDescription).toContain('Some values may not be available in the query builder lookups due to the following error: The query to fetch product values timed out. Please try again with a more specific filter.');
+    expect(datastore.errorDescription).toContain(`Some values may not be available in the query builder lookups due to a timeout error. Please try again with a more specific filter.`);
   })
 
 });

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -280,12 +280,13 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
 
   private handleQueryProductValuesError(error: unknown): void {
     const errorDetails = extractErrorInfo((error as Error).message);
-    if (errorDetails.statusCode === '504') {
-      errorDetails.message = 'The query to fetch product values timed out. Please try again with a more specific filter.';
-    }
     this.errorTitle = 'Warning during product value query';
-    this.errorDescription = errorDetails.message
-      ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`
-      : 'Some values may not be available in the query builder lookups due to an unknown error.';
+    if (errorDetails.statusCode === '504') {
+      this.errorDescription = `Some values may not be available in the query builder lookups due to a timeout error. Please try again with a more specific filter.`;
+    } else {
+      this.errorDescription = errorDetails.message
+        ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`
+        : 'Some values may not be available in the query builder lookups due to an unknown error.';
+    }
   }
 }

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -80,7 +80,7 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
       if (!errorDetails.statusCode) {
         errorMessage = 'The query failed due to an unknown error.';
       } else if (errorDetails.statusCode === '504') {
-        errorMessage = 'The query to fetch products timed out. Please try again with a smaller record count or a more specific filter.';
+        errorMessage = 'The query to fetch products experienced a timeout error. Narrow your query with a more specific filter and try again.';
       } else {
         errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
       }
@@ -282,7 +282,7 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
     const errorDetails = extractErrorInfo((error as Error).message);
     this.errorTitle = 'Warning during product value query';
     if (errorDetails.statusCode === '504') {
-      this.errorDescription = `Some values may not be available in the query builder lookups due to a timeout error. Please try again with a more specific filter.`;
+      this.errorDescription = `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`;
     } else {
       this.errorDescription = errorDetails.message
         ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -79,6 +79,8 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
       let errorMessage: string;
       if (!errorDetails.statusCode) {
         errorMessage = 'The query failed due to an unknown error.';
+      } else if (errorDetails.statusCode === '504') {
+        errorMessage = 'The query to fetch products timed out. Please try again with a smaller record count or a more specific filter.';
       } else {
         errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
       }
@@ -278,6 +280,9 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
 
   private handleQueryProductValuesError(error: unknown): void {
     const errorDetails = extractErrorInfo((error as Error).message);
+    if (errorDetails.statusCode === '504') {
+      errorDetails.message = 'The query to fetch product values timed out. Please try again with a more specific filter.';
+    }
     this.errorTitle = 'Warning during product value query';
     this.errorDescription = errorDetails.message
       ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`

--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -198,16 +198,21 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
 
   handleQueryValuesError(error: unknown, errorContext: string): void {
     const errorDetails = extractErrorInfo((error as Error).message);
-    let detailedMessage = '';
-    try {
-      const parsed = JSON.parse(errorDetails.message);
-      detailedMessage = parsed?.message || errorDetails.message;
-    } catch {
-      detailedMessage = errorDetails.message;
-    }
     this.errorTitle = `Warning during ${errorContext} value query`;
-    this.errorDescription = errorDetails.message
-      ? `Some values may not be available in the query builder lookups due to the following error:${detailedMessage}.`
-      : 'Some values may not be available in the query builder lookups due to an unknown error.';
+
+    if (errorDetails.statusCode === '504') {
+      this.errorDescription = `Some values may not be available in the query builder lookups due to a timeout error. Please try again with a more specific filter.`;
+    } else {
+      let detailedMessage = '';
+      try {
+        const parsed = JSON.parse(errorDetails.message);
+        detailedMessage = parsed?.message || errorDetails.message;
+      } catch {
+        detailedMessage = errorDetails.message;
+      }
+      this.errorDescription = errorDetails.message
+        ? `Some values may not be available in the query builder lookups due to the following error:${detailedMessage}.`
+        : 'Some values may not be available in the query builder lookups due to an unknown error.';
+    }
   }
 }

--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -201,7 +201,7 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
     this.errorTitle = `Warning during ${errorContext} value query`;
 
     if (errorDetails.statusCode === '504') {
-      this.errorDescription = `Some values may not be available in the query builder lookups due to a timeout error. Please try again with a more specific filter.`;
+      this.errorDescription = `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`;
     } else {
       let detailedMessage = '';
       try {

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -75,7 +75,7 @@ describe('QueryResultsDataSource', () => {
     
         await expect(datastore.queryResults())
           .rejects
-          .toThrow('The query to fetch results timed out. Please try again with a smaller record count or a more specific filter.');
+          .toThrow('The query to fetch results experienced a timeout error. Narrow your query with a more specific filter and try again.');
       })
   });
 
@@ -346,7 +346,7 @@ describe('QueryResultsDataSource', () => {
       await datastore.getPartNumbers();
 
       expect(datastore.errorTitle).toBe('Warning during result value query');
-      expect(datastore.errorDescription).toContain('Some values may not be available in the query builder lookups due to a timeout error. Please try again with a more specific filter.');
+      expect(datastore.errorDescription).toContain('The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.');
     })
   });
   

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -37,7 +37,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
       if (!errorDetails.statusCode) {
         errorMessage = 'The query failed due to an unknown error.';
       } else if (errorDetails.statusCode === '504') {
-        errorMessage = 'The query to fetch results timed out. Please try again with a smaller record count or a more specific filter.';
+        errorMessage = 'The query to fetch results experienced a timeout error. Narrow your query with a more specific filter and try again.';
       } else {
         errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
       }

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -36,6 +36,8 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
 
       if (!errorDetails.statusCode) {
         errorMessage = 'The query failed due to an unknown error.';
+      } else if (errorDetails.statusCode === '504') {
+        errorMessage = 'The query to fetch results timed out. Please try again with a smaller record count or a more specific filter.';
       } else {
         errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
       }

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -106,7 +106,7 @@ describe('QueryStepsDataSource', () => {
 
     await expect(datastore.querySteps())
       .rejects
-      .toThrow('The query to fetch steps timed out. Please try again with a smaller record count or a more specific filter.');
+      .toThrow('The query to fetch steps experienced a timeout error. Narrow your query with a more specific filter and try again.');
   })
   });
 
@@ -1087,7 +1087,7 @@ describe('QueryStepsDataSource', () => {
 
       expect(stepsPathLookupValues).toEqual([]);
       expect(datastore.errorTitle).toBe('Warning during step paths value query');
-      expect(datastore.errorDescription).toContain('Some values may not be available in the query builder lookups due to a timeout error. Please try again with a more specific filter.');
+      expect(datastore.errorDescription).toContain('The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.');
     })
 
     it('should handle error in query-result-values when loading step path', async () => {
@@ -1459,7 +1459,7 @@ describe('QueryStepsDataSource', () => {
 
           expect(stepsPathLookupValues).toEqual([]);
           expect(datastore.errorTitle).toBe('Warning during step paths value query');
-          expect(datastore.errorDescription).toContain('Some values may not be available in the query builder lookups due to a timeout error. Please try again with a more specific filter.');
+          expect(datastore.errorDescription).toContain('The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.');
         })
 
         it('should handle error in query-result-values when loading step path', async () => {

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -91,7 +91,7 @@ describe('QueryStepsDataSource', () => {
 
       await expect(datastore.querySteps())
         .rejects
-        .toThrow('The query to fetch steps failed due to the following error: (status 400) "Error".');
+        .toThrow('The query failed due to the following error: (status 400) "Error".');
 
       expect(publishMock).toHaveBeenCalledWith({
         type: 'alert-error',
@@ -106,7 +106,7 @@ describe('QueryStepsDataSource', () => {
 
     await expect(datastore.querySteps())
       .rejects
-      .toThrow('The query timed out. Please try again with a smaller record count or a more specific filter.');
+      .toThrow('The query to fetch steps timed out. Please try again with a smaller record count or a more specific filter.');
   })
   });
 

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -67,6 +67,8 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
       let errorMessage: string;
       if (!errorDetails.statusCode) {
         errorMessage = 'The query failed due to an unknown error.';
+      } else if (errorDetails.statusCode === '504') {
+        errorMessage = 'The query to fetch steps timed out. Please try again with a smaller record count or a more specific filter.';
       } else {
         errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
       }

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -68,7 +68,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
       if (!errorDetails.statusCode) {
         errorMessage = 'The query failed due to an unknown error.';
       } else if (errorDetails.statusCode === '504') {
-        errorMessage = 'The query to fetch steps timed out. Please try again with a smaller record count or a more specific filter.';
+        errorMessage = 'The query to fetch steps experienced a timeout error. Narrow your query with a more specific filter and try again.';
       } else {
         errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
       }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
Current Implementation of error handling doesn't handle timeout scenarios (HTTP 504 status code) which contains a html page as the error message. This PR handles the 504 - Timeout Error in Products and results datasource.

## 👩‍💻 Implementation


### Enhanced Error Handling for Timeout Scenarios:

#### Updates to `ProductsDataSource`:
* Added logic to handle HTTP 504 errors in the `ProductsDataSource` class, providing a specific timeout error message for `queryProducts` and `queryProductValues` API calls. )

#### Updates to `ResultsDataSourceBase`:
* Implemented timeout error handling for value queries in the `ResultsDataSourceBase` class, ensuring descriptive error titles and messages. 

#### Updates to `QueryStepsDataSource`:
* Incorporated timeout error handling for step-related queries in the `QueryStepsDataSource` class, including `querySteps` and `loadStepPaths` methods.


## 🧪 Testing

* Added tests to validate timeout error handling for `query` and `queryValues` methods. 


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).