### PR TITLE
feat(workorders): Error handling of workorders

### DIFF
--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -397,7 +397,7 @@ describe('WorkOrdersDataSource', () => {
     it('should handle errors and set error and innerError fields', async () => {
       jest.spyOn(datastore.usersUtils, 'getUsers').mockRejectedValue(new Error('Error'));
 
-      await datastore.loadWorkspaces();
+      await datastore.loadUsers();
 
       expect(datastore.errorTitle).toBe('Warning during workorders query');
       expect(datastore.errorDescription).toContain(
@@ -413,7 +413,7 @@ describe('WorkOrdersDataSource', () => {
           new Error('Request failed with status code: 500, Error message: {"message": "Internal Server Error"}')
         );
 
-      await datastore.loadWorkspaces();
+      await datastore.loadUsers();
 
       expect(datastore.errorTitle).toBe('Warning during workorders query');
       expect(datastore.errorDescription).toContain(
@@ -427,7 +427,7 @@ describe('WorkOrdersDataSource', () => {
         .spyOn(datastore.usersUtils, 'getUsers')
         .mockRejectedValue(new Error('Request failed with status code: 504'));
 
-      await datastore.loadWorkspaces();
+      await datastore.loadUsers();
 
       expect(datastore.errorTitle).toBe('Warning during workorders query');
       expect(datastore.errorDescription).toContain(

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -297,7 +297,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
 
   private handleDependenciesError(error: unknown): void {
     const errorDetails = extractErrorInfo((error as Error).message);
-    this.errorTitle = 'Warning during product value query';
+    this.errorTitle = 'Warning during workorders query';
     if (errorDetails.statusCode === '504') {
       this.errorDescription = `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`;
     } else {

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -1,14 +1,16 @@
-import { DataSourceInstanceSettings, DataQueryRequest, DataFrameDTO, FieldType, TestDataSourceResponse, LegacyMetricFindQueryOptions, MetricFindValue } from '@grafana/data';
+import { DataSourceInstanceSettings, DataQueryRequest, DataFrameDTO, FieldType, TestDataSourceResponse, LegacyMetricFindQueryOptions, MetricFindValue, AppEvents } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { WorkOrdersQuery, OutputType, WorkOrderPropertiesOptions, OrderByOptions, WorkOrder, WorkOrderProperties, QueryWorkOrdersRequestBody, WorkOrdersResponse, WorkOrdersVariableQuery } from './types';
-import { QueryBuilderOption, QueryResponse } from 'core/types';
+import { QueryBuilderOption, QueryResponse, Workspace } from 'core/types';
 import { transformComputedFieldsQuery, ExpressionTransformFunction } from 'core/query-builder.utils';
 import { QueryBuilderOperations } from 'core/query-builder.constants';
 import { getVariableOptions, queryInBatches } from 'core/utils';
 import { QUERY_WORK_ORDERS_MAX_TAKE, QUERY_WORK_ORDERS_REQUEST_PER_SECOND } from './constants/QueryWorkOrders.constants';
 import { WorkspaceUtils } from 'shared/workspace.utils';
 import { UsersUtils } from 'shared/users.utils';
+import { extractErrorInfo } from 'core/errors';
+import { User } from 'shared/types/QueryUsers.types';
 
 export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
   constructor(
@@ -23,6 +25,8 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
 
   baseUrl = `${this.instanceSettings.url}/niworkorder/v1`;
   queryWorkOrdersUrl = `${this.baseUrl}/query-workorders`;
+  errorTitle = '';
+  errorDescription = '';
   workspaceUtils: WorkspaceUtils;
   usersUtils: UsersUtils;
   defaultQuery = {
@@ -97,8 +101,8 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
   }
 
   async processWorkOrdersQuery(query: WorkOrdersQuery): Promise<DataFrameDTO> {
-    const workspaces = await this.workspaceUtils.getWorkspaces();
-    const users = await this.usersUtils.getUsers();
+    const workspaces = await this.loadWorkspaces();
+    const users = await this.loadUsers();
     const workOrders: WorkOrder[] = await this.queryWorkordersData(
       query.queryBy,
       query.properties,
@@ -141,6 +145,28 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
       name: query.refId,
       fields: mappedFields ?? [],
     };
+  }
+
+  public async loadWorkspaces(): Promise<Map<string, Workspace>> {
+    try {
+      return await this.workspaceUtils.getWorkspaces();
+    } catch (error) {
+      if (!this.errorTitle) {
+        this.handleDependenciesError(error);
+      }
+      return new Map<string, Workspace>();
+    }
+  }
+
+  public async loadUsers(): Promise<Map<string, User>> {
+    try {
+      return await this.usersUtils.getUsers();
+    } catch (error) {
+      if (!this.errorTitle) {
+        this.handleDependenciesError(error);
+      }
+      return new Map<string, User>();
+    }
   }
 
   async queryWorkordersData(
@@ -194,7 +220,22 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
       let response = await this.post<WorkOrdersResponse>(this.queryWorkOrdersUrl, body);
       return response;
     } catch (error) {
-      throw new Error(`An error occurred while querying workorders: ${error}`);
+      const errorDetails = extractErrorInfo((error as Error).message);
+      let errorMessage: string;
+      if (!errorDetails.statusCode) {
+        errorMessage = 'The query failed due to an unknown error.';
+      } else if (errorDetails.statusCode === '504') {
+        errorMessage = 'The query to fetch workorders experienced a timeout error. Narrow your query with a more specific filter and try again.';
+      } else {
+        errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+      }
+
+      this.appEvents?.publish?.({
+        type: AppEvents.alertError.name,
+        payload: ['Error during workorders query', errorMessage],
+      });
+
+      throw new Error(errorMessage);
     }
   }
 
@@ -252,5 +293,17 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
     ];
 
     return timeFields.includes(field);
+  }
+
+  private handleDependenciesError(error: unknown): void {
+    const errorDetails = extractErrorInfo((error as Error).message);
+    this.errorTitle = 'Warning during product value query';
+    if (errorDetails.statusCode === '504') {
+      this.errorDescription = `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`;
+    } else {
+      this.errorDescription = errorDetails.message
+        ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`
+        : 'Some values may not be available in the query builder lookups due to an unknown error.';
+    }
   }
 }

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.test.tsx
@@ -12,22 +12,18 @@ const mockOnRunQuery = jest.fn();
 const mockDatasource = {
   prepareQuery: jest.fn((query: WorkOrdersQuery) => query),
   globalVariableOptions: jest.fn(() => []),
-  workspaceUtils: {
-    getWorkspaces: jest.fn().mockResolvedValue(
-        new Map([
-            ['1', { id: '1', name: 'WorkspaceName' }],
-            ['2', { id: '2', name: 'AnotherWorkspaceName' }],
-        ])
-    )
-  },
-  usersUtils: {
-    getUsers: jest.fn().mockResolvedValue(
+  loadWorkspaces: jest.fn().mockResolvedValue(
       new Map([
-        ['1', { id: '1', firstName: 'User', lastName: '1' }],
-        ['2', { id: '2', firstName: 'User', lastName: '2' }],
+          ['1', { id: '1', name: 'WorkspaceName' }],
+          ['2', { id: '2', name: 'AnotherWorkspaceName' }],
       ])
-    ),
-  },
+  ),
+  loadUsers: jest.fn().mockResolvedValue(
+    new Map([
+      ['1', { id: '1', firstName: 'User', lastName: '1' }],
+      ['2', { id: '2', firstName: 'User', lastName: '2' }],
+    ])
+  ),
 } as unknown as WorkOrdersDataSource;
 
 const defaultProps: QueryEditorProps<WorkOrdersDataSource, WorkOrdersQuery> = {
@@ -202,7 +198,7 @@ describe('WorkOrdersQueryEditor', () => {
   it('should load workspaces and set them in state', async () => {
     await renderElement();
 
-    const workspaces = await mockDatasource.workspaceUtils.getWorkspaces();
+    const workspaces = await mockDatasource.loadWorkspaces();
     expect(workspaces).toBeDefined();
     expect(workspaces).toEqual(
         new Map([
@@ -215,7 +211,7 @@ describe('WorkOrdersQueryEditor', () => {
   it('should load users and set them in state', async () => {
     await renderElement();
 
-    const users = await mockDatasource.usersUtils.getUsers();
+    const users = await mockDatasource.loadUsers();
     expect(users).toBeDefined();
     expect(users).toEqual(
       new Map([

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
@@ -16,6 +16,7 @@ import { TAKE_LIMIT, takeErrorMessages, tooltips } from '../constants/QueryEdito
 import { validateNumericInput } from 'core/utils';
 import { Workspace } from 'core/types';
 import { User } from 'shared/types/QueryUsers.types';
+import { FloatingError } from 'core/errors';
 
 type Props = QueryEditorProps<WorkOrdersDataSource, WorkOrdersQuery>;
 
@@ -26,7 +27,7 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
   const [workspaces, setWorkspaces] = useState<Workspace[] | null>(null);
   useEffect(() => {
     const loadWorkspaces = async () => {
-      const workspaces = await datasource.workspaceUtils.getWorkspaces();
+      const workspaces = await datasource.loadWorkspaces();
       setWorkspaces(Array.from(workspaces.values()));
     };
 
@@ -37,7 +38,7 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
   const [users, setUsers] = useState<User[] | null>(null);
   useEffect(() => {
     const loadUsers = async () => {
-      const users = await datasource.usersUtils.getUsers();
+      const users = await datasource.loadUsers();
       setUsers(Array.from(users.values()));
     };
 
@@ -180,6 +181,7 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
           </div>
         </VerticalGroup>
       </HorizontalGroup>
+      <FloatingError message={datasource.errorTitle} innerMessage={datasource.errorDescription} severity="warning" />
     </>
   );
 }

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
@@ -12,22 +12,18 @@ const mockOnRunQuery = jest.fn();
 const mockDatasource = {
   prepareQuery: jest.fn((query: WorkOrdersVariableQuery) => query),
   globalVariableOptions: jest.fn(() => []),
-  workspaceUtils: {
-    getWorkspaces: jest.fn().mockResolvedValue(
-        new Map([
-            ['1', { id: '1', name: 'WorkspaceName' }],
-            ['2', { id: '2', name: 'AnotherWorkspaceName' }],
-        ])
-    )
-  },
-  usersUtils: {
-    getUsers: jest.fn().mockResolvedValue(
+  getWorkspaces: jest.fn().mockResolvedValue(
       new Map([
-        ['1', { id: '1', firstName: 'User', lastName: '1' }],
-        ['2', { id: '2', firstName: 'User', lastName: '2' }],
+          ['1', { id: '1', name: 'WorkspaceName' }],
+          ['2', { id: '2', name: 'AnotherWorkspaceName' }],
       ])
-    ),
-  },
+  ),
+  getUsers: jest.fn().mockResolvedValue(
+    new Map([
+      ['1', { id: '1', firstName: 'User', lastName: '1' }],
+      ['2', { id: '2', firstName: 'User', lastName: '2' }],
+    ])
+  ),
 } as unknown as WorkOrdersDataSource;
 
 const defaultProps: QueryEditorProps<WorkOrdersDataSource, WorkOrdersVariableQuery> = {
@@ -105,7 +101,7 @@ describe('WorkOrdersVariableQueryEditor', () => {
   it('should load workspaces and set them in state', async () => {
     await renderElement();
 
-    const workspaces = await mockDatasource.workspaceUtils.getWorkspaces();
+    const workspaces = await mockDatasource.loadWorkspaces();
     expect(workspaces).toBeDefined();
     expect(workspaces).toEqual(
         new Map([
@@ -118,7 +114,7 @@ describe('WorkOrdersVariableQueryEditor', () => {
   it('should load users and set them in state', async () => {
     renderElement();
 
-    const users = await mockDatasource.usersUtils.getUsers();
+    const users = await mockDatasource.loadUsers();
     expect(users).toBeDefined();
     expect(users).toEqual(
       new Map([

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
@@ -12,13 +12,13 @@ const mockOnRunQuery = jest.fn();
 const mockDatasource = {
   prepareQuery: jest.fn((query: WorkOrdersVariableQuery) => query),
   globalVariableOptions: jest.fn(() => []),
-  getWorkspaces: jest.fn().mockResolvedValue(
+  loadWorkspaces: jest.fn().mockResolvedValue(
       new Map([
           ['1', { id: '1', name: 'WorkspaceName' }],
           ['2', { id: '2', name: 'AnotherWorkspaceName' }],
       ])
   ),
-  getUsers: jest.fn().mockResolvedValue(
+  loadUsers: jest.fn().mockResolvedValue(
     new Map([
       ['1', { id: '1', firstName: 'User', lastName: '1' }],
       ['2', { id: '2', firstName: 'User', lastName: '2' }],

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
@@ -19,7 +19,7 @@ export function WorkOrdersVariableQueryEditor({ query, onChange, datasource }: P
   const [workspaces, setWorkspaces] = useState<Workspace[] | null>(null);
   useEffect(() => {
     const loadWorkspaces = async () => {
-      const workspaces = await datasource.workspaceUtils.getWorkspaces();
+      const workspaces = await datasource.loadWorkspaces();
       setWorkspaces(Array.from(workspaces.values()));
     };
 
@@ -29,7 +29,7 @@ export function WorkOrdersVariableQueryEditor({ query, onChange, datasource }: P
   const [users, setUsers] = useState<User[] | null>(null);
   useEffect(() => {
     const loadUsers = async () => {
-      const users = await datasource.usersUtils.getUsers();
+      const users = await datasource.loadUsers();
       setUsers(Array.from(users.values()));
     };
 

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
@@ -8,6 +8,7 @@ import { TAKE_LIMIT, takeErrorMessages, tooltips } from '../constants/QueryEdito
 import { validateNumericInput } from 'core/utils';
 import { Workspace } from 'core/types';
 import { User } from 'shared/types/QueryUsers.types';
+import { FloatingError } from 'core/errors';
 
 type Props = QueryEditorProps<WorkOrdersDataSource, WorkOrdersVariableQuery>;
 
@@ -73,53 +74,56 @@ export function WorkOrdersVariableQueryEditor({ query, onChange, datasource }: P
   };
 
   return (
-    <VerticalGroup>
-      <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
-        <WorkOrdersQueryBuilder
-          filter={query.queryBy}
-          workspaces={workspaces}
-          users={users}
-          globalVariableOptions={datasource.globalVariableOptions()}
-          onChange={(event: any) => onQueryByChange(event.detail.linq)}
-        ></WorkOrdersQueryBuilder>
-      </InlineField>
-      <div>
-        <InlineField label="OrderBy" labelWidth={25} tooltip={tooltips.orderBy}>
-          <Select
-            options={[...OrderBy] as SelectableValue[]}
-            placeholder="Select a field to set the query order"
-            onChange={onOrderByChange}
-            value={query.orderBy}
-            defaultValue={query.orderBy}
-            width={26}
+    <>
+      <VerticalGroup>
+        <InlineField label="Query By" labelWidth={25} tooltip={tooltips.queryBy}>
+          <WorkOrdersQueryBuilder
+            filter={query.queryBy}
+            workspaces={workspaces}
+            users={users}
+            globalVariableOptions={datasource.globalVariableOptions()}
+            onChange={(event: any) => onQueryByChange(event.detail.linq)}
+          ></WorkOrdersQueryBuilder>
+        </InlineField>
+        <div>
+          <InlineField label="OrderBy" labelWidth={25} tooltip={tooltips.orderBy}>
+            <Select
+              options={[...OrderBy] as SelectableValue[]}
+              placeholder="Select a field to set the query order"
+              onChange={onOrderByChange}
+              value={query.orderBy}
+              defaultValue={query.orderBy}
+              width={26}
+            />
+          </InlineField>
+          <InlineField label="Descending" labelWidth={25} tooltip={tooltips.descending}>
+            <InlineSwitch
+              onChange={event => onDescendingChange(event.currentTarget.checked)}
+              value={query.descending}
+            />
+          </InlineField>
+        </div>
+        <InlineField
+          label="Take"
+          labelWidth={25}
+          tooltip={tooltips.take}
+          invalid={!!recordCountInvalidMessage}
+          error={recordCountInvalidMessage}
+        >
+          <AutoSizeInput
+            minWidth={26}
+            maxWidth={26}
+            type="number"
+            defaultValue={query.take}
+            onCommitChange={onTakeChange}
+            placeholder="Enter record count"
+            onKeyDown={event => {
+              validateNumericInput(event);
+            }}
           />
         </InlineField>
-        <InlineField label="Descending" labelWidth={25} tooltip={tooltips.descending}>
-          <InlineSwitch
-            onChange={event => onDescendingChange(event.currentTarget.checked)}
-            value={query.descending}
-          />
-        </InlineField>
-      </div>
-      <InlineField
-        label="Take"
-        labelWidth={25}
-        tooltip={tooltips.take}
-        invalid={!!recordCountInvalidMessage}
-        error={recordCountInvalidMessage}
-      >
-        <AutoSizeInput
-          minWidth={26}
-          maxWidth={26}
-          type="number"
-          defaultValue={query.take}
-          onCommitChange={onTakeChange}
-          placeholder="Enter record count"
-          onKeyDown={event => {
-            validateNumericInput(event);
-          }}
-        />
-      </InlineField>
-    </VerticalGroup>
+      </VerticalGroup>
+      <FloatingError message={datasource.errorTitle} innerMessage={datasource.errorDescription} severity="warning" />
+    </>
   );
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To show floating errors and warnings when API call fails in workorders datasource

## 👩‍💻 Implementation

- Added floating error in editors
- Added methods to catch and parse errors in datasource

## 🧪 Testing

- Manually verified
- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).