### PR TITLE
fix(results): Persist query changes between query type switches

### DIFF
--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -82,43 +82,6 @@ describe('ResultsQueryEditor', () => {
         expect(mockOnRunQuery).toHaveBeenCalled();
       });
     });
-
-    test('should preserve previous results query when switching to steps and restore it when switching back', async () => {
-      const customResultsQuery = {
-        refId: 'A',
-        queryType: QueryType.Results,
-        properties: ['ID', 'STATUS'],
-        orderBy: 'STARTED_AT',
-        descending: true,
-        recordCount: 1000,
-        useTimeRange: false,
-        useTimeRangeFor: 'startedAt',
-        queryBy: '',
-      };
-      const renderResult = renderElement(customResultsQuery);
-
-      const stepsRadioButton = renderResult.getByRole('radio', { name: QueryType.Steps });
-      await userEvent.click(stepsRadioButton);
-      await waitFor(() => {
-        expect(mockOnChange).toHaveBeenCalledWith(
-          expect.objectContaining({
-            ...defaultStepsQuery,
-            refId: 'A',
-          })
-        );
-      });
-
-      const resultsRadioButton = renderResult.getByRole('radio', { name: QueryType.Results });
-      await userEvent.click(resultsRadioButton);
-      await waitFor(() => {
-        expect(mockOnChange).toHaveBeenCalledWith(
-          expect.objectContaining({
-            properties: ['ID', 'STATUS'],
-            queryType: QueryType.Results,
-          })
-        );
-      });
-    });
   });
 
   describe('Editor', () => {

--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -83,7 +83,44 @@ describe('ResultsQueryEditor', () => {
       });
     });
   });
+  test('should save resultsQuery value when switching to steps and back to results', async () => {
+    // Start with Results query type and set a custom value for resultsQuery
+    const customResultsQuery = {
+      refId: 'A',
+      queryType: QueryType.Results,
+      customField: 'customValue',
+    } as ResultsQuery;
 
+    let currentQuery = { ...customResultsQuery };
+    const onChange = jest.fn((query) => {
+      currentQuery = { ...currentQuery, ...query };
+      renderResult.rerender(
+        React.createElement(ResultsQueryEditor, { ...defaultProps, query: currentQuery, onChange })
+      );
+    });
+
+    const renderResult = render(
+      React.createElement(ResultsQueryEditor, { ...defaultProps, query: currentQuery, onChange })
+    );
+
+    // Switch to Steps
+    userEvent.click(renderResult.getByRole('radio', { name: QueryType.Steps }));
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining(defaultStepsQuery));
+    });
+
+    // Switch back to Results
+    userEvent.click(renderResult.getByRole('radio', { name: QueryType.Results }));
+    await waitFor(() => {
+      // The customField should be preserved in resultsQuery state and merged back in
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...defaultResultsQuery,
+          customField: 'customValue',
+        })
+      );
+    });
+  });
   describe('Editor', () => {
     test('should render QueryResultsEditor when query type is results', () => {
       const renderResult = renderElement();

--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -82,6 +82,43 @@ describe('ResultsQueryEditor', () => {
         expect(mockOnRunQuery).toHaveBeenCalled();
       });
     });
+
+    test('should preserve previous results query when switching to steps and restore it when switching back', async () => {
+      const customResultsQuery = {
+        refId: 'A',
+        queryType: QueryType.Results,
+        properties: ['ID', 'STATUS'],
+        orderBy: 'STARTED_AT',
+        descending: true,
+        recordCount: 1000,
+        useTimeRange: false,
+        useTimeRangeFor: 'startedAt',
+        queryBy: '',
+      };
+      const renderResult = renderElement(customResultsQuery);
+
+      const stepsRadioButton = renderResult.getByRole('radio', { name: QueryType.Steps });
+      await userEvent.click(stepsRadioButton);
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ...defaultStepsQuery,
+            refId: 'A',
+          })
+        );
+      });
+
+      const resultsRadioButton = renderResult.getByRole('radio', { name: QueryType.Results });
+      await userEvent.click(resultsRadioButton);
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            properties: ['ID', 'STATUS'],
+            queryType: QueryType.Results,
+          })
+        );
+      });
+    });
   });
 
   describe('Editor', () => {

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -16,7 +16,6 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
   const [stepsQuery, setStepsQuery] = React.useState<QuerySteps>();
 
   query = datasource.prepareQuery(query);
-  console.log('query', query);
 
   const handleQueryChange = useCallback(
     (query: ResultsQuery, runQuery = true): void => {

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -12,7 +12,11 @@ import { QuerySteps } from '../types/QuerySteps.types';
 type Props = QueryEditorProps<ResultsDataSource, ResultsQuery, ResultsDataSourceOptions>;
 
 export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+  const [resultsQuery, setResultsQuery] = React.useState<QueryResults>();
+  const [stepsQuery, setStepsQuery] = React.useState<QuerySteps>();
+
   query = datasource.prepareQuery(query);
+  console.log('query', query);
 
   const handleQueryChange = useCallback(
     (query: ResultsQuery, runQuery = true): void => {
@@ -25,20 +29,14 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
 
   const handleQueryTypeChange = useCallback((queryType: QueryType): void => {
     if (queryType === QueryType.Results) {
-      handleQueryChange({
-        ...query,
-          ...defaultResultsQuery
-        }
-      );
+      setStepsQuery(query as QuerySteps);
+      handleQueryChange({ ...defaultResultsQuery, ...resultsQuery, refId: query.refId});
     }
     if (queryType === QueryType.Steps) {
-      handleQueryChange({
-        ...query,
-        ...defaultStepsQuery
-      }
-    );
+      setResultsQuery(query as QueryResults);
+      handleQueryChange({...defaultStepsQuery, ...stepsQuery, refId: query.refId});
     }
-  }, [query, handleQueryChange]);
+  }, [query, resultsQuery, stepsQuery, handleQueryChange]);
 
   return (
     <>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
In the current implementation, switching the query type clears all data from the previous selection. We need to preserve the query state so that when a user switches back to a previous query type, their earlier input is retained and visible.

## 👩‍💻 Implementation

* Added two new state variables, `resultsQuery` and `stepsQuery`, using React's `useState` to manage query data for `Results` and `Steps` query types.
* Updated the `handleQueryTypeChange` function to use the newly introduced state variables (`resultsQuery` and `stepsQuery`) for constructing queries when switching between query types. This ensures better separation and management of query-specific data. 

## 🧪 Testing

* Added test to verify that the states are preserved.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).