### PR TITLE
fix(core): infinite api calls with `queryInBatch` method

### DIFF
--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -197,6 +197,22 @@ describe('queryInBatches', () => {
     });
   });
 
+  test('should fetch all records in a single request when totalCount is not provided', async () => {
+    mockQueryRecord.mockResolvedValue({
+      data: [{ id: 1 }, { id: 2 }],
+      continuationToken: null,
+    });
+
+    const result = await queryInBatches(mockQueryRecord, queryConfig, 2);
+
+    expect(mockQueryRecord).toHaveBeenCalledTimes(1);
+    expect(mockQueryRecord).toHaveBeenCalledWith(2);
+    expect(result).toEqual({
+      data: [{ id: 1 }, { id: 2 }],
+      continuationToken: null,
+    });
+  });
+
   test('should fetch records in multiple requests when take is greater than maxTakePerRequest', async () => {
     mockQueryRecord
       .mockResolvedValueOnce({

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -143,7 +143,7 @@ export async function queryInBatches<T>(
       Math.min(take - queryResponse.length, totalCount - queryResponse.length) :
       take - queryResponse.length;
 
-    if (remainingRecordsToGet <= 0) {
+    if (remainingRecordsToGet <= 0 || continuationToken === null) {
       return;
     }
 
@@ -157,7 +157,7 @@ export async function queryInBatches<T>(
     }
   };
 
-  while (queryResponse.length < take && (totalCount === undefined || queryResponse.length < totalCount)) {
+  while (queryResponse.length < take && (totalCount === undefined || queryResponse.length < totalCount) && continuationToken !== null) {
     const remainingRequestCount = Math.ceil((take - queryResponse.length) / queryConfig.maxTakePerRequest);
     const requestsInCurrentBatch = Math.min(queryConfig.requestsPerSecond, remainingRequestCount);
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Currently, when the API calls ignore requesting for `recordCount` and the number of records are fetched are less than the requested take, the API calls continue to happen without any end. This occurs as we are not accounting for the factor that `continuationToken` will be `null` when the number of records requested are served.

## 👩‍💻 Implementation

- Updated the `queryInBatches` method to account for `continuationToken` to be `null` to exit the recursion.

## 🧪 Testing

- Added unit tests to validate the behavior

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).