### PR TITLE
fix(results): Handle invalid queries to return empty data

### DIFF
--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.test.tsx
@@ -123,14 +123,14 @@ describe('QueryResultsEditor', () => {
       expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: 500 }));
     });
 
-    it('should show error and not call onChange when Take is greater than Take limit', async () => {
+    it('should show error and call onChange when Take is greater than Take limit', async () => {
       mockHandleQueryChange.mockClear();
 
       await userEvent.clear(recordCount);
       await userEvent.type(recordCount, '10001');
       await userEvent.click(document.body);
 
-      expect(mockHandleQueryChange).not.toHaveBeenCalled();
+      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
       expect(screen.getByText(recordCountErrorMessages.lessOrEqualToTakeLimit)).toBeInTheDocument();
     });
 
@@ -141,7 +141,7 @@ describe('QueryResultsEditor', () => {
       await userEvent.type(recordCount, 'abc');
       await userEvent.click(document.body);
 
-      expect(mockHandleQueryChange).not.toHaveBeenCalled();
+      expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
       expect(screen.getByText(recordCountErrorMessages.greaterOrEqualToZero)).toBeInTheDocument();
     });
   });

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -52,6 +52,8 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
     const value = parseInt((event.target as HTMLInputElement).value, 10);
     if (isRecordCountValid(value, TAKE_LIMIT)) {
       handleQueryChange({ ...query, recordCount: value });
+    } else {
+      handleQueryChange({ ...query, recordCount: undefined });
     }
   };
 

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
@@ -140,25 +140,25 @@ describe('QueryStepsEditor', () => {
         expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: 500 }));
       });
     
-      it('should show error and not call onChange when Take is greater than Take limit', async () => {
+      it('should show error and call onChange with undefined when Take is greater than Take limit', async () => {
         mockHandleQueryChange.mockClear();
       
         await userEvent.clear(recordCount);
         await userEvent.type(recordCount, '10001');
         await userEvent.click(document.body);
       
-        expect(mockHandleQueryChange).not.toHaveBeenCalled();
+        expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
         expect(screen.getByText(recordCountErrorMessages.lessOrEqualToTakeLimit)).toBeInTheDocument();
       });
     
-      it('should show error and not call onChange when Take is not a number', async () => {
+      it('should show error and call onChange with undefined when Take is not a number', async () => {
         mockHandleQueryChange.mockClear();
       
         await userEvent.clear(recordCount);
         await userEvent.type(recordCount, 'abc');
         await userEvent.click(document.body);
       
-        expect(mockHandleQueryChange).not.toHaveBeenCalled();
+        expect(mockHandleQueryChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
         expect(screen.getByText(recordCountErrorMessages.greaterOrEqualToZero)).toBeInTheDocument();
       });
     });

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -40,6 +40,8 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
     const value = parseInt((event.target as HTMLInputElement).value, 10);
     if (isRecordCountValid(value, TAKE_LIMIT)) {
       handleQueryChange({ ...query, recordCount: value });
+    } else {
+      handleQueryChange({ ...query, recordCount: undefined });
     }
   };
 
@@ -62,7 +64,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
 
   const onResultsFilterChange = (resultsQuery: string) => {
     if (resultsQuery === '') {
-      handleQueryChange({ ...query, resultsQuery: resultsQuery }, false);
+      handleQueryChange({ ...query, resultsQuery: resultsQuery });
     } else if (query.resultsQuery !== resultsQuery) {
       query.resultsQuery = resultsQuery;
       handleQueryChange({ ...query, resultsQuery: resultsQuery });

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -82,6 +82,18 @@ describe('QueryResultsDataSource', () => {
       expect(response.data).toMatchSnapshot();
     });
 
+    test('returns empty data for invalid query', async () => {
+      const query = buildQuery({
+        refId: 'A',
+        outputType: OutputType.Data,
+        properties: []
+      });
+
+      const response = await datastore.query(query);
+
+      expect(response.data).toMatchSnapshot();
+    });
+
     test('should set the default order by to "STARTED_AT" and descending to "true"', async () => {
       const query = buildQuery({
         refId: 'A',

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -50,6 +50,12 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
   }
 
   async runQuery(query: QueryResults, options: DataQueryRequest): Promise<DataFrameDTO> {
+    if (query.outputType === OutputType.Data && !this.isQueryValid(query)) {
+      return {
+        refId: query.refId,
+        fields: [],
+      };
+    }
     if (query.queryBy) {
       query.queryBy = transformComputedFieldsQuery(
         this.templateSrv.replace(query.queryBy, options.scopedVars),
@@ -61,7 +67,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
 
     let properties = query.properties;
     let recordCount = query.recordCount;
-    if(query.outputType === OutputType.TotalCount) {
+    if (query.outputType === OutputType.TotalCount) {
       properties = [];
       recordCount = 0;
     }
@@ -82,7 +88,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
           fields: [],
         };
       }
-      
+
       const results = responseData.results;
       const availableFields = Object.keys(results[0]);
       const selectedFields = query.properties?.filter((field) =>
@@ -143,7 +149,7 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
   );
 
   async metricFindQuery(query: ResultsVariableQuery, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
-    if (query.properties !== undefined && this.isTakeValidValid(query.resultsTake!)) {
+    if (query.properties !== undefined && this.isTakeValid(query.resultsTake!)) {
       const filter = query.queryBy ? transformComputedFieldsQuery(
         this.templateSrv.replace(query.queryBy, options?.scopedVars),
         this.resultsComputedDataFields
@@ -167,8 +173,13 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
     return [];
   }
 
-  private isTakeValidValid(value: number): boolean {
+  private isTakeValid(value: number): boolean {
     return !isNaN(value) && value > 0 && value <= TAKE_LIMIT;
+  }
+
+  private isQueryValid(query: QueryResults): boolean {
+    return query.properties!.length !== 0 && query.recordCount !== undefined
+     
   }
 
   shouldRunQuery(_: QueryResults): boolean {

--- a/src/datasources/results/query-handlers/query-results/__snapshots__/QueryResultsDataSource.test.ts.snap
+++ b/src/datasources/results/query-handlers/query-results/__snapshots__/QueryResultsDataSource.test.ts.snap
@@ -17,6 +17,15 @@ exports[`QueryResultsDataSource query returns data for valid data-output-type qu
 ]
 `;
 
+exports[`QueryResultsDataSource query returns empty data for invalid query 1`] = `
+[
+  {
+    "fields": [],
+    "refId": "A",
+  },
+]
+`;
+
 exports[`QueryResultsDataSource query returns no data when QueryResults API returns empty array 1`] = `[]`;
 
 exports[`QueryResultsDataSource query returns total count for valid total count output type queries 1`] = `

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -113,6 +113,18 @@ describe('QueryStepsDataSource', () => {
       expect(response.data).toMatchSnapshot();
     });
 
+    test('returns empty data for invalid query', async () => {
+      const query = buildQuery({
+        refId: 'A',
+        outputType: OutputType.Data,
+        properties: []
+      });
+
+      const response = await datastore.query(query);
+
+      expect(response.data).toMatchSnapshot();
+    });
+
     test('should set default orderby to "STARTED_AT" and descending to "false"', async () => {
       const query = buildQuery({
         refId: 'A',
@@ -1038,6 +1050,8 @@ describe('QueryStepsDataSource', () => {
       const query = {
         refId: 'A',
         resultsQuery: 'new-query',
+        properties: [StepsPropertiesOptions.NAME as StepsProperties],
+        recordCount: 100,
       } as QuerySteps;
       const spy = jest.spyOn(datastore as any, 'loadStepPaths')
 
@@ -1050,6 +1064,8 @@ describe('QueryStepsDataSource', () => {
       const query = {
         refId: 'A',
         resultsQuery: 'ProgramName = "same-query"',
+        properties: [StepsPropertiesOptions.NAME as StepsProperties],
+        recordCount: 100
       } as QuerySteps;
       (datastore as any).previousResultsQuery = "ProgramName = \"same-query\"";
       const spy = jest.spyOn(datastore as any, 'loadStepPaths')
@@ -1079,6 +1095,8 @@ describe('QueryStepsDataSource', () => {
         refId: 'A',
         resultsQuery: 'ProgramName = "Test"',
         outputType: OutputType.Data,
+        properties: [StepsPropertiesOptions.NAME as StepsProperties],
+        recordCount: 100
       } as QuerySteps;
 
       await datastore.runQuery(query, { scopedVars: {} } as DataQueryRequest);
@@ -1093,6 +1111,8 @@ describe('QueryStepsDataSource', () => {
       const query = {
         refId: 'A',
         resultsQuery: 'ProgramName = "Test"',
+        properties: [StepsPropertiesOptions.NAME as StepsProperties],
+        recordCount: 100
       } as QuerySteps;
 
       await datastore.runQuery(query, { scopedVars: {} } as DataQueryRequest);
@@ -1107,6 +1127,8 @@ describe('QueryStepsDataSource', () => {
         refId: 'A',
         resultsQuery: 'ProgramName = "Test"',
         outputType: OutputType.Data,
+        properties: [StepsPropertiesOptions.NAME as StepsProperties],
+        recordCount: 100
       } as QuerySteps;
 
       await datastore.runQuery(query, { scopedVars: {} } as DataQueryRequest);
@@ -1124,6 +1146,8 @@ describe('QueryStepsDataSource', () => {
         refId: 'A',
         resultsQuery: 'ProgramName = "Test"',
         outputType: OutputType.Data,
+        properties: [StepsPropertiesOptions.NAME as StepsProperties],
+        recordCount: 100
       } as QuerySteps;
 
       await datastore.runQuery(query, { scopedVars: {} } as DataQueryRequest);
@@ -1141,6 +1165,8 @@ describe('QueryStepsDataSource', () => {
         refId: 'A',
         resultsQuery: 'ProgramName = "Test"',
         outputType: OutputType.Data,
+        properties: [StepsPropertiesOptions.NAME as StepsProperties],
+        recordCount: 100
       } as QuerySteps;
 
       await datastore.runQuery(query, { scopedVars: {} } as DataQueryRequest);
@@ -1156,6 +1182,8 @@ describe('QueryStepsDataSource', () => {
         refId: 'A',
         resultsQuery: 'ProgramName = "Test"',
         outputType: OutputType.Data,
+        properties: [StepsPropertiesOptions.NAME as StepsProperties],
+        recordCount: 100
       } as QuerySteps;
       
       await datastore.runQuery(query, { scopedVars: {} } as DataQueryRequest);

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -178,7 +178,7 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
   }
   
   async runQuery(query: QuerySteps, options: DataQueryRequest): Promise<DataFrameDTO> {
-    if (!query.resultsQuery) {
+    if (query.outputType === OutputType.Data && !this.isQueryValid(query)) {
       return {
         refId: query.refId,
         fields: [],
@@ -493,6 +493,10 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
 
   private isTakeValid(value: number): boolean {
     return !isNaN(value) && value > 0 && value <= TAKE_LIMIT;
+  }
+
+  private isQueryValid(query: QuerySteps): boolean {
+    return query.resultsQuery !== '' && query.recordCount !== undefined && query.properties!.length > 0;
   }
 
   shouldRunQuery(_: QuerySteps): boolean {

--- a/src/datasources/results/query-handlers/query-steps/__snapshots__/QueryStepsDataSource.test.ts.snap
+++ b/src/datasources/results/query-handlers/query-steps/__snapshots__/QueryStepsDataSource.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`QueryStepsDataSource query returns empty data for invalid query 1`] = `
+[
+  {
+    "fields": [],
+    "refId": "A",
+  },
+]
+`;
+
 exports[`QueryStepsDataSource query should convert properties to Grafana fields 1`] = `
 [
   {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
This pull request  contains changes invalid queries to return empty data and enhance the handling of edge cases, such as exceeding limits or providing invalid input.

## 👩‍💻 Implementation

### Validation Logic Updates:

*  Updated the `onRecordCountChange` function to call `handleQueryChange` with `recordCount: undefined` when the input is invalid.
*  Added `isQueryValid` to validate queries and return empty data for invalid queries in `runQuery`.

## 🧪 Testing

- Updated the Tests and added test to check if Query is valid


## ✅ Checklist


- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).