### PR TITLE
fix(workorders,testplans): Return field type as string for all fields from datasource

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -3,7 +3,7 @@ import { TestPlansDataSource } from "./TestPlansDataSource";
 import { BackendSrv } from "@grafana/runtime";
 import { createFetchError, createFetchResponse, requestMatching, setupDataSource } from "test/fixtures";
 import { OrderByOptions, OutputType, Projections, Properties, QueryTestPlansResponse, TestPlansVariableQuery } from "./types";
-import { DataQueryRequest, LegacyMetricFindQueryOptions } from "@grafana/data";
+import { DataQueryRequest, FieldType, LegacyMetricFindQueryOptions } from "@grafana/data";
 
 let datastore: TestPlansDataSource, backendServer: MockProxy<BackendSrv>;
 
@@ -817,6 +817,29 @@ describe('runQuery', () => {
       undefined,
       true
     );
+  });
+
+  test('should return type as string type', async () => {
+    const mockQuery = {
+      refId: 'A',
+      outputType: OutputType.Properties,
+      properties: [Properties.ID, Properties.UPDATED_AT],
+    };
+
+    const testPlansResponse = {
+      testPlans: [
+        { id: '1', updatedAt: '2023-01-02T00:00:00Z' },
+        { id: '2', updatedAt: '2023-01-05T00:00:00Z' },
+      ],
+    };
+
+    jest.spyOn(datastore, 'queryTestPlansInBatches').mockResolvedValue(testPlansResponse);
+
+    const result = await datastore.runQuery(mockQuery, {} as DataQueryRequest);
+
+    expect(result.fields).toHaveLength(2);
+    expect(result.fields[0].type).toEqual(FieldType.string);
+    expect(result.fields[1].type).toEqual(FieldType.string);
   });
 });
 

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -1,4 +1,4 @@
-import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, LegacyMetricFindQueryOptions, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
+import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, FieldType, LegacyMetricFindQueryOptions, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { Asset, OrderByOptions, OutputType, Projections, Properties, PropertiesProjectionMap, QueryTemplatesResponse, QueryTestPlansResponse, TemplateResponseProperties, TestPlanResponseProperties, TestPlansQuery, TestPlansVariableQuery } from './types';
@@ -94,6 +94,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
       const fields = projectionAndFields?.map(data => {
         const label = data.label;
         const field = data.field;
+        const fieldType = FieldType.string;
         const values = testPlans.map(data => data[field as unknown as keyof TestPlanResponseProperties] as any);
 
         const fieldValues = values.map(value => {
@@ -143,7 +144,8 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
 
         return {
           name: label,
-          values: fieldValues
+          values: fieldValues,
+          type: fieldType,
         };
       });
       return {

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -1,4 +1,4 @@
-import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, FieldType, LegacyMetricFindQueryOptions, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
+import { DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, LegacyMetricFindQueryOptions, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { Asset, OrderByOptions, OutputType, Projections, Properties, PropertiesProjectionMap, QueryTemplatesResponse, QueryTestPlansResponse, TemplateResponseProperties, TestPlanResponseProperties, TestPlansQuery, TestPlansVariableQuery } from './types';
@@ -94,7 +94,6 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
       const fields = projectionAndFields?.map(data => {
         const label = data.label;
         const field = data.field;
-        const fieldType = isTimeField(field) ? FieldType.time : FieldType.string;
         const values = testPlans.map(data => data[field as unknown as keyof TestPlanResponseProperties] as any);
 
         const fieldValues = values.map(value => {
@@ -144,8 +143,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
 
         return {
           name: label,
-          values: fieldValues,
-          type: fieldType,
+          values: fieldValues
         };
       });
       return {

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -3,7 +3,7 @@ import { MockProxy } from 'jest-mock-extended';
 import { setupDataSource, requestMatching, createFetchResponse, createFetchError } from 'test/fixtures';
 import { WorkOrdersDataSource } from './WorkOrdersDataSource';
 import { OrderByOptions, OutputType, State, Type, WorkOrder, WorkOrderPropertiesOptions, WorkOrdersVariableQuery } from './types';
-import { DataQueryRequest, Field, LegacyMetricFindQueryOptions } from '@grafana/data';
+import { DataQueryRequest, Field, FieldType, LegacyMetricFindQueryOptions } from '@grafana/data';
 import { QUERY_WORK_ORDERS_MAX_TAKE, QUERY_WORK_ORDERS_REQUEST_PER_SECOND } from './constants/QueryWorkOrders.constants';
 import { queryInBatches } from 'core/utils';
 
@@ -333,6 +333,27 @@ describe('WorkOrdersDataSource', () => {
       );
 
       jest.useRealTimers();
+    });
+
+    test('should return type as string type', async () => {
+      const mockQuery = {
+        refId: 'A',
+        outputType: OutputType.Properties,
+        properties: [WorkOrderPropertiesOptions.NAME, WorkOrderPropertiesOptions.UPDATED_AT],
+      };
+
+      const workOrdersResponse = [
+        {name: 'WorkOrder1', updatedAt: '2023-01-02T00:00:00Z'},
+        {name: 'WorkOrder2', updatedAt: '2023-01-05T00:00:00Z'},
+      ];
+
+      jest.spyOn(datastore, 'queryWorkordersData').mockResolvedValue(workOrdersResponse as WorkOrder[]);
+
+      const result = await datastore.runQuery(mockQuery, {} as DataQueryRequest);
+
+      expect(result.fields).toHaveLength(2);
+      expect(result.fields[0].type).toEqual(FieldType.string);
+      expect(result.fields[1].type).toEqual(FieldType.string);
     });
   });
 

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -1,4 +1,4 @@
-import { DataSourceInstanceSettings, DataQueryRequest, DataFrameDTO, FieldType, TestDataSourceResponse, LegacyMetricFindQueryOptions, MetricFindValue } from '@grafana/data';
+import { DataSourceInstanceSettings, DataQueryRequest, DataFrameDTO, TestDataSourceResponse, LegacyMetricFindQueryOptions, MetricFindValue } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { WorkOrdersQuery, OutputType, WorkOrderPropertiesOptions, OrderByOptions, WorkOrder, WorkOrderProperties, QueryWorkOrdersRequestBody, WorkOrdersResponse, WorkOrdersVariableQuery } from './types';
@@ -109,10 +109,8 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
 
     const mappedFields = query.properties?.map(property => {
       const field = WorkOrderProperties[property];
-      const fieldType = this.isTimeField(field.value) ? FieldType.time : FieldType.string;
       const fieldName = field.label;
 
-      // TODO: Add mapping for other field types
       const fieldValue = workOrders.map(workOrder => {
         switch (field.value) {
           case WorkOrderPropertiesOptions.WORKSPACE:
@@ -133,7 +131,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
         }
       });
 
-      return { name: fieldName, values: fieldValue, type: fieldType };
+      return { name: fieldName, values: fieldValue };
     });
 
     return {

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -1,4 +1,4 @@
-import { DataSourceInstanceSettings, DataQueryRequest, DataFrameDTO, TestDataSourceResponse, LegacyMetricFindQueryOptions, MetricFindValue } from '@grafana/data';
+import { DataSourceInstanceSettings, DataQueryRequest, DataFrameDTO, FieldType, TestDataSourceResponse, LegacyMetricFindQueryOptions, MetricFindValue } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import { WorkOrdersQuery, OutputType, WorkOrderPropertiesOptions, OrderByOptions, WorkOrder, WorkOrderProperties, QueryWorkOrdersRequestBody, WorkOrdersResponse, WorkOrdersVariableQuery } from './types';
@@ -109,6 +109,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
 
     const mappedFields = query.properties?.map(property => {
       const field = WorkOrderProperties[property];
+      const fieldType = FieldType.string;
       const fieldName = field.label;
 
       const fieldValue = workOrders.map(workOrder => {
@@ -131,7 +132,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
         }
       });
 
-      return { name: fieldName, values: fieldValue };
+      return { name: fieldName, values: fieldValue, type: fieldType };
     });
 
     return {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To remove field type from datasource so that all fields are returned as string type. IF necessary user can add transformation to get desired date time format

## 👩‍💻 Implementation

- Removed field type when processing data

## 🧪 Testing

- Manually verified 

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).