### PR TITLE
fix(results): allow empty results query to trigger update

### DIFF
--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.test.tsx
@@ -226,6 +226,17 @@ describe('QueryStepsEditor', () => {
       );
     });
 
+    test('should update results query even when filter is empty', () => {
+      const resultsQueryInput = screen.getByTestId('results-query');
+      mockHandleQueryChange.mockClear();
+
+      fireEvent.change(resultsQueryInput, { target: { value: '' } });
+
+      expect(mockHandleQueryChange).toHaveBeenCalledWith(
+        expect.objectContaining({ resultsQuery: '' })
+      );
+    });
+
     test('should not update results query when filter doesnt change', () => {
       const resultsQueryInput = screen.getByTestId('results-query');
       fireEvent.change(resultsQueryInput, { target: { value: 'partNumber = "PN1"' } });// ensure initial value is set

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -63,9 +63,11 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
   };
 
   const onResultsFilterChange = (resultsQuery: string) => {
-    if (query.resultsQuery !== resultsQuery || datasource.previousResultsQuery !== resultsQuery) {
+    if (resultsQuery === '') {
+      handleQueryChange({ ...query, resultsQuery });
+    } else if (query.resultsQuery !== resultsQuery || datasource.previousResultsQuery !== resultsQuery) {
       query.resultsQuery = resultsQuery;
-      handleQueryChange({ ...query, resultsQuery: resultsQuery });
+      handleQueryChange({ ...query, resultsQuery });
     }
   };
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
The current implementation runs into an issue when a valid results query is added and then removed — the results filter can't be cleared properly because an empty results query doesn't render as expected.

![bug](https://github.com/user-attachments/assets/88aeea86-ae9f-48da-b828-6d13b5629ca9)

To address this, the pull request updates the QueryStepsEditor component to gracefully handle cases where the results query is empty, ensuring proper rendering and cleanup of filters.

## 👩‍💻 Implementation

* Updated the `onResultsFilterChange` function to explicitly handle cases where the `resultsQuery` is empty, ensuring the `handleQueryChange` function is called with the correct query.

## 🧪 Testing

* Added a new test case to verify that the `resultsQuery` is updated correctly when it is set to an empty string.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).