### PR TITLE
feat(results): Update dependencies to load on initialization

### DIFF
--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
@@ -45,6 +45,7 @@ describe('QueryStepsEditor', () => {
   const mockHandleQueryChange = jest.fn();
 
   const mockDatasource = {
+    previousResultsQuery: '',
     loadWorkspaces: jest.fn(),
     getPartNumbers: jest.fn(),
     workspacesCache: new Map(),
@@ -228,12 +229,25 @@ describe('QueryStepsEditor', () => {
     test('should not update results query when filter doesnt change', () => {
       const resultsQueryInput = screen.getByTestId('results-query');
       fireEvent.change(resultsQueryInput, { target: { value: 'partNumber = "PN1"' } });// ensure initial value is set
+      mockDatasource.previousResultsQuery = 'partNumber = "PN1"';
       mockHandleQueryChange.mockClear();
 
       fireEvent.change(resultsQueryInput, { target: { value: 'partNumber = "PN1"' } });
 
       expect(mockHandleQueryChange).not.toHaveBeenCalledWith(
         expect.objectContaining({ resultsQuery: 'partNumber = "PN1"' })
+      );
+    });
+
+    test('should update results query when filter is not equal to previous results query', () => {
+      const resultsQueryInput = screen.getByTestId('results-query');
+      mockDatasource.previousResultsQuery = 'partNumber = "PN1"'; // Set previous results query
+      mockHandleQueryChange.mockClear();
+
+      fireEvent.change(resultsQueryInput, { target: { value: 'partNumber = "PN2"' } });
+
+      expect(mockHandleQueryChange).toHaveBeenCalledWith(
+        expect.objectContaining({ resultsQuery: 'partNumber = "PN2"' })
       );
     });
 

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -63,9 +63,7 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
   };
 
   const onResultsFilterChange = (resultsQuery: string) => {
-    if (resultsQuery === '') {
-      handleQueryChange({ ...query, resultsQuery: resultsQuery });
-    } else if (query.resultsQuery !== resultsQuery) {
+    if (query.resultsQuery !== resultsQuery || datasource.previousResultsQuery !== resultsQuery) {
       query.resultsQuery = resultsQuery;
       handleQueryChange({ ...query, resultsQuery: resultsQuery });
     }

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -1101,7 +1101,7 @@ describe('QueryStepsDataSource', () => {
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-paths', method: 'POST' }))
         .mockReturnValue(
           createFetchResponse({
-             paths: [
+            paths: [
               { path: 'path1' },
               { path: 'path2' },
               { path: 'path1' },

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -1101,13 +1101,7 @@ describe('QueryStepsDataSource', () => {
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-paths', method: 'POST' }))
         .mockReturnValue(
           createFetchResponse({
-            paths: [
-              { path: 'path1' },
-              { path: 'path2' },
-              { path: 'path1' },
-              { path: 'path3' },
-              { path: 'path2' },
-            ],
+            paths: ['path1', 'path2', 'path1', 'path3', 'path2'],
             continuationToken: null,
             totalCount: 5,
           })
@@ -1119,6 +1113,10 @@ describe('QueryStepsDataSource', () => {
         properties: [StepsPropertiesOptions.NAME as StepsProperties],
         recordCount: 100
       } as QuerySteps;
+      jest.spyOn(datastore as any, 'validateAndUpdateStepPaths').mockImplementation(function (this: any) {
+        this.stepsPath = ['path1', 'path2', 'path3'];
+        return Promise.resolve();
+      });
 
       await datastore.runQuery(query, { scopedVars: {} } as DataQueryRequest);
       const result = datastore.getStepPaths();
@@ -1217,6 +1215,7 @@ describe('QueryStepsDataSource', () => {
 
     it('should contain error details when query-path error contains additional information', async () => {
       const error = new Error(`API failed Error message: ${JSON.stringify({ message: 'Detailed error message', statusCode: 500 })}`);
+      jest.spyOn(datastore as any, 'queryResultsValues').mockResolvedValue(['name1', 'name2']); 
       jest.spyOn(datastore as any, 'queryStepPaths').mockRejectedValue(error);
       const query = {
         refId: 'A',

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -1101,7 +1101,13 @@ describe('QueryStepsDataSource', () => {
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-paths', method: 'POST' }))
         .mockReturnValue(
           createFetchResponse({
-            paths: ['path1', 'path2', 'path1', 'path3', 'path2'],
+             paths: [
+              { path: 'path1' },
+              { path: 'path2' },
+              { path: 'path1' },
+              { path: 'path3' },
+              { path: 'path2' },
+            ],
             continuationToken: null,
             totalCount: 5,
           })


### PR DESCRIPTION

# Pull Request

## 🤨 Rationale
The current implementation does not update the dependency when initializing.

This pull request refines the logic for detecting and handling changes in `resultsQuery`.

## 👩‍💻 Implementation

* Simplified the `loadStepPaths` method in `QueryStepsDataSource` by removing unused parameters and streamlining its implementation. (
* Consolidated duplicate logic for updating `stepsPath` into the new `validateAndUpdateStepPaths` method, reducing redundancy across the codebase.
* Refined the logic in `onResultsFilterChange` within `QueryStepsEditor` to ensure that `handleQueryChange` is triggered only when `resultsQuery` differs from both the current and previous values.
* Updated `QueryStepsDataSource` to introduce `currentResultsQuery` alongside `previousResultsQuery`, and moved the logic for updating `stepsPath` into a new `validateAndUpdateStepPaths` method for better encapsulation and reusability. 

## 🧪 Testing

* Added a new test case in `QueryStepsEditor.test.tsx` to verify that `resultsQuery` updates correctly when it differs from the previous query.
* Mocked and validated the behavior of `validateAndUpdateStepPaths` in `QueryStepsDataSource.test.ts` to ensure it updates `stepsPath` correctly when `resultsQuery` changes.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).