### PR TITLE
fix(core): Update text color in query builder

### DIFF
--- a/src/core/components/SlQueryBuilder/SlQueryBuilder.css
+++ b/src/core/components/SlQueryBuilder/SlQueryBuilder.css
@@ -7,6 +7,7 @@
     /* Tokens from grafana */
     --smart-background: var(--ni-grafana-input-background);
     --smart-border: var(--ni-grafana-border-medium);
+    --smart-background-color: var(--ni-grafana-text-primary);
 }
 
 .smart-query-builder[theme=ni-grafana] {
@@ -25,7 +26,6 @@
     --smart-scroll-bar-button-border: transparent;
 
     /* Tokens from grafana */
-    --smart-background-color: var(--ni-grafana-text-primary);
     --smart-ui-state-focus: var(--ni-grafana-focus-color);
     --smart-ui-state-color-focus: var(--smart-background-color);
     --smart-scroll-bar-background: var(--smart-background);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To fix color in the query builder's text

## 👩‍💻 Implementation

- Move the `--smart-background-color` so that value is updated for query builder too
![image](https://github.com/user-attachments/assets/05bd088c-60a7-4dd6-bd6d-a94ff0c91f0d)

![image](https://github.com/user-attachments/assets/34ac71b6-3e7f-4929-ae4f-fb0a2de63671)
 

## 🧪 Testing

- Manually verified

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).