### PR TITLE
fix(results): change Take field layout in Query Editor

### DIFF
--- a/src/datasources/results/components/ResultsQueryEditor.scss
+++ b/src/datasources/results/components/ResultsQueryEditor.scss
@@ -1,7 +1,0 @@
-.results-horizontal-control-group {
-  display: flex;
-}
-
-.results-right-query-controls {
-  padding-left: 8px;
-}

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -2,7 +2,6 @@ import { SelectableValue } from '@grafana/data';
 import { AutoSizeInput, InlineField, MultiSelect, RadioButtonGroup, VerticalGroup } from '@grafana/ui';
 import { enumToOptions, validateNumericInput } from 'core/utils';
 import React, { useEffect, useState } from 'react';
-import '../../ResultsQueryEditor.scss';
 import { QueryResults, ResultsProperties } from 'datasources/results/types/QueryResults.types';
 import { OutputType, TestMeasurementStatus } from 'datasources/results/types/types';
 import { TimeRangeControls } from '../time-range/TimeRangeControls';
@@ -109,13 +108,12 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           </InlineField>
         )}
         <div>
-        <TimeRangeControls
-          query={query}
-          handleQueryChange={(updatedQuery, runQuery) => {
-            handleQueryChange(updatedQuery as QueryResults, runQuery);
-          }}
-        />
-        <div className="results-horizontal-control-group">
+          <TimeRangeControls
+            query={query}
+            handleQueryChange={(updatedQuery, runQuery) => {
+              handleQueryChange(updatedQuery as QueryResults, runQuery);
+            }}
+          />
           <InlineField label={labels.queryBy} labelWidth={26} tooltip={tooltips.queryBy}>
             <ResultsQueryBuilder
               filter={query.queryBy}
@@ -123,33 +121,30 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
               status={enumToOptions(TestMeasurementStatus).map(option => option.value as string)}
               partNumbers={partNumbers}
               globalVariableOptions={datasource.globalVariableOptions()}
-              onChange={(event: any) => onParameterChange(event.detail.linq)}>
-            </ResultsQueryBuilder>
+              onChange={(event: any) => onParameterChange(event.detail.linq)}
+            ></ResultsQueryBuilder>
           </InlineField>
           {query.outputType === OutputType.Data && (
-            <div className="results-right-query-controls">
-              <InlineField 
-                  label={labels.take}
-                  labelWidth={26} 
-                  tooltip={tooltips.recordCount}
-                  invalid={!!recordCountInvalidMessage}
-                  error={recordCountInvalidMessage}
-                >
-                  <AutoSizeInput
-                    minWidth={25}
-                    maxWidth={25}
-                    type="number"
-                    defaultValue={query.recordCount}
-                    onCommitChange={recordCountChange}
-                    placeholder={placeholders.take}
-                    onKeyDown={event => {
-                      validateNumericInput(event);
-                    }}
-                  />
-                </InlineField>
-              </div>
-            )}
-          </div>
+            <InlineField
+              label={labels.take}
+              labelWidth={26}
+              tooltip={tooltips.recordCount}
+              invalid={!!recordCountInvalidMessage}
+              error={recordCountInvalidMessage}
+            >
+              <AutoSizeInput
+                minWidth={25}
+                maxWidth={25}
+                type="number"
+                defaultValue={query.recordCount}
+                onCommitChange={recordCountChange}
+                placeholder={placeholders.take}
+                onKeyDown={event => {
+                  validateNumericInput(event);
+                }}
+              />
+            </InlineField>
+          )}
         </div>
       </VerticalGroup>
       <FloatingError message={datasource.errorTitle} innerMessage={datasource.errorDescription} severity="warning" />

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -2,7 +2,6 @@ import { SelectableValue } from '@grafana/data';
 import { AutoSizeInput, InlineField, InlineSwitch, MultiSelect, RadioButtonGroup, VerticalGroup } from '@grafana/ui';
 import { enumToOptions, validateNumericInput } from 'core/utils';
 import React, { useEffect, useState } from 'react';
-import '../../ResultsQueryEditor.scss';
 import { OutputType } from 'datasources/results/types/types';
 import { TimeRangeControls } from '../time-range/TimeRangeControls';
 import { QuerySteps, StepsProperties } from 'datasources/results/types/QuerySteps.types';
@@ -25,7 +24,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
   useEffect(() => {
     setDisableStepsQueryBuilder(!query.resultsQuery);
   }, [query.resultsQuery]);
-  
+
   const onOutputChange = (outputType: OutputType) => {
     handleQueryChange({ ...query, outputType: outputType });
   };
@@ -62,10 +61,9 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
   };
 
   const onResultsFilterChange = (resultsQuery: string) => {
-    if (resultsQuery === ''){
+    if (resultsQuery === '') {
       handleQueryChange({ ...query, resultsQuery: resultsQuery }, false);
-    }
-    else if (query.resultsQuery !== resultsQuery) {
+    } else if (query.resultsQuery !== resultsQuery) {
       query.resultsQuery = resultsQuery;
       handleQueryChange({ ...query, resultsQuery: resultsQuery });
     }
@@ -125,8 +123,6 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
               handleQueryChange(updatedQuery as QuerySteps, runQuery);
             }}
           />
-        </div>
-        <div className="results-horizontal-control-group">
           <StepsQueryBuilderWrapper
             datasource={datasource}
             resultsQuery={query.resultsQuery}
@@ -136,27 +132,25 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
             disableStepsQueryBuilder={disableStepsQueryBuilder}
           />
           {query.outputType === OutputType.Data && (
-            <div className="results-right-query-controls">
-              <InlineField
-                label={labels.take}
-                labelWidth={26}
-                tooltip={tooltips.recordCount}
-                invalid={!!recordCountInvalidMessage}
-                error={recordCountInvalidMessage}
-              >
-                <AutoSizeInput
-                  minWidth={25}
-                  maxWidth={25}
-                  type="number"
-                  defaultValue={query.recordCount}
-                  onCommitChange={recordCountChange}
-                  placeholder={placeholders.take}
-                  onKeyDown={event => {
-                    validateNumericInput(event);
-                  }}
-                />
-              </InlineField>
-            </div>
+            <InlineField
+              label={labels.take}
+              labelWidth={26}
+              tooltip={tooltips.recordCount}
+              invalid={!!recordCountInvalidMessage}
+              error={recordCountInvalidMessage}
+            >
+              <AutoSizeInput
+                minWidth={25}
+                maxWidth={25}
+                type="number"
+                defaultValue={query.recordCount}
+                onCommitChange={recordCountChange}
+                placeholder={placeholders.take}
+                onKeyDown={event => {
+                  validateNumericInput(event);
+                }}
+              />
+            </InlineField>
           )}
         </div>
       </VerticalGroup>

--- a/src/datasources/results/components/editors/time-range/TimeRangeControls.tsx
+++ b/src/datasources/results/components/editors/time-range/TimeRangeControls.tsx
@@ -14,14 +14,12 @@ export function TimeRangeControls({query, handleQueryChange}: Props) {
   };
 
   return (
-    <div className="results-horizontal-control-group">
-      <InlineField label={labels.useTimeRange} tooltip={tooltips.useTimeRange} labelWidth={26}>
-        <InlineSwitch
-          onChange={event => onUseTimeRangeChecked(event.currentTarget.checked)}
-          value={query.useTimeRange}
-        />
-      </InlineField>
-    </div>
+    <InlineField label={labels.useTimeRange} tooltip={tooltips.useTimeRange} labelWidth={26}>
+      <InlineSwitch
+        onChange={event => onUseTimeRangeChecked(event.currentTarget.checked)}
+        value={query.useTimeRange}
+      />
+    </InlineField>
   );
 }
 


### PR DESCRIPTION

# Pull Request

## 🤨 Rationale

This pull request focuses on cleaning up unused CSS styles and changing the structure of `Take` Field in the result Datasource.

## 👩‍💻 Implementation

*  Removed unnecessary `<div>` wrappers (`results-horizontal-control-group` and `results-right-query-controls`) to simplify the component structure
*  Removed the `results-horizontal-control-group` wrapper to streamline the component presentation. 
* Deleted `.results-horizontal-control-group` and `.results-right-query-controls` styles, which are no longer used in the codebase.

## 🧪 Testing

Verified the UI through Local Development Environment

## UI Change : 
### Existing UI: 
#### Results Query Type: 
![image](https://github.com/user-attachments/assets/22247bd5-6df6-4177-8794-b475ac3efb01)

#### Steps Query Type: 
![image](https://github.com/user-attachments/assets/74ef50e6-19a2-4667-9b46-abe7bd3da388)

### Changed UI : 
#### Results Query Type: 
![image](https://github.com/user-attachments/assets/912a9b05-8d03-4956-8d2e-0712dcea9c9e)

#### Steps Query Type: 
![image](https://github.com/user-attachments/assets/1cf276f6-8a8c-48b9-aaa9-7102f5a9f62d)


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).
