### PR TITLE
fix(results): preserve stepsQuery only when switching query types

### DIFF
--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -83,6 +83,72 @@ describe('ResultsQueryEditor', () => {
       });
     });
   });
+
+  test('should save stepsQuery value only when switched from steps query type to results', async () => {
+    const customStepsQuery = {
+      refId: 'A',
+      queryType: QueryType.Steps,
+      customField: 'customValue',
+    } as ResultsQuery;
+
+    let currentQuery = { ...customStepsQuery };
+    const onChange = jest.fn((query) => {
+      currentQuery = { ...currentQuery, ...query };
+      renderResult.rerender(
+        React.createElement(ResultsQueryEditor, { ...defaultProps, query: currentQuery, onChange })
+      );
+    });
+
+    const renderResult = render(
+      React.createElement(ResultsQueryEditor, { ...defaultProps, query: currentQuery, onChange })
+    );
+
+    // Switch to Results
+    userEvent.click(renderResult.getByRole('radio', { name: QueryType.Results }));
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining(defaultResultsQuery));
+    });
+
+    // Switch back to Steps
+    userEvent.click(renderResult.getByRole('radio', { name: QueryType.Steps }));
+    await waitFor(() => {
+      // The customField should be preserved in stepsQuery state and merged back in
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...defaultStepsQuery,
+          customField: 'customValue',
+        })
+      );
+    });
+  })
+
+  test('should not save stepsQuery value when switching from results to steps without previous steps query', async () => {
+   const query = {
+      refId: 'A',
+    } as ResultsQuery; // undefined queryType
+
+    const renderResult = render(
+      React.createElement(ResultsQueryEditor, {
+        query,
+        datasource: mockDatasource,
+        onRunQuery: mockOnRunQuery,
+        onChange: mockOnChange,
+      })
+    );
+
+    // Switch to Results
+    userEvent.click(renderResult.getByRole('radio', { name: QueryType.Results }));
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining(defaultResultsQuery));
+    });
+
+    // Switch to Steps without any previous steps query
+    userEvent.click(renderResult.getByRole('radio', { name: QueryType.Steps }));
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining(defaultStepsQuery));
+    });
+  });
+
   test('should save resultsQuery value when switching to steps and back to results', async () => {
     // Start with Results query type and set a custom value for resultsQuery
     const customResultsQuery = {

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -29,7 +29,10 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
 
   const handleQueryTypeChange = useCallback((queryType: QueryType): void => {
     if (queryType === QueryType.Results) {
-      setStepsQuery(query as QuerySteps);
+      if(query.queryType === QueryType.Steps) {
+        // Preserve the current steps query when switching from Steps to Results
+        setStepsQuery(query as QuerySteps);
+      }
       handleQueryChange({
         ...defaultResultsQuery,
         ...resultsQuery,

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -42,7 +42,10 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
         });
         break;
       case QueryType.Steps:
-        setResultsQuery(query as QueryResults);
+        // Preserve results query state when switching from Results to Steps
+        if (query.queryType === QueryType.Results) {
+          setResultsQuery(query as QueryResults);
+        }
         handleQueryChange({
           ...defaultStepsQuery,
           ...stepsQuery,

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -28,25 +28,29 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
   );
 
   const handleQueryTypeChange = useCallback((queryType: QueryType): void => {
-    if (queryType === QueryType.Results) {
-      if(query.queryType === QueryType.Steps) {
+    switch (queryType) {
+      case QueryType.Results:
         // Preserve the current steps query when switching from Steps to Results
-        setStepsQuery(query as QuerySteps);
-      }
-      handleQueryChange({
-        ...defaultResultsQuery,
-        ...resultsQuery,
-        queryType: QueryType.Results,
-        refId: query.refId
-      });
-    }
-    if (queryType === QueryType.Steps) {
-      setResultsQuery(query as QueryResults);
-      handleQueryChange({
-        ...defaultStepsQuery,
-        ...stepsQuery,
-        refId: query.refId
-      });
+        if (query.queryType === QueryType.Steps) {
+          setStepsQuery(query as QuerySteps);
+        }
+        handleQueryChange({
+          ...defaultResultsQuery,
+          ...resultsQuery,
+          queryType: QueryType.Results,
+          refId: query.refId,
+        });
+        break;
+      case QueryType.Steps:
+        setResultsQuery(query as QueryResults);
+        handleQueryChange({
+          ...defaultStepsQuery,
+          ...stepsQuery,
+          refId: query.refId,
+        });
+        break;
+      default:
+        break;
     }
   }, [query, resultsQuery, stepsQuery, handleQueryChange]);
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
To fix the behavior of propagating Results query into Steps on rendering ,this pull request preserves steps query state only when switching between query types. 

## 👩‍💻 Implementation

* Updated the `handleQueryTypeChange` method in `ResultsQueryEditor` to preserve the current `stepsQuery` state when switching from "Steps" to "Results".

## 🧪 Testing

* Added a test to ensure that `stepsQuery` values are preserved when switching from "Steps" to "Results" and back to "Steps". This verifies that custom fields in the `stepsQuery` state are retained.
* Added a test to confirm that a default `stepsQuery` is applied when switching from "Results" to "Steps" without a prior `stepsQuery` state.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ x ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).