### PR TITLE
fix(results): fix steps query not disabled by default in variable editor

### DIFF
--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.test.tsx
@@ -190,6 +190,20 @@ describe('Steps Query Type', () => {
     expect(stepsQueryInput).toBeDisabled();
   });
 
+  it('should disable the steps query builder when resultQuery is undefined', async () => {
+    await act(async () => {
+      renderEditor({
+        refId: '',
+        queryType: QueryType.Steps,
+        queryByResults: undefined,
+        queryBySteps: '',
+      } as unknown as ResultsQuery);
+    });
+    const stepsQueryInput = screen.getByTestId('Query by steps properties');
+    expect(stepsQueryInput).toBeInTheDocument();
+    expect(stepsQueryInput).toBeDisabled();
+  })
+
   it('should enable the steps query builder when resultQuery has value', async () => {
     await act(async () => {
       renderEditor({

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -85,7 +85,7 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
   };
 
   const onResultsQueryChange = (resultsQuery: string) => {
-    onChange({ ...queryResultsquery, queryByResults: resultsQuery } as ResultsVariableQuery);
+    onChange({ ...stepsVariableQuery, queryByResults: resultsQuery } as StepsVariableQuery);
   };
 
   const onStepsQueryChange = (stepsQuery: string) => {

--- a/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
+++ b/src/datasources/results/components/variable-editors/ResultsVariableQueryEditor.tsx
@@ -62,7 +62,10 @@ export function ResultsVariableQueryEditor({ query, onChange, datasource }: Prop
   }, [datasource]);
 
   useEffect(() => {
-    disableStepsQueryBuilder(stepsVariableQuery.queryByResults === '');
+    disableStepsQueryBuilder(
+      stepsVariableQuery.queryByResults === '' 
+      || stepsVariableQuery.queryByResults === undefined
+    );
   }, [stepsVariableQuery.queryByResults]);
 
   const onQueryTypeChange = (queryType: QueryType) => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
To fix the Steps query enabled by default in the Results Variable query editor , this PR contains changes to the logic to disable the steps query if the results query is undefined.

![image](https://github.com/user-attachments/assets/40bce59c-f40e-4c6c-b098-d2133bfb3039)

## 👩‍💻 Implementation

* Updated the `disableStepsQueryBuilder` logic to disable the steps query builder when `queryByResults` is either an empty string or `undefined`.

* **Typo correction in `onResultsQueryChange`**: Fixed a typo in the `onResultsQueryChange` function where `queryResultsquery` was incorrectly used instead of `stepsVariableQuery`. 

## 🧪 Testing

* Added a test to verify that the steps query builder is disabled when `queryByResults` is `undefined`.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).