### PR TITLE
feat(results): update measurement columns to include units

### DIFF
--- a/src/datasources/results/constants/stepMeasurements.constants.ts
+++ b/src/datasources/results/constants/stepMeasurements.constants.ts
@@ -10,7 +10,6 @@ export enum MeasurementProperties {
 export const measurementProperties: MeasurementProperties[] = [
     MeasurementProperties.NAME,
     MeasurementProperties.STATUS,
-    MeasurementProperties.UNITS,
     MeasurementProperties.LOW_LIMIT,
     MeasurementProperties.HIGH_LIMIT
 ];
@@ -18,13 +17,24 @@ export const measurementProperties: MeasurementProperties[] = [
 export const measurementColumnLabelSuffix: Record<MeasurementProperties, string> = {
     [MeasurementProperties.NAME]: '',
     [MeasurementProperties.STATUS]: 'Status',
-    [MeasurementProperties.UNITS]: 'Unit',
+    [MeasurementProperties.UNITS]: '',
     [MeasurementProperties.MEASUREMENT]: '',
     [MeasurementProperties.LOW_LIMIT]: 'Low Limit',
     [MeasurementProperties.HIGH_LIMIT]: 'High Limit'
 };
 
 export const MEASUREMENT_NAME_COLUMN = MeasurementProperties.NAME;
+export const MEASUREMENT_UNITS_COLUMN = MeasurementProperties.UNITS;
+
+
+const MEASUREMENT_COLUMN_NAME_FORMAT = '{name} ({unit})';
+
+export function formatMeasurementValueColumnName(measurementName: string, unit: string): string {
+    if (!unit) {
+        return measurementName;
+    }
+    return MEASUREMENT_COLUMN_NAME_FORMAT.replace('{name}', measurementName).replace('{unit}', unit);
+}
 
 const COLUMN_NAME_FORMAT = '{name}-{suffix}';
 

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -313,6 +313,45 @@ describe('QueryStepsDataSource', () => {
         const fields = response.data[0].fields as Field[];
         expect(fields).toMatchSnapshot();
       });
+
+      test('should create new columns when units are different in the same measurement', async () => {
+        const mockQueryStepsMeasurementResponse: QueryStepsResponse = {
+          steps: [
+            {
+              stepId: '1',
+              data: {
+                text: 'Step 1',
+                parameters: [{ name: 'Current', measurement: '1.2', units: 'A'}]
+              }
+            },
+             {
+              stepId: '2',
+              data: {
+                text: 'Step 1',
+                parameters: [{ name: 'Current', measurement: '370', units: 'mA'}]
+              }
+            },
+          ],
+          totalCount: 1
+        };
+  
+        backendServer.fetch
+          .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-steps', method: 'POST' }))
+          .mockReturnValue(createFetchResponse(mockQueryStepsMeasurementResponse));
+  
+        const query = buildQuery(
+          {
+            refId: 'A',
+            outputType: OutputType.Data,
+            showMeasurements: true
+          },
+        );
+  
+        const response = await datastore.query(query);
+  
+        const fields = response.data[0].fields as Field[];
+        expect(fields).toMatchSnapshot();
+      });
     })
 
 

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -21,7 +21,7 @@ import { QueryResponse } from 'core/types';
 import { queryInBatches } from 'core/utils';
 import { MAX_PATH_TAKE_PER_REQUEST, QUERY_PATH_REQUEST_PER_SECOND } from 'datasources/results/constants/QueryStepPath.constants';
 import { extractErrorInfo } from 'core/errors';
-import { formatMeasurementColumnName, MEASUREMENT_NAME_COLUMN, measurementColumnLabelSuffix, MeasurementProperties, measurementProperties } from 'datasources/results/constants/stepMeasurements.constants';
+import { formatMeasurementColumnName, formatMeasurementValueColumnName, MEASUREMENT_NAME_COLUMN, MEASUREMENT_UNITS_COLUMN, measurementColumnLabelSuffix, MeasurementProperties, measurementProperties } from 'datasources/results/constants/stepMeasurements.constants';
 
 export class QueryStepsDataSource extends ResultsDataSourceBase {
   queryStepsUrl = this.baseUrl + '/v2/query-steps';
@@ -315,7 +315,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
 
           measurementProperties.forEach(property => {
             const suffix = measurementColumnLabelSuffix[property];
-            const columnName = formatMeasurementColumnName(measurementName, suffix);
+            let columnName = formatMeasurementColumnName(measurementName, suffix);
             let value = measurement[property] ?? '';
             if(!value) {
               // If the value is empty, skip adding it to the column this is considering
@@ -324,6 +324,8 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
             }
 
             if (property === MEASUREMENT_NAME_COLUMN) {
+              // For the measurement name column, format the column name with units if available
+              columnName = formatMeasurementValueColumnName(measurementName, measurement[MEASUREMENT_UNITS_COLUMN] || '');
               // For the measurement name column, use the measurement values if available
               value = measurement[MeasurementProperties.MEASUREMENT] ?? '';
             }

--- a/src/datasources/results/query-handlers/query-steps/__snapshots__/QueryStepsDataSource.test.ts.snap
+++ b/src/datasources/results/query-handlers/query-steps/__snapshots__/QueryStepsDataSource.test.ts.snap
@@ -50,7 +50,7 @@ exports[`QueryStepsDataSource query should return total count for valid total co
 exports[`QueryStepsDataSource query show measurements is enabled should convert step measurements to Grafana fields as a column 1`] = `
 [
   {
-    "name": "Voltage",
+    "name": "Voltage (V)",
     "type": "number",
     "values": [
       "3.7",
@@ -63,14 +63,6 @@ exports[`QueryStepsDataSource query show measurements is enabled should convert 
     "values": [
       "Passed",
       "Passed",
-    ],
-  },
-  {
-    "name": "Voltage-Unit",
-    "type": "string",
-    "values": [
-      "V",
-      "V",
     ],
   },
   {
@@ -90,7 +82,7 @@ exports[`QueryStepsDataSource query show measurements is enabled should convert 
     ],
   },
   {
-    "name": "Current",
+    "name": "Current (A)",
     "type": "number",
     "values": [
       "",
@@ -103,14 +95,6 @@ exports[`QueryStepsDataSource query show measurements is enabled should convert 
     "values": [
       "",
       "Failed",
-    ],
-  },
-  {
-    "name": "Current-Unit",
-    "type": "string",
-    "values": [
-      "",
-      "A",
     ],
   },
   {
@@ -146,6 +130,25 @@ exports[`QueryStepsDataSource query show measurements is enabled should create e
     "type": "number",
     "values": [
       "3.7",
+    ],
+  },
+]
+`;
+
+exports[`QueryStepsDataSource query show measurements is enabled should create new columns when units are different in the same measurement 1`] = `
+[
+  {
+    "name": "Current (A)",
+    "type": "number",
+    "values": [
+      "1.2",
+    ],
+  },
+  {
+    "name": "Current (mA)",
+    "type": "number",
+    "values": [
+      "370",
     ],
   },
 ]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

When plotting the measurement values, it is impossible to view the unit associated to the measurement. Currently, the Units are displayed as separate column which isn't helpful either. 

## 👩‍💻 Implementation

1. Updated the measurement column name to follow the format _Measurement name (unit)_ (ex: _Output voltage (V)_) when `units` property is available in the `data.parameters` and just Measurement name when units are not available

> Assumption:
> A new column will be created for every unique Measurement name - Unit pair. This would mean that the same measurement (say, _Current_) will have two columns if the units are different (say, _A_ and _mA_). In such cases, it is expected that users should leverage simple Grafana transformations like "Add field from calculation" to merge these columns after proper unit conversions

## 🧪 Testing

- Added tests to verify the behavior

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).