### PR TITLE
fix(core): Rethow error in queryUsingSkip

### DIFF
--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -465,10 +465,8 @@ describe('queryUsingSkip', () => {
       })
       .mockRejectedValueOnce(new Error('Test error'));
 
-    const result = await queryUsingSkip(mockQueryRecord, queryConfig);
-
+    await expect(queryUsingSkip(mockQueryRecord, queryConfig)).rejects.toThrow('Test error');
     expect(mockQueryRecord).toHaveBeenCalledTimes(2);
-    expect(result.data.length).toBe(100);
   });
 
   test('should delay between requests if requests exceed requestsPerSecond', async () => {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -259,9 +259,8 @@ export async function queryUsingSkip<T>(
 
         skip += maxTakePerRequest;
       } catch (error) {
-        console.error(`Error during batch fetch at skip=${skip}:`, error);
         hasMore = false;
-        break;
+        throw error; // Re-throw the error to be handled by the caller
       }
     }
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -248,7 +248,6 @@ export async function queryUsingSkip<T>(
     const start = Date.now();
 
     for (let i = 0; i < requestsPerSecond && hasMore; i++) {
-      try {
         const response = await queryRecord(maxTakePerRequest, skip);
         data.push(...response.data);
 
@@ -258,10 +257,6 @@ export async function queryUsingSkip<T>(
         }
 
         skip += maxTakePerRequest;
-      } catch (error) {
-        hasMore = false;
-        throw error; // Re-throw the error to be handled by the caller
-      }
     }
 
     const elapsed = Date.now() - start;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To rethrow error in queryUsingSkip as it is handled in TestPlansDatasource

## 👩‍💻 Implementation

- Rethrow error in `queryUsingSkip`

## 🧪 Testing

- Updated tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).