### PR TITLE
fix(core): remove filtering of variable with datasource

### DIFF
--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -1,5 +1,5 @@
 import { TemplateSrv } from "@grafana/runtime";
-import { validateNumericInput, enumToOptions, filterXSSField, filterXSSLINQExpression, replaceVariables, queryInBatches, queryUsingSkip, queryUntilComplete } from "./utils";
+import { validateNumericInput, enumToOptions, filterXSSField, filterXSSLINQExpression, replaceVariables, queryInBatches, queryUsingSkip, queryUntilComplete, getVariableOptions } from "./utils";
 import { BatchQueryConfig } from "./types";
 
 test('enumToOptions', () => {
@@ -14,6 +14,20 @@ test('enumToOptions', () => {
     { label: 'Label1', value: 'Value1' },
     { label: 'Label2', value: 'Value2' }
   ]);
+});
+
+describe('getVariableOptions', () => {
+  it('returns variables as SelectableValue array', () => {
+    const ds: any = {
+      templateSrv: {
+        getVariables: () => [{ name: 'var1' }, { name: 'var2' }]
+      }
+    };
+    expect(getVariableOptions(ds)).toEqual([
+      { label: '$var1', value: '$var1' },
+      { label: '$var2', value: '$var2' }
+    ]);
+  });
 });
 
 describe("filterXSSLINQExpression", () => {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -48,7 +48,6 @@ export function useWorkspaceOptions<DSType extends DataSourceBase<any, any>>(dat
 export function getVariableOptions<DSType extends DataSourceBase<any, any>>(datasource: DSType) {
   return datasource.templateSrv
     .getVariables()
-    .filter((variable: any) => !variable.datasource || variable.datasource.uid !== datasource.uid)
     .map(variable => ({ label: '$' + variable.name, value: '$' + variable.name }));
 }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In the current implementation, variables created using a datasource are not listed when configuring queries for that same datasource. This happens because those variables are explicitly filtered out if they were created under the same datasource.

[See teams discussion](https://teams.microsoft.com/l/message/19:b0c2c359cadf418ca24bb9a51a67dcea@thread.tacv2/1750350630751?tenantId=eb06985d-06ca-4a17-81da-629ab99f6505&groupId=1e74afef-f47b-4137-ad1b-e550ec9c6bef&parentMessageId=1750350630751&teamName=TM-SystemLink&channelName=Grafana%20Discussions&createdTime=1750350630751).

## 👩‍💻 Implementation

- Removed the filter from the `getVariableOptions` method

## 🧪 Testing

- Added tests to check if all the variables are returned

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).