### PR TITLE
fix(testplans): Handle invalid queries to return empty data

### DIFF
--- a/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, RenderResult, waitFor } from '@testing-library/react';
+import { act, render, RenderResult, screen, waitFor } from '@testing-library/react';
 import { TestPlansQueryEditor } from './TestPlansQueryEditor';
 import { QueryEditorProps } from '@grafana/data';
 import { TestPlansDataSource } from '../TestPlansDataSource';
@@ -307,6 +307,25 @@ describe('TestPlansQueryEditor', () => {
             });
         });
 
+        it('should show error when all properties are removed', async () => {
+            const container = await renderElement();
+      
+            const properties = container.getAllByRole('combobox')[0];
+            // User adds a property
+            await select(properties, "Workspace", { container: document.body });
+            await waitFor(() => {
+              expect(mockOnChange).toHaveBeenCalledWith(
+                expect.objectContaining({ properties: ["WORKSPACE"] })
+              )
+            });
+      
+            // User removes the property
+            const removeButton = screen.getByRole('button', { name: 'Remove' });
+            await userEvent.click(removeButton);
+      
+            expect(screen.getByText('You must select at least one property.')).toBeInTheDocument();
+        })
+
         it('should call onChange with order by when user selects order by', async () => {
             const container = await renderElement();
             const orderBySelect = container.getAllByRole('combobox')[1];
@@ -374,8 +393,8 @@ describe('TestPlansQueryEditor', () => {
 
             await waitFor(() => {
                 expect(container.getByText('Enter a value less than or equal to 10,000')).toBeInTheDocument();
-                expect(mockOnChange).not.toHaveBeenCalled();
-                expect(mockOnRunQuery).not.toHaveBeenCalled();
+                expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
+                expect(mockOnRunQuery).toHaveBeenCalled();
             });
         });
 
@@ -390,8 +409,8 @@ describe('TestPlansQueryEditor', () => {
 
             await waitFor(() => {
                 expect(container.getByText('Enter a value greater than or equal to 0')).toBeInTheDocument();
-                expect(mockOnChange).not.toHaveBeenCalled();
-                expect(mockOnRunQuery).not.toHaveBeenCalled();
+                expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
+                expect(mockOnRunQuery).toHaveBeenCalled();
             });
         });
 

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -17,6 +17,7 @@ type Props = QueryEditorProps<TestPlansDataSource, TestPlansQuery>;
 export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   query = datasource.prepareQuery(query);
   const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
+  const [isPropertiesValid, setIsPropertiesValid] = useState<boolean>(true);  
 
   const [workspaces, setWorkspaces] = useState<Workspace[] | null>(null);
   const [users, setUsers] = useState<User[] | null>(null);
@@ -67,6 +68,7 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
   };
 
   const onPropertiesChange = (items: Array<SelectableValue<string>>) => {
+    setIsPropertiesValid(items.length > 0);
     if (items !== undefined) {
       handleQueryChange({ ...query, properties: items.map(i => i.value as Properties) });
     }
@@ -80,16 +82,22 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
     handleQueryChange({ ...query, descending: isDescendingChecked });
   };
 
+  const validateRecordCoundValue = (value: number, TAKE_LIMIT: number) => {
+    if (isNaN(value) || value < 0) {
+      return { message: recordCountErrorMessages.greaterOrEqualToZero, take: undefined };
+    }
+    if (value > TAKE_LIMIT) {
+      return { message: recordCountErrorMessages.lessOrEqualToTenThousand, take: undefined };
+    }
+    return {message: '', recordCount: value };
+  };
+
   const recordCountChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = parseInt((event.target as HTMLInputElement).value, 10);
-    if (isNaN(value) || value < 0) {
-      setRecordCountInvalidMessage(recordCountErrorMessages.greaterOrEqualToZero);
-    } else if (value > TAKE_LIMIT) {
-      setRecordCountInvalidMessage(recordCountErrorMessages.lessOrEqualToTenThousand);
-    } else {
-      setRecordCountInvalidMessage('');
-      handleQueryChange({ ...query, recordCount: value });
-    }
+    const { message, recordCount } = validateRecordCoundValue(value, TAKE_LIMIT);
+
+    setRecordCountInvalidMessage(message);
+    handleQueryChange({ ...query, recordCount });
   };
 
   const onQueryByChange = (queryBy: string) => {
@@ -110,7 +118,13 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
           />
         </InlineField>
         {query.outputType === OutputType.Properties && (
-          <InlineField label="Properties" labelWidth={25} tooltip={tooltips.properties}>
+          <InlineField
+            label="Properties" 
+            labelWidth={25} 
+            tooltip={tooltips.properties}
+            invalid={!isPropertiesValid}
+            error='You must select at least one property.'
+          >
             <MultiSelect
               placeholder="Select the properties to query"
               options={Object.entries(PropertiesProjectionMap).map(([key, value]) => ({ label: value.label, value: key })) as SelectableValue[]}

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
@@ -216,7 +216,7 @@ describe('TestPlansVariableQueryEditor', () => {
 
       await waitFor(() => {
         expect(container.getByText('Enter a value less than or equal to 10,000')).toBeInTheDocument();
-        expect(mockOnChange).not.toHaveBeenCalled();
+        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
       });
     });
 
@@ -230,7 +230,7 @@ describe('TestPlansVariableQueryEditor', () => {
 
       await waitFor(() => {
         expect(container.getByText('Enter a value greater than or equal to 0')).toBeInTheDocument();
-        expect(mockOnChange).not.toHaveBeenCalled();
+        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
       });
     });
 

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
@@ -67,16 +67,22 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
     handleQueryChange({ ...query, descending: isDescendingChecked });
   };
 
+  const validateRecordCoundValue = (value: number, TAKE_LIMIT: number) => {
+    if (isNaN(value) || value < 0) {
+      return { message: recordCountErrorMessages.greaterOrEqualToZero, take: undefined };
+    }
+    if (value > TAKE_LIMIT) {
+      return { message: recordCountErrorMessages.lessOrEqualToTenThousand, take: undefined };
+    }
+    return {message: '', recordCount: value };
+  };
+
   const recordCountChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = parseInt((event.target as HTMLInputElement).value, 10);
-    if (isNaN(value) || value < 0) {
-      setRecordCountInvalidMessage(recordCountErrorMessages.greaterOrEqualToZero);
-    } else if (value > TAKE_LIMIT) {
-      setRecordCountInvalidMessage(recordCountErrorMessages.lessOrEqualToTenThousand);
-    } else {
-      setRecordCountInvalidMessage('');
-      handleQueryChange({ ...query, recordCount: value });
-    }
+    const { message, recordCount } = validateRecordCoundValue(value, TAKE_LIMIT);
+
+    setRecordCountInvalidMessage(message);
+    handleQueryChange({ ...query, recordCount });
   };
 
   const onQueryByChange = (queryBy: string) => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To return empty data when user enters invalid queries and to show error message when all properties are removed

## 👩‍💻 Implementation

- Handled invalidity when all properties are removed
- Check validity of take and properties and return empty data if it's invalid
- Use `prepareQuery` in `metricFindQuery` so that initial run query gets populated with default query

## 🧪 Testing

- Manually verified
- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).