### PR TITLE
fix(workorders,testplans): Show column names when there is no data and show refID in output's column name

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -181,7 +181,7 @@ describe('runQuery', () => {
     expect(result.fields[1].values).toEqual(['Active', 'Completed']);
   });
 
-  test('returns empty data frame when no test plans are available', async () => {
+  test('should return field without values when no test plans are available', async () => {
     const query = {
       refId: 'A',
       outputType: OutputType.Properties,

--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -195,7 +195,9 @@ describe('runQuery', () => {
 
     const result = await datastore.runQuery(query, mockOptions);
 
-    expect(result.fields).toHaveLength(0);
+    expect(result.fields).toHaveLength(2);
+    expect(result.fields[0]).toEqual({"name": "Name", "type": "string", "values": []});
+    expect(result.fields[1]).toEqual({"name": "State", "type": "string", "values": []});
   });
 
   test('returns total count when output type is TotalCount', async () => {
@@ -217,7 +219,7 @@ describe('runQuery', () => {
     const result = await datastore.runQuery(query, mockOptions);
 
     expect(result.fields).toHaveLength(1);
-    expect(result.fields[0].name).toEqual('Total count');
+    expect(result.fields[0].name).toEqual('A');
     expect(result.fields[0].values).toEqual([42]);
   });
 
@@ -240,7 +242,7 @@ describe('runQuery', () => {
     const result = await datastore.runQuery(query, mockOptions);
 
     expect(result.fields).toHaveLength(1);
-    expect(result.fields[0].name).toEqual('Total count');
+    expect(result.fields[0].name).toEqual('A');
     expect(result.fields[0].values).toEqual([0]);
   });
 

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -101,9 +101,10 @@ describe('WorkOrdersDataSource', () => {
   });
 
   describe('runQuery', () => {
-    test('should return empty field when no work orders are found', async () => {
+    test('should return field with no data when no work orders are found', async () => {
       const mockQuery = {
         refId: 'A',
+        properties: [WorkOrderPropertiesOptions.NAME],
         outputType: OutputType.Properties,
         queryBy: 'filter',
       };
@@ -112,10 +113,11 @@ describe('WorkOrdersDataSource', () => {
 
       const response = await datastore.runQuery(mockQuery, {} as DataQueryRequest);
 
-      expect(response.fields).toHaveLength(0);
+      expect(response.fields).toHaveLength(1);
+      expect(response.fields).toEqual([{"name": "Work order name", "type": "string", "values": []}]);
       expect(response.refId).toEqual('A');
       expect(response.name).toEqual('A');
-      expect(datastore.queryWorkordersData).toHaveBeenCalledWith('filter', undefined, undefined, undefined, undefined);
+      expect(datastore.queryWorkordersData).toHaveBeenCalledWith('filter', ["NAME"], undefined, undefined, undefined);
     });
 
     test('processes work orders query when outputType is Properties', async () => {
@@ -141,7 +143,7 @@ describe('WorkOrdersDataSource', () => {
 
       const result = await datastore.runQuery(mockQuery, {} as DataQueryRequest);
 
-      expect(result.fields).toEqual([{ name: 'Total count', values: [42] }]);
+      expect(result.fields).toEqual([{ name: 'B', values: [42] }]);
       expect(result.refId).toEqual('B');
     });
 

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -101,7 +101,7 @@ describe('WorkOrdersDataSource', () => {
   });
 
   describe('runQuery', () => {
-    test('should return field with no data when no work orders are found', async () => {
+    test('should return field without values when no work orders are found', async () => {
       const mockQuery = {
         refId: 'A',
         properties: [WorkOrderPropertiesOptions.NAME],

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -58,7 +58,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
       return {
         refId: query.refId,
         name: query.refId,
-        fields: [{ name: 'Total count', values: [totalCount] }],
+        fields: [{ name: query.refId, values: [totalCount] }],
       };
     }
   }
@@ -107,46 +107,39 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
       query.take
     );
 
-    if (workOrders.length > 0) {
-      const mappedFields = query.properties?.map(property => {
-        const field = WorkOrderProperties[property];
-        const fieldType = this.isTimeField(field.value) ? FieldType.time : FieldType.string;
-        const fieldName = field.label;
+    const mappedFields = query.properties?.map(property => {
+      const field = WorkOrderProperties[property];
+      const fieldType = this.isTimeField(field.value) ? FieldType.time : FieldType.string;
+      const fieldName = field.label;
 
-        // TODO: Add mapping for other field types
-        const fieldValue = workOrders.map(workOrder => {
-          switch (field.value) {
-            case WorkOrderPropertiesOptions.WORKSPACE:
-                const workspace = workspaces.get(workOrder.workspace);
-                return workspace ? workspace.name : workOrder.workspace;
-            case WorkOrderPropertiesOptions.ASSIGNED_TO:
-            case WorkOrderPropertiesOptions.CREATED_BY:
-            case WorkOrderPropertiesOptions.REQUESTED_BY:
-            case WorkOrderPropertiesOptions.UPDATED_BY:
-              const userId = workOrder[field.field] as string ?? '';
-              const user = users.get(userId);
-              return user ? UsersUtils.getUserFullName(user) : userId;
-            case WorkOrderPropertiesOptions.PROPERTIES:
-                const properties = workOrder.properties || {};
-                return JSON.stringify(properties);
-            default:
-              return workOrder[field.field] ?? '';
-          }
-        });
-
-        return { name: fieldName, values: fieldValue, type: fieldType };
+      // TODO: Add mapping for other field types
+      const fieldValue = workOrders.map(workOrder => {
+        switch (field.value) {
+          case WorkOrderPropertiesOptions.WORKSPACE:
+              const workspace = workspaces.get(workOrder.workspace);
+              return workspace ? workspace.name : workOrder.workspace;
+          case WorkOrderPropertiesOptions.ASSIGNED_TO:
+          case WorkOrderPropertiesOptions.CREATED_BY:
+          case WorkOrderPropertiesOptions.REQUESTED_BY:
+          case WorkOrderPropertiesOptions.UPDATED_BY:
+            const userId = workOrder[field.field] as string ?? '';
+            const user = users.get(userId);
+            return user ? UsersUtils.getUserFullName(user) : userId;
+          case WorkOrderPropertiesOptions.PROPERTIES:
+              const properties = workOrder.properties || {};
+              return JSON.stringify(properties);
+          default:
+            return workOrder[field.field] ?? '';
+        }
       });
 
-      return {
-        refId: query.refId,
-        name: query.refId,
-        fields: mappedFields ?? [],
-      };
-    }
+      return { name: fieldName, values: fieldValue, type: fieldType };
+    });
+
     return {
       refId: query.refId,
       name: query.refId,
-      fields: [],
+      fields: mappedFields ?? [],
     };
   }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To show column names when there is no data and to show outputs from the "Total count" output type as it's refID instead of "Total Count"
![image](https://github.com/user-attachments/assets/08289b05-888c-4d4a-89eb-0235dcf8f2b7)
![image](https://github.com/user-attachments/assets/3f3a120b-34ef-4c51-a8ef-833def47c20e)
![image](https://github.com/user-attachments/assets/d7926534-3c7c-41a1-a317-861fe37d6666)
![image](https://github.com/user-attachments/assets/409ef79c-343d-4628-a61f-cbf5f286760d)

## 👩‍💻 Implementation

- Remove hardcoded value of "Total count" and passed query name
- Remove the check of length on data when returning fields

## 🧪 Testing

- Updated unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).