### PR TITLE
feat(results): fix column headers to sentence case

### DIFF
--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -2,7 +2,7 @@ import { SelectableValue } from '@grafana/data';
 import { AutoSizeInput, InlineField, MultiSelect, RadioButtonGroup, VerticalGroup } from '@grafana/ui';
 import { enumToOptions, validateNumericInput } from 'core/utils';
 import React, { useEffect, useState } from 'react';
-import { QueryResults, ResultPropertiesProjectionMap, ResultsProperties } from 'datasources/results/types/QueryResults.types';
+import { PropertiesProjectionMap, QueryResults, ResultsProperties } from 'datasources/results/types/QueryResults.types';
 import { OutputType, TestMeasurementStatus } from 'datasources/results/types/types';
 import { TimeRangeControls } from '../time-range/TimeRangeControls';
 import { Workspace } from 'core/types';
@@ -97,8 +97,8 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
           >
             <MultiSelect
               placeholder={placeholders.properties}
-              options={Object.entries(ResultPropertiesProjectionMap)
-                .map(([key, value]) => ({ label: key, value })) as SelectableValue[]}
+              options={Object.entries(PropertiesProjectionMap)
+                .map(([key, value]) => ({ label: value.label, value: key })) as SelectableValue[]}
               onChange={onPropertiesChange}
               value={query.properties}
               defaultValue={query.properties!}

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -4,7 +4,7 @@ import { validateNumericInput } from 'core/utils';
 import React, { useEffect, useState } from 'react';
 import { OutputType } from 'datasources/results/types/types';
 import { TimeRangeControls } from '../time-range/TimeRangeControls';
-import { QuerySteps, StepPropertiesProjectionMap, StepsProperties } from 'datasources/results/types/QuerySteps.types';
+import { PropertiesProjectionMap, QuerySteps, StepsProperties } from 'datasources/results/types/QuerySteps.types';
 import { QueryStepsDataSource } from 'datasources/results/query-handlers/query-steps/QueryStepsDataSource';
 import { StepsQueryBuilderWrapper } from '../../query-builders/steps-querybuilder-wrapper/StepsQueryBuilderWrapper';
 import { FloatingError } from 'core/errors';
@@ -98,8 +98,8 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
           >
             <MultiSelect
               placeholder={placeholders.properties}
-              options={Object.entries(StepPropertiesProjectionMap)
-                .map(([key, value]) => ({ label: key, value: value })) as SelectableValue[]}
+              options={Object.entries(PropertiesProjectionMap)
+                .map(([key, value]) => ({ label: value.label, value: key })) as SelectableValue[]}
               onChange={onPropertiesChange}
               value={query.properties}
               defaultValue={query.properties!}

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -280,7 +280,7 @@ describe('QueryResultsDataSource', () => {
         const response = await datastore.query(query);
         const fields = response.data[0].fields as Field[];
         expect(fields).toEqual([
-          { name: 'properties', values: [""], type: 'string' },
+          { name: 'Properties', values: [""], type: 'string' },
         ]);
     });
 

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -1,4 +1,4 @@
-import { QueryResults, QueryResultsResponse, ResultsProperties, ResultsPropertiesOptions, ResultsResponseProperties, ResultsVariableQuery } from "datasources/results/types/QueryResults.types";
+import { PropertiesProjectionMap, QueryResults, QueryResultsResponse, ResultsProperties, ResultsPropertiesOptions, ResultsResponseProperties, ResultsVariableQuery } from "datasources/results/types/QueryResults.types";
 import { ResultsDataSourceBase } from "datasources/results/ResultsDataSourceBase";
 import { DataQueryRequest, DataFrameDTO, FieldType, LegacyMetricFindQueryOptions, MetricFindValue, AppEvents } from "@grafana/data";
 import { OutputType } from "datasources/results/types/types";
@@ -108,18 +108,18 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
           case ResultsPropertiesOptions.PROPERTIES:
           case ResultsPropertiesOptions.STATUS_TYPE_SUMMARY:
             return {
-              name: field,
+              name: PropertiesProjectionMap[field].label,
               values: values.map((v) => (v != null ? JSON.stringify(v) : '')),
               type: fieldType,
             };
           case ResultsPropertiesOptions.STATUS:
             return {
-              name: field,
+              name: PropertiesProjectionMap[field].label,
               values: values.map((v: any) => v?.statusType),
               type: fieldType,
             };
           default:
-            return { name: field, values, type: fieldType };
+            return { name: PropertiesProjectionMap[field].label, values, type: fieldType };
         }
       });
 

--- a/src/datasources/results/query-handlers/query-results/__snapshots__/QueryResultsDataSource.test.ts.snap
+++ b/src/datasources/results/query-handlers/query-results/__snapshots__/QueryResultsDataSource.test.ts.snap
@@ -5,7 +5,7 @@ exports[`QueryResultsDataSource query returns data for valid data-output-type qu
   {
     "fields": [
       {
-        "name": "programName",
+        "name": "Test program name",
         "type": "string",
         "values": [
           "My Program Name",
@@ -32,7 +32,7 @@ exports[`QueryResultsDataSource query returns column headers with no data when Q
   {
     "fields": [
       {
-        "name": "id",
+        "name": "Result ID",
         "type": "string",
         "values": [],
       },
@@ -62,7 +62,7 @@ exports[`QueryResultsDataSource query returns total count for valid total count 
 exports[`QueryResultsDataSource query should convert properties to Grafana fields 1`] = `
 [
   {
-    "name": "programName",
+    "name": "Test program name",
     "type": "string",
     "values": [
       "My Program Name",

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -441,7 +441,7 @@ describe('QueryStepsDataSource', () => {
       const response = await datastore.query(query);
       const fields = response.data[0].fields as Field[];
       expect(fields).toEqual([
-        { name: 'properties', values: [""], type: 'string' },
+        { name: 'Properties', values: [""], type: 'string' },
       ]);
     });
 

--- a/src/datasources/results/query-handlers/query-steps/__snapshots__/QueryStepsDataSource.test.ts.snap
+++ b/src/datasources/results/query-handlers/query-steps/__snapshots__/QueryStepsDataSource.test.ts.snap
@@ -12,7 +12,7 @@ exports[`QueryStepsDataSource query returns empty data for invalid query 1`] = `
 exports[`QueryStepsDataSource query should convert properties to Grafana fields 1`] = `
 [
   {
-    "name": "properties",
+    "name": "Properties",
     "type": "string",
     "values": [
       "{"key1":"value1","key2":"value2"}",
@@ -26,7 +26,7 @@ exports[`QueryStepsDataSource query should return data for valid data-output-typ
   {
     "fields": [
       {
-        "name": "name",
+        "name": "Step name",
         "type": "string",
         "values": [
           "Step 1",
@@ -44,7 +44,7 @@ exports[`QueryStepsDataSource query should show column header with no data when 
   {
     "fields": [
       {
-        "name": "stepId",
+        "name": "Step ID",
         "type": "string",
         "values": [],
       },
@@ -74,7 +74,7 @@ exports[`QueryStepsDataSource query should return total count for valid total co
 exports[`QueryStepsDataSource query show measurements is enabled should convert step measurements to Grafana fields as a column 1`] = `
 [
   {
-    "name": "stepId",
+    "name": "Step ID",
     "type": "number",
     "values": [
       "1",
@@ -151,7 +151,7 @@ exports[`QueryStepsDataSource query show measurements is enabled should convert 
 exports[`QueryStepsDataSource query show measurements is enabled should create empty cells when measurements are not available 1`] = `
 [
   {
-    "name": "stepId",
+    "name": "Step ID",
     "type": "number",
     "values": [
       "1",
@@ -180,7 +180,7 @@ exports[`QueryStepsDataSource query show measurements is enabled should create e
 exports[`QueryStepsDataSource query show measurements is enabled should create new columns when units are different in the same measurement 1`] = `
 [
   {
-    "name": "stepId",
+    "name": "Step ID",
     "type": "number",
     "values": [
       "1",

--- a/src/datasources/results/types/QueryResults.types.ts
+++ b/src/datasources/results/types/QueryResults.types.ts
@@ -80,25 +80,79 @@ export enum ResultsProperties {
   workspace = 'workspace',
 }
 
-export const ResultPropertiesProjectionMap = {
-    'Result ID': ResultsProperties.id,
-    'Test program name': ResultsProperties.programName,
-    'Serial number': ResultsProperties.serialNumber,
-    'System ID': ResultsProperties.systemId,
-    'Status': ResultsProperties.status,
-    'Total time (s)': ResultsProperties.totalTimeInSeconds,
-    'Started at': ResultsProperties.startedAt,
-    'Updated at': ResultsProperties.updatedAt,
-    'Part number': ResultsProperties.partNumber,
-    'Data table IDs': ResultsProperties.dataTableIds,
-    'File IDs': ResultsProperties.fileIds,
-    'Host name': ResultsProperties.hostName,
-    'Operator': ResultsProperties.operator,
-    'Keywords': ResultsProperties.keywords,
-    'Properties': ResultsProperties.properties,
-    'Status type summary': ResultsProperties.statusTypeSummary,
-    'Workspace': ResultsProperties.workspace
-} as const;
+export const PropertiesProjectionMap: Record<ResultsProperties, {
+  label: string;
+  projection: ResultsProperties;
+}> = {
+  [ResultsProperties.id]: {
+    label: 'Result ID',
+    projection: ResultsProperties.id
+  },
+  [ResultsProperties.programName]: {
+    label: 'Test program name',
+    projection: ResultsProperties.programName
+  },
+  [ResultsProperties.serialNumber]: {
+    label: 'Serial number',
+    projection: ResultsProperties.serialNumber
+  },
+  [ResultsProperties.systemId]: {
+    label: 'System ID',
+    projection: ResultsProperties.systemId
+  },
+  [ResultsProperties.status]: {
+    label: 'Status',
+    projection: ResultsProperties.status
+  },
+  [ResultsProperties.totalTimeInSeconds]: {
+    label: 'Total time (s)',
+    projection: ResultsProperties.totalTimeInSeconds
+  },
+  [ResultsProperties.startedAt]: {
+    label: 'Started at',
+    projection: ResultsProperties.startedAt
+  },
+  [ResultsProperties.updatedAt]: {
+    label: 'Updated at',
+    projection: ResultsProperties.updatedAt
+  },
+  [ResultsProperties.partNumber]: {
+    label: 'Part number',
+    projection: ResultsProperties.partNumber
+  },
+  [ResultsProperties.dataTableIds]: {
+    label: 'Data table IDs',
+    projection: ResultsProperties.dataTableIds
+  },
+  [ResultsProperties.fileIds]: {
+    label: 'File IDs',
+    projection: ResultsProperties.fileIds
+  },
+  [ResultsProperties.hostName]: {
+    label: 'Host name',
+    projection: ResultsProperties.hostName
+  },
+  [ResultsProperties.operator]: {
+    label: 'Operator',
+    projection: ResultsProperties.operator
+  },
+  [ResultsProperties.keywords]: {
+    label: 'Keywords',
+    projection: ResultsProperties.keywords
+  },
+  [ResultsProperties.properties]: {
+    label: 'Properties',
+    projection: ResultsProperties.properties
+  },
+  [ResultsProperties.statusTypeSummary]: {
+    label: 'Status type summary',
+    projection: ResultsProperties.statusTypeSummary
+  },
+  [ResultsProperties.workspace]: {
+    label: 'Workspace',
+    projection: ResultsProperties.workspace
+  }
+}
 
 export interface StatusHttp {
   statusType: string;

--- a/src/datasources/results/types/QuerySteps.types.ts
+++ b/src/datasources/results/types/QuerySteps.types.ts
@@ -56,23 +56,73 @@ export enum StepsProperties {
   properties = 'properties',
 }
 
-export const StepPropertiesProjectionMap = {
-  'Step name': StepsProperties.name,
-  'Step type': StepsProperties.stepType,
-  'Step ID': StepsProperties.stepId,
-  'Parent ID': StepsProperties.parentId,
-  'Result ID': StepsProperties.resultId,
-  'Status': StepsProperties.status,
-  'Total time (s)': StepsProperties.totalTimeInSeconds,
-  'Started at': StepsProperties.startedAt,
-  'Updated at': StepsProperties.updatedAt,
-  'Inputs': StepsProperties.inputs,
-  'Outputs': StepsProperties.outputs,
-  'Data model': StepsProperties.dataModel,
-  'Data': StepsProperties.data,
-  'Workspace': StepsProperties.workspace,
-  'Keywords': StepsProperties.keywords,
-  'Properties': StepsProperties.properties,
+export const PropertiesProjectionMap: Record<StepsProperties, {
+  label: string,
+  projection: StepsProperties
+}> = {
+  [StepsProperties.name]: {
+    label: 'Step name',
+    projection: StepsProperties.name
+  },
+  [StepsProperties.stepType]: {
+    label: 'Step type',
+    projection: StepsProperties.stepType
+  },
+  [StepsProperties.stepId]: {
+    label: 'Step ID',
+    projection: StepsProperties.stepId
+  },
+  [StepsProperties.parentId]: {
+    label: 'Parent ID',
+    projection: StepsProperties.parentId
+  },
+  [StepsProperties.resultId]: {
+    label: 'Result ID',
+    projection: StepsProperties.resultId
+  },
+  [StepsProperties.status]: {
+    label: 'Status', projection: StepsProperties.status
+  },
+  [StepsProperties.totalTimeInSeconds]: {
+    label: 'Total time (s)',
+    projection: StepsProperties.totalTimeInSeconds
+  },
+  [StepsProperties.startedAt]: {
+    label: 'Started at',
+    projection: StepsProperties.startedAt
+  },
+  [StepsProperties.updatedAt]: {
+    label: 'Updated at',
+    projection: StepsProperties.updatedAt
+  },
+  [StepsProperties.inputs]: {
+    label: 'Inputs',
+    projection: StepsProperties.inputs
+  },
+  [StepsProperties.outputs]: {
+    label: 'Outputs',
+    projection: StepsProperties.outputs
+  },
+  [StepsProperties.dataModel]: {
+    label: 'Data model',
+    projection: StepsProperties.dataModel
+  },
+  [StepsProperties.data]: {
+    label: 'Data',
+    projection: StepsProperties.data
+  },
+  [StepsProperties.workspace]: {
+    label: 'Workspace',
+    projection: StepsProperties.workspace
+  },
+  [StepsProperties.keywords]: {
+    label: 'Keywords',
+    projection: StepsProperties.keywords
+  },
+  [StepsProperties.properties]: {
+    label: 'Properties',
+    projection: StepsProperties.properties
+  },
 }
 
 export interface StatusHttp {


### PR DESCRIPTION

# Pull Request

## 🤨 Rationale

To convert the casing of column headers listed from camelCase to Sentencecase. 
![image](https://github.com/user-attachments/assets/2f1bc42b-6557-4230-9b15-3cbb9ae9b719)


## 👩‍💻 Implementation

- Added a PropertiesProjectionMap to 
This pull request refactors how property mappings are handled across the `QueryResults` and `QuerySteps` components and their associated data sources. It replaces the `ResultPropertiesProjectionMap` and `StepPropertiesProjectionMap` with a unified `PropertiesProjectionMap` structure that includes both labels and projections. This change improves consistency and simplifies the codebase. Additionally, tests and snapshots were updated to reflect these changes.

### Refactoring of Property Mappings:

* Replaced `ResultPropertiesProjectionMap` and `StepPropertiesProjectionMap` with a unified `PropertiesProjectionMap` structure in `QueryResults.types.ts` and `QuerySteps.types.ts`. The new structure includes both `label` and `projection` fields for each property. (`[[1]](diffhunk://#diff-5a76899aa028d6cdf264c1a124f244cc2259a2437142c93be383b999d9090f6dL83-R155)`, `[[2]](diffhunk://#diff-4cf50f1154eac7defb60ddc51932cfb51ae4f6acc7b4b38d2dc10608872785c5L59-R125)`)

* Updated imports and references in `QueryResultsEditor.tsx`, `QueryStepsEditor.tsx`, `QueryResultsDataSource.ts`, and `QueryStepsDataSource.ts` to use `PropertiesProjectionMap` instead of the older projection maps. (`[[1]](diffhunk://#diff-e67be385849f409d44b8a6e1340bce8b3d3461f6bf5192a6fc05b63d4ff9fe62L5-R5)`, `[[2]](diffhunk://#diff-757b0acc8c82ac8b167544e63835b1a45a87952cbe13189094829274660c7019L7-R7)`, `[[3]](diffhunk://#diff-5e826579a51779c73134532292c02dd12953836e1b85a88a8be9bd2aa784ab6aL1-R1)`, `[[4]](diffhunk://#diff-09604d1030cd36eeaad2f6b05caa3ce46411237563257915b0b92b19a5ee83fbR4)`)

### Updates to Data Source Logic:

* Modified the logic in `QueryResultsDataSource` and `QueryStepsDataSource` to use `PropertiesProjectionMap` for property labels when generating field names. This ensures that human-readable labels are consistently applied. (`[[1]](diffhunk://#diff-5e826579a51779c73134532292c02dd12953836e1b85a88a8be9bd2aa784ab6aL111-R122)`, `[[2]](diffhunk://#diff-09604d1030cd36eeaad2f6b05caa3ce46411237563257915b0b92b19a5ee83fbL224-R227)`, `[[3]](diffhunk://#diff-09604d1030cd36eeaad2f6b05caa3ce46411237563257915b0b92b19a5ee83fbR318-R321)`)

### Adjustments to Tests and Snapshots:

* Updated test cases and snapshots to reflect the new property labels derived from `PropertiesProjectionMap`. This includes changes to field names in test responses for both `QueryResultsDataSource` and `QueryStepsDataSource`. (`[[1]](diffhunk://#diff-ca28451fbae48913f45df9d17c4977eea6f929b80d1f7814d7c2110e190647b3L283-R283)`, `[[2]](diffhunk://#diff-25c3b0c86aa8016007a7286d28d94e9b5b2d18e50e6d6470f7b9a27a531925f4L444-R444)`, `[[3]](diffhunk://#diff-2d564ff1e5a95a3238693f4df7865683f53666dd073926dbd1c2b66969c58574L8-R8)`, `[[4]](diffhunk://#diff-36fff0712634b0210effc2ab780c6e139f4daefa10f876c9f1424715aae393bdL15-R15)`, `[[5]](diffhunk://#diff-36fff0712634b0210effc2ab780c6e139f4daefa10f876c9f1424715aae393bdL29-R29)`)

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements.

Include automated test additions or modifications, manual testing done on a local build, and additional testing not covered by automatic pull request validation.
-->

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).