### PR TITLE
feat(testplans): Add error handling

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -795,6 +795,205 @@ describe('runQuery', () => {
   });
 });
 
+describe('loadWorkspaces', () => {
+  test('returns workspaces', async () => {
+    const result = await datastore.loadWorkspaces();
+
+    expect(result.get('1')?.name).toBe('WorkspaceName');
+    expect(result.get('2')?.name).toBe('AnotherWorkspaceName');
+  });
+
+  it('should handle errors and set error and innerError fields', async () => {
+    jest.spyOn(datastore.workspaceUtils, 'getWorkspaces').mockRejectedValue(new Error('Error'));
+
+    await datastore.loadWorkspaces();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      'Some values may not be available in the query builder lookups due to an unknown error.'
+    );
+  });
+
+  it('should handle errors and set innerError fields with error message detail', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.workspaceUtils, 'getWorkspaces')
+      .mockRejectedValue(
+        new Error('Request failed with status code: 500, Error message: {"message": "Internal Server Error"}')
+      );
+
+    await datastore.loadWorkspaces();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      'Some values may not be available in the query builder lookups due to the following error: Internal Server Error.'
+    );
+  });
+
+  test('should throw timeOut error when API returns 504 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.workspaceUtils, 'getWorkspaces')
+      .mockRejectedValue(new Error('Request failed with status code: 504'));
+
+    await datastore.loadWorkspaces();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
+    );
+  });
+});
+
+describe('loadUsers', () => {
+  test('returns users', async () => {
+    const result = await datastore.loadUsers();
+
+    expect(result.get('1')?.lastName).toBe('1');
+    expect(result.get('2')?.lastName).toBe('2');
+  });
+
+  it('should handle errors and set error and innerError fields', async () => {
+    jest.spyOn(datastore.usersUtils, 'getUsers').mockRejectedValue(new Error('Error'));
+
+    await datastore.loadUsers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      'Some values may not be available in the query builder lookups due to an unknown error.'
+    );
+  });
+
+  it('should handle errors and set innerError fields with error message detail', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.usersUtils, 'getUsers')
+      .mockRejectedValue(
+        new Error('Request failed with status code: 500, Error message: {"message": "Internal Server Error"}')
+      );
+
+    await datastore.loadUsers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      'Some values may not be available in the query builder lookups due to the following error: Internal Server Error.'
+    );
+  });
+
+  test('should throw timeOut error when API returns 504 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.usersUtils, 'getUsers')
+      .mockRejectedValue(new Error('Request failed with status code: 504'));
+
+    await datastore.loadUsers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
+    );
+  });
+});
+
+describe('loadSystemAliases', () => {
+  test('returns system aliases', async () => {
+    const result = await datastore.loadSystemAliases();
+    expect(result.get('1')?.alias).toBe('System 1');
+    expect(result.get('2')?.alias).toBe('System 2');
+  });
+
+  it('should handle errors and set error and innerError fields', async () => {
+    jest.spyOn(datastore.systemUtils, 'getSystemAliases').mockRejectedValue(new Error('Error'));
+
+    await datastore.loadSystemAliases();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      'Some values may not be available in the query builder lookups due to an unknown error.'
+    );
+  });
+
+  it('should handle errors and set innerError fields with error message detail', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.systemUtils, 'getSystemAliases')
+      .mockRejectedValue(
+        new Error('Request failed with status code: 500, Error message: {"message": "Internal Server Error"}')
+      );
+
+    await datastore.loadSystemAliases();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      'Some values may not be available in the query builder lookups due to the following error: Internal Server Error.'
+    );
+  });
+
+  test('should throw timeOut error when API returns 504 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.systemUtils, 'getSystemAliases')
+      .mockRejectedValue(new Error('Request failed with status code: 504'));
+
+    await datastore.loadSystemAliases();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
+    );
+  });
+});
+
+describe('loadProductNamesAndPartNumbers', ()=>{
+  test('returns product names and part numbers', async () => {
+    const result = await datastore.loadProductNamesAndPartNumbers();
+
+    expect(result.get('part-number-1')?.name).toBe('Product 1');
+    expect(result.get('part-number-2')?.name).toBe('Product 2');
+  });
+
+  it('should handle errors and set error and innerError fields', async () => {
+    jest.spyOn(datastore.productUtils, 'getProductNamesAndPartNumbers').mockRejectedValue(new Error('Error'));
+
+    await datastore.loadProductNamesAndPartNumbers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      'Some values may not be available in the query builder lookups due to an unknown error.'
+    );
+  });
+
+  it('should handle errors and set innerError fields with error message detail', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.productUtils, 'getProductNamesAndPartNumbers')
+      .mockRejectedValue(
+        new Error('Request failed with status code: 500, Error message: {"message": "Internal Server Error"}')
+      );
+
+    await datastore.loadProductNamesAndPartNumbers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      'Some values may not be available in the query builder lookups due to the following error: Internal Server Error.'
+    );
+  });
+
+  test('should throw timeOut error when API returns 504 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.productUtils, 'getProductNamesAndPartNumbers')
+      .mockRejectedValue(new Error('Request failed with status code: 504'));
+
+    await datastore.loadProductNamesAndPartNumbers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
+    );
+  });
+})
+
 describe('queryTestPlansInBatches', () => {
   test('queries test plans in batches and returns aggregated response', async () => {
     const mockQueryResponse = {
@@ -843,8 +1042,48 @@ describe('queryTestPlans', () => {
 
     await expect(datastore.queryTestPlans('', OrderByOptions.UPDATED_AT, [Projections.NAME], 1, true))
       .rejects
-      .toThrow('An error occurred while querying test plans: Error: Request to url "/niworkorder/v1/query-testplans" failed with status code: 500. Error message: "Error"');
-  });
+      .toThrow('The query failed due to the following error: (status 500) "Error".');
+    });
+
+    it('should throw timeOut error when API returns 504 status', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/niworkorder/v1/query-testplans' }))
+        .mockReturnValue(createFetchError(504));
+
+      await expect(datastore.queryTestPlans()).rejects.toThrow(
+        'The query to fetch testplans experienced a timeout error. Narrow your query with a more specific filter and try again.'
+      );
+    });
+
+    it('should throw error with unknown error when API returns error without status', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/niworkorder/v1/query-testplans' }))
+        .mockImplementation(() => {
+          throw new Error('Error');
+        });
+
+      await expect(datastore.queryTestPlans()).rejects.toThrow('The query failed due to an unknown error.');
+    });
+
+    it('should publish alertError event when error occurs', async () => {
+      const publishMock = jest.fn();
+      (datastore as any).appEvents = { publish: publishMock };
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/niworkorder/v1/query-testplans' }))
+        .mockReturnValue(createFetchError(400));
+
+      await expect(datastore.queryTestPlans()).rejects.toThrow(
+        'The query failed due to the following error: (status 400) "Error".'
+      );
+
+      expect(publishMock).toHaveBeenCalledWith({
+        type: 'alert-error',
+        payload: [
+          'Error during testplans query',
+          expect.stringContaining('The query failed due to the following error: (status 400) "Error".'),
+        ],
+      });
+    });
 });
 
 describe('metricFindQuery', () => {

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -1,9 +1,9 @@
-import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, FieldType, LegacyMetricFindQueryOptions, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
+import { AppEvents, DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, FieldType, LegacyMetricFindQueryOptions, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { Asset, OrderByOptions, OutputType, Projections, Properties, PropertiesProjectionMap, QueryTemplatesResponse, QueryTestPlansResponse, TemplateResponseProperties, TestPlanResponseProperties, TestPlansQuery, TestPlansVariableQuery } from './types';
 import { getWorkspaceName, getVariableOptions, queryInBatches } from 'core/utils';
-import { QueryBuilderOption, QueryResponse } from 'core/types';
+import { QueryBuilderOption, QueryResponse, Workspace } from 'core/types';
 import { isTimeField, transformDuration } from './utils';
 import { QUERY_TEMPLATES_BATCH_SIZE, QUERY_TEMPLATES_REQUEST_PER_SECOND, QUERY_TEST_PLANS_MAX_TAKE, QUERY_TEST_PLANS_REQUEST_PER_SECOND } from './constants/QueryTestPlans.constants';
 import { AssetUtils } from './asset.utils';
@@ -13,6 +13,10 @@ import { QueryBuilderOperations } from 'core/query-builder.constants';
 import { computedFieldsupportedOperations, ExpressionTransformFunction, transformComputedFieldsQuery } from 'core/query-builder.utils';
 import { UsersUtils } from 'shared/users.utils';
 import { ProductUtils } from 'shared/product.utils';
+import { extractErrorInfo } from 'core/errors';
+import { User } from 'shared/types/QueryUsers.types';
+import { SystemAlias } from 'shared/types/QuerySystems.types';
+import { ProductPartNumberAndName } from 'shared/types/QueryProducts.types';
 
 export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   constructor(
@@ -31,6 +35,8 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   baseUrl = `${this.instanceSettings.url}/niworkorder/v1`;
   queryTestPlansUrl = `${this.baseUrl}/query-testplans`;
   queryTemplatesUrl = `${this.baseUrl}/query-testplan-templates`;
+  errorTitle = '';
+  errorDescription = '';
   assetUtils: AssetUtils;
   workspaceUtils: WorkspaceUtils;
   systemUtils: SystemUtils;
@@ -58,10 +64,10 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   readonly globalVariableOptions = (): QueryBuilderOption[] => getVariableOptions(this);
 
   async runQuery(query: TestPlansQuery, options: DataQueryRequest): Promise<DataFrameDTO> {
-    const workspaces = await this.workspaceUtils.getWorkspaces();
-    const systemAliases = await this.systemUtils.getSystemAliases();
-    const users = await this.usersUtils.getUsers();
-    const products = await this.productUtils.getProductNamesAndPartNumbers();
+    const workspaces = await this.loadWorkspaces();
+    const systemAliases = await this.loadSystemAliases();
+    const users = await this.loadUsers();
+    const products = await this.loadProductNamesAndPartNumbers();
 
     if (query.queryBy) {
       query.queryBy = transformComputedFieldsQuery(
@@ -170,6 +176,49 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
     }
   }
 
+  public async loadWorkspaces(): Promise<Map<string, Workspace>> {
+    try {
+      return await this.workspaceUtils.getWorkspaces();
+    } catch (error) {
+      if (!this.errorTitle) {
+        this.handleDependenciesError(error);
+      }
+      return new Map<string, Workspace>();
+    }
+  }
+
+  public async loadUsers(): Promise<Map<string, User>> {
+    try {
+      return await this.usersUtils.getUsers();
+    } catch (error) {
+      if (!this.errorTitle) {
+        this.handleDependenciesError(error);
+      }
+      return new Map<string, User>();
+    }
+  }
+
+  public async loadSystemAliases(): Promise<Map<string, SystemAlias>> {
+    try {
+      return await this.systemUtils.getSystemAliases();
+    } catch (error) {
+      if (!this.errorTitle) {
+        this.handleDependenciesError(error);
+      }
+      return new Map<string, SystemAlias>();
+    }
+  }
+
+  public async loadProductNamesAndPartNumbers(): Promise<Map<string, ProductPartNumberAndName>> {
+    try {
+      return await this.productUtils.getProductNamesAndPartNumbers();
+    } catch (error) {
+      if (!this.errorTitle) {
+        this.handleDependenciesError(error);
+      }
+      return new Map<string, ProductPartNumberAndName>();
+    }
+  }
 
   shouldRunQuery(query: TestPlansQuery): boolean {
     return true;
@@ -361,7 +410,22 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
       });
       return response;
     } catch (error) {
-      throw new Error(`An error occurred while querying test plans: ${error} `);
+      const errorDetails = extractErrorInfo((error as Error).message);
+      let errorMessage: string;
+      if (!errorDetails.statusCode) {
+        errorMessage = 'The query failed due to an unknown error.';
+      } else if (errorDetails.statusCode === '504') {
+        errorMessage = 'The query to fetch testplans experienced a timeout error. Narrow your query with a more specific filter and try again.';
+      } else {
+        errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+      }
+
+      this.appEvents?.publish?.({
+        type: AppEvents.alertError.name,
+        payload: ['Error during testplans query', errorMessage],
+      });
+
+      throw new Error(errorMessage);
     }
   }
 
@@ -406,6 +470,18 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
       return response.testPlanTemplates;
     } catch (error) {
       throw new Error(`An error occurred while querying test plan templates: ${error} `);
+    }
+  }
+
+  private handleDependenciesError(error: unknown): void {
+    const errorDetails = extractErrorInfo((error as Error).message);
+    this.errorTitle = 'Warning during testplans query';
+    if (errorDetails.statusCode === '504') {
+      this.errorDescription = `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`;
+    } else {
+      this.errorDescription = errorDetails.message
+        ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`
+        : 'Some values may not be available in the query builder lookups due to an unknown error.';
     }
   }
 }

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -10,6 +10,7 @@ import { Workspace } from 'core/types';
 import { SystemAlias } from 'shared/types/QuerySystems.types';
 import { User } from 'shared/types/QueryUsers.types';
 import { ProductPartNumberAndName } from 'shared/types/QueryProducts.types';
+import { FloatingError } from 'core/errors';
 
 type Props = QueryEditorProps<TestPlansDataSource, TestPlansQuery>;
 
@@ -177,6 +178,7 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
           )}
         </HorizontalGroup >
       </VerticalGroup>
+      <FloatingError message={datasource.errorTitle} innerMessage={datasource.errorDescription} severity="warning" />
     </>
   );
 }

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
@@ -10,6 +10,7 @@ import { Workspace } from 'core/types';
 import { SystemAlias } from 'shared/types/QuerySystems.types';
 import { User } from 'shared/types/QueryUsers.types';
 import { ProductPartNumberAndName } from 'shared/types/QueryProducts.types';
+import { FloatingError } from 'core/errors';
 
 type Props = QueryEditorProps<TestPlansDataSource, TestPlansVariableQuery>;
 
@@ -86,54 +87,57 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
   };
 
   return (
-    <VerticalGroup>
-      <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
-        <TestPlansQueryBuilder
-          filter={query.queryBy}
-          workspaces={workspaces}
-          systemAliases={systemAliases}
-          users={users}
-          products={products}
-          globalVariableOptions={datasource.globalVariableOptions()}
-          onChange={(event: any) => onQueryByChange(event.detail.linq)}
-        ></TestPlansQueryBuilder>
-      </InlineField>
-      <div>
-        <InlineField label="OrderBy" labelWidth={25} tooltip={tooltips.orderBy}>
-          <Select
-            options={[...OrderBy] as SelectableValue[]}
-            placeholder="Select a field to set the query order"
-            onChange={onOrderByChange}
-            value={query.orderBy}
-            defaultValue={query.orderBy}
-            width={26}
+    <>
+      <VerticalGroup>
+        <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
+          <TestPlansQueryBuilder
+            filter={query.queryBy}
+            workspaces={workspaces}
+            systemAliases={systemAliases}
+            users={users}
+            products={products}
+            globalVariableOptions={datasource.globalVariableOptions()}
+            onChange={(event: any) => onQueryByChange(event.detail.linq)}
+          ></TestPlansQueryBuilder>
+        </InlineField>
+        <div>
+          <InlineField label="OrderBy" labelWidth={25} tooltip={tooltips.orderBy}>
+            <Select
+              options={[...OrderBy] as SelectableValue[]}
+              placeholder="Select a field to set the query order"
+              onChange={onOrderByChange}
+              value={query.orderBy}
+              defaultValue={query.orderBy}
+              width={26}
+            />
+          </InlineField>
+          <InlineField label="Descending" labelWidth={25} tooltip={tooltips.descending}>
+            <InlineSwitch
+              onChange={event => onDescendingChange(event.currentTarget.checked)}
+              value={query.descending}
+            />
+          </InlineField>
+        </div>
+        <InlineField
+          label="Take"
+          labelWidth={25}
+          tooltip={tooltips.recordCount}
+          invalid={!!recordCountInvalidMessage}
+          error={recordCountInvalidMessage}
+        >
+          <AutoSizeInput
+            minWidth={26}
+            maxWidth={26}
+            type='number'
+            defaultValue={query.recordCount}
+            onCommitChange={recordCountChange}
+            placeholder="Enter record count"
+            onKeyDown={(event) => { validateNumericInput(event) }}
           />
         </InlineField>
-        <InlineField label="Descending" labelWidth={25} tooltip={tooltips.descending}>
-          <InlineSwitch
-            onChange={event => onDescendingChange(event.currentTarget.checked)}
-            value={query.descending}
-          />
-        </InlineField>
-      </div>
-      <InlineField
-        label="Take"
-        labelWidth={25}
-        tooltip={tooltips.recordCount}
-        invalid={!!recordCountInvalidMessage}
-        error={recordCountInvalidMessage}
-      >
-        <AutoSizeInput
-          minWidth={26}
-          maxWidth={26}
-          type='number'
-          defaultValue={query.recordCount}
-          onCommitChange={recordCountChange}
-          placeholder="Enter record count"
-          onKeyDown={(event) => { validateNumericInput(event) }}
-        />
-      </InlineField>
-    </VerticalGroup >
+      </VerticalGroup >
+      <FloatingError message={datasource.errorTitle} innerMessage={datasource.errorDescription} severity="warning" />
+    </>
   );
 }
 

--- a/src/shared/product.utils.test.ts
+++ b/src/shared/product.utils.test.ts
@@ -47,22 +47,6 @@ describe('ProductUtils', () => {
         expect(result.get('part-number-2')).toEqual(products[1]);
     });
 
-    it('should handle errors when loading products', async () => {
-        (ProductUtils as any)['_productCache'] = undefined;
-        jest.spyOn(console, 'error').mockImplementation(() => {});
-        const error = new Error('Failed to fetch products');
-        (queryUntilComplete as jest.Mock)
-            .mockImplementationOnce(() => {
-                return Promise.reject(error);
-            });
-
-        const result = await productUtils.getProductNamesAndPartNumbers();
-
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('Error in loading products:', error);
-        expect(result).toEqual(new Map<string, ProductPartNumberAndName>());
-    });
-
     it('should return cached products if already loaded', async () => {
         (ProductUtils as any)['_productCache'] = undefined;
         await productUtils.getProductNamesAndPartNumbers();

--- a/src/shared/product.utils.ts
+++ b/src/shared/product.utils.ts
@@ -25,17 +25,12 @@ export class ProductUtils {
     }
 
     private async loadProducts(): Promise<Map<string, ProductPartNumberAndName>> {
-        try {
-            const products = await this.queryProductsInBatches();
-            const productMap = new Map<string, ProductPartNumberAndName>();
-            if (products) {
-                products.forEach(product => productMap.set(product.partNumber, product));
-            }
-            return productMap;
-        } catch (error) {
-            console.error('Error in loading products:', error);
-            return new Map<string, ProductPartNumberAndName>();
+        const products = await this.queryProductsInBatches();
+        const productMap = new Map<string, ProductPartNumberAndName>();
+        if (products) {
+            products.forEach(product => productMap.set(product.partNumber, product));
         }
+        return productMap;
     }
 
     private async queryProductsInBatches(): Promise<ProductPartNumberAndName[]> {

--- a/src/shared/system.utils.test.ts
+++ b/src/shared/system.utils.test.ts
@@ -47,21 +47,6 @@ describe('SystemUtils', () => {
         expect(result.get('2')).toEqual(systemAliases[1]);
     });
 
-    it('should handle errors when loading system aliases', async () => {
-        (SystemUtils as any)['_systemAliasCache'] = undefined;
-        jest.spyOn(console, 'error').mockImplementation(() => {});
-        const error = new Error('Failed to fetch systems');
-        (queryUsingSkip as jest.Mock).mockImplementationOnce(() => {
-            return Promise.reject(error);
-        });
-
-        const result = await systemUtils.getSystemAliases();
-
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('Error in loading systems:', error);
-        expect(result).toEqual(new Map<string, SystemAlias>());
-    });
-
     it('should return cached system aliases if already loaded', async () => {
         (SystemUtils as any)['_systemAliasCache'] = undefined;
         await systemUtils.getSystemAliases();

--- a/src/shared/system.utils.ts
+++ b/src/shared/system.utils.ts
@@ -23,17 +23,12 @@ export class SystemUtils {
     }
 
     private async loadSystems(): Promise<Map<string, SystemAlias>> {
-        try {
-            const systems = await this.querySystemsInBatches();
-            const systemAliasMap = new Map<string, SystemAlias>();
-            if (systems) {
-                systems.forEach(system => systemAliasMap.set(system.id, system));
-            }
-            return systemAliasMap;
-        } catch (error) {
-            console.error('Error in loading systems:', error);
-            return new Map<string, SystemAlias>();
+        const systems = await this.querySystemsInBatches();
+        const systemAliasMap = new Map<string, SystemAlias>();
+        if (systems) {
+            systems.forEach(system => systemAliasMap.set(system.id, system));
         }
+        return systemAliasMap;
     }
 
     private async querySystemsInBatches(): Promise<SystemAlias[]> {

--- a/src/shared/users.utils.test.ts
+++ b/src/shared/users.utils.test.ts
@@ -49,20 +49,7 @@ describe('UsersUtils', () => {
     users = new UsersUtils(mockInstanceSettings, mockBackendSrv);
   });
 
-  describe('getUsers', () => {
-    it('should handle errors when fetching users', async () => {
-      jest.spyOn(console, 'error').mockImplementation(() => {});
-      (queryUntilComplete as jest.Mock).mockImplementationOnce(() => {
-        return Promise.reject(new Error('Failed to fetch users'));
-      });
-
-      const result = await users.getUsers();
-
-      expect(console.error).toHaveBeenCalledTimes(1);
-      expect(console.error).toHaveBeenCalledWith('An error occurred while querying users:', expect.any(Error));
-      expect(result).toEqual(new Map<string, UsersUtils>());
-    });
-    
+  describe('getUsers', () => {    
     it('should fetch and cache users', async () => {
       const result = await users.getUsers();
       const expectedUsersMap = new Map<string, User>([

--- a/src/shared/users.utils.ts
+++ b/src/shared/users.utils.ts
@@ -56,18 +56,12 @@ export class UsersUtils {
    * In case of an error during the query, an empty map is returned, and the cache is cleared.
    */
   private async loadUsers(): Promise<Map<string, User>> {
-    try {
-      const users = await this.queryUsersInBatches()
-      const usersMap = new Map<string, User>();
-      users.users.forEach((user) => {
-        usersMap.set(user.id, user);
-      });
-      return usersMap;
-    } catch (error) {
-        console.error('An error occurred while querying users:', error);
-        UsersUtils._usersCache = undefined; // Clear the cache on error
-        return new Map<string, User>();
-    }
+    const users = await this.queryUsersInBatches()
+    const usersMap = new Map<string, User>();
+    users.users.forEach((user) => {
+      usersMap.set(user.id, user);
+    });
+    return usersMap;
   }
 
   /**

--- a/src/shared/workspace.utils.test.ts
+++ b/src/shared/workspace.utils.test.ts
@@ -46,17 +46,4 @@ describe('WorkspaceUtils', () => {
         expect(result.get('1')).toEqual(mockWorkspaces[0]);
         expect(result.get('2')).toEqual(mockWorkspaces[1]);
     });
-
-    it('should handle errors when loading workspaces', async () => {
-        (WorkspaceUtils as any)._workspacesCache = undefined;
-        const error = new Error('API failed');
-        backendSrv.get = jest.fn().mockRejectedValue(error);
-        jest.spyOn(console, 'error').mockImplementation(() => {});
-
-        const result = await workspaceUtils.getWorkspaces();
-
-        expect(result.size).toBe(0);
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('Error in loading workspaces:', error);
-    });
 });

--- a/src/shared/workspace.utils.ts
+++ b/src/shared/workspace.utils.ts
@@ -20,17 +20,12 @@ export class WorkspaceUtils {
     }
 
     private async loadWorkspaces(): Promise<Map<string, Workspace>> {
-        try {
-            const workspaces = await this.fetchWorkspaces();
-            const workspaceMap = new Map<string, Workspace>();
-            if (workspaces) {
-                workspaces.forEach(workspace => workspaceMap.set(workspace.id, workspace));
-            }
-            return workspaceMap;
-        } catch (error) {
-            console.error('Error in loading workspaces:', error);
-            return new Map<string, Workspace>();
+        const workspaces = await this.fetchWorkspaces();
+        const workspaceMap = new Map<string, Workspace>();
+        if (workspaces) {
+            workspaces.forEach(workspace => workspaceMap.set(workspace.id, workspace));
         }
+        return workspaceMap;
     }
 
     private async fetchWorkspaces(): Promise<Workspace[]> {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To show floating errors and warnings when API call fails in testplans datasource

## 👩‍💻 Implementation

- Removed catching of error from utils
- Added floating error in editors
- Added methods to catch and parse errors in datasource

## 🧪 Testing

- Manually verified
- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).