### PR TITLE
fix(core): remove error message on 504 status code

### DIFF
--- a/src/core/DataSourceBase.ts
+++ b/src/core/DataSourceBase.ts
@@ -55,9 +55,14 @@ export abstract class DataSourceBase<TQuery extends DataQuery, TOptions extends 
       if (isFetchError(error)) {
         const fetchError = error as FetchError;
         const statusCode = fetchError.status;
-        const data = fetchError.data;
-        const errorMessage = data.error?.message || JSON.stringify(data);
-        throw new Error(`Request to url "${options.url}" failed with status code: ${statusCode}. Error message: ${errorMessage}`);
+        const genericErrorMessage = `Request to url "${options.url}" failed with status code: ${statusCode}.`;
+        if (statusCode === 504) {
+          throw new Error(genericErrorMessage);
+        } else {
+          const data = fetchError.data;
+          const errorMessage = data.error?.message || JSON.stringify(data);
+          throw new Error(`${genericErrorMessage} Error message: ${errorMessage}`);
+        }
       }
       throw error;
     }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
https://dev.azure.com/ni/DevCentral/_workitems/edit/3162580

## 👩‍💻 Implementation

Remove the error message from the error thrown when status code is 504. This way we avoid having the entire HTML shown there that is returned by Cloudflare.

## 🧪 Testing

Tested locally with the Systems datasource and used a fake backend. When I returned 504 from the systems request, the error message wasn't shown, when I returned any other status code, it was shown.

## ✅ Checklist

- [X] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).