### PR TITLE
fix(results): run query on initialization when switching datasources

### DIFF
--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -140,6 +140,17 @@ describe('ResultsQueryEditor', () => {
       expect(renderResult.queryByTestId('query-steps-editor')).toBeInTheDocument();
       expect(renderResult.queryByTestId('query-results-editor')).not.toBeInTheDocument();
     });
+
+    test('should call onRunQuery on init', () => {
+      const query = {
+        refId: 'A',
+      }
+
+      renderElement(query);
+      expect(mockOnRunQuery).toHaveBeenCalled();
+      expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining(query));
+      
+    })
   });
 
   describe('Datasource', () => {

--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -148,7 +148,7 @@ describe('ResultsQueryEditor', () => {
 
       renderElement(query);
       expect(mockOnRunQuery).toHaveBeenCalled();
-      expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining(query));
+      expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ ...defaultResultsQuery, queryType: QueryType.Results, refId: 'A' }));
       
     })
   });

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { ResultsDataSource } from '../ResultsDataSource';
-import { QueryType, ResultsDataSourceOptions, ResultsQuery } from '../types/types';
+import { defaultResultsQueryType, QueryType, ResultsDataSourceOptions, ResultsQuery } from '../types/types';
 import { QueryResultsEditor } from './editors/query-results/QueryResultsEditor';
 import { QueryResults } from '../types/QueryResults.types';
 import { defaultResultsQuery, defaultStepsQuery } from '../defaultQueries';
@@ -12,7 +12,6 @@ import { QuerySteps } from '../types/QuerySteps.types';
 type Props = QueryEditorProps<ResultsDataSource, ResultsQuery, ResultsDataSourceOptions>;
 
 export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
-  const [queryType, setQueryType] = React.useState(query.queryType);
   const [resultsQuery, setResultsQuery] = React.useState<QueryResults>();
   const [stepsQuery, setStepsQuery] = React.useState<QuerySteps>();
 
@@ -29,8 +28,6 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
   );
 
   const handleQueryTypeChange = useCallback((queryType: QueryType): void => {
-    setQueryType(queryType);
-  
     if (queryType === QueryType.Results) {
       setStepsQuery(query as QuerySteps);
       handleQueryChange({
@@ -52,10 +49,9 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
 
   React.useEffect(() => {
     if (!query.queryType) {
-      const firstQueryType = Object.values(QueryType)[0];
-      handleQueryTypeChange(firstQueryType);
+      handleQueryTypeChange(defaultResultsQueryType);
     }
-  }, [query.queryType, handleQueryTypeChange, query, queryType]);
+  }, [query.queryType, handleQueryTypeChange]);
 
   return (
     <>

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -12,6 +12,7 @@ import { QuerySteps } from '../types/QuerySteps.types';
 type Props = QueryEditorProps<ResultsDataSource, ResultsQuery, ResultsDataSourceOptions>;
 
 export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+  const [queryType, setQueryType] = React.useState(query.queryType);
   const [resultsQuery, setResultsQuery] = React.useState<QueryResults>();
   const [stepsQuery, setStepsQuery] = React.useState<QuerySteps>();
 
@@ -28,11 +29,14 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
   );
 
   const handleQueryTypeChange = useCallback((queryType: QueryType): void => {
+    setQueryType(queryType);
+  
     if (queryType === QueryType.Results) {
       setStepsQuery(query as QuerySteps);
       handleQueryChange({
         ...defaultResultsQuery,
         ...resultsQuery,
+        queryType: QueryType.Results,
         refId: query.refId
       });
     }
@@ -45,6 +49,13 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
       });
     }
   }, [query, resultsQuery, stepsQuery, handleQueryChange]);
+
+  React.useEffect(() => {
+    if (!query.queryType) {
+      const firstQueryType = Object.values(QueryType)[0];
+      handleQueryTypeChange(firstQueryType);
+    }
+  }, [query.queryType, handleQueryTypeChange, query, queryType]);
 
   return (
     <>

--- a/src/datasources/results/defaultQueries.ts
+++ b/src/datasources/results/defaultQueries.ts
@@ -3,7 +3,6 @@ import { QueryStepsDefaultValues, StepsProperties } from "./types/QuerySteps.typ
 import { OutputType, QueryType } from "./types/types";
 
 export const defaultResultsQuery: Omit<QueryResultsDefaultValues, 'refId'> = {
-  queryType: QueryType.Results,
   outputType: OutputType.Data,
   properties: [
     ResultsPropertiesOptions.PROGRAM_NAME,

--- a/src/datasources/results/types/types.ts
+++ b/src/datasources/results/types/types.ts
@@ -1,7 +1,7 @@
 import { DataQuery, DataSourceJsonData } from '@grafana/schema';
 
 export interface ResultsQuery extends DataQuery {
-  queryType: QueryType;
+  queryType?: QueryType;
 }
 
 export enum QueryType {

--- a/src/datasources/results/types/types.ts
+++ b/src/datasources/results/types/types.ts
@@ -9,6 +9,8 @@ export enum QueryType {
   Steps = 'Steps'
 }
 
+export const defaultResultsQueryType: QueryType = QueryType.Results;
+
 export enum OutputType {
   Data = 'Data',
   TotalCount = 'Total Count'


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
The current implementation does not call run Query when switched from other datasource.

This pull request introduces changes to the `ResultsQueryEditor` component by adding default handling for `queryType`, modifying the `ResultsQuery` type to make `queryType` optional, and ensuring `onRunQuery` is called during initialization.

## 👩‍💻 Implementation

* Introduced a `useEffect` to assign a default `queryType` if none is provided. 

* Made the `queryType` property in the `ResultsQuery` interface optional to account for cases where it is not explicitly set.
* Removed the default `queryType` from `defaultResultsQuery` to allow for dynamic assignment during initialization.
## 🧪 Testing

* Added a test to verify that `onRunQuery` is called during initialization and that the `onChange` callback is invoked with the correct query object.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).