### PR TITLE
fix(workorders,testplans): REname fields and update value mappings

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -118,12 +118,11 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
               return workspace ? getWorkspaceName([workspace], value) : value;
             case PropertiesProjectionMap.WORK_ORDER.label:
               const workOrder = workOrderIdAndName.find(data => data.id === value);
-              const workOrderId = value ? `(${value})` : '';
               const workOrderName = workOrder && workOrder?.name ? workOrder.name : '';
-              return `${workOrderName} ${workOrderId}`;
+              return workOrderName;
             case PropertiesProjectionMap.TEMPLATE.label:
               const template = templatesName.find(data => data.id === value);
-              return template ? `${template.name} (${template.id})` : value;
+              return template ? template.name : value;
             case PropertiesProjectionMap.ESTIMATED_DURATION_IN_SECONDS.label:
               return value ? transformDuration(value) : '';
             case PropertiesProjectionMap.SYSTEM_NAME.label:

--- a/src/datasources/test-plans/types.ts
+++ b/src/datasources/test-plans/types.ts
@@ -112,12 +112,12 @@ export const PropertiesProjectionMap: Record<Properties, {
         field: 'description',
     },
     [Properties.ID]: {
-        label: 'ID',
+        label: 'Test plan ID',
         projection: [Projections.ID],
         field: 'id',
     },
     [Properties.NAME]: {
-        label: 'Name',
+        label: 'Test plan name',
         projection: [Projections.NAME],
         field: 'name',
     },
@@ -147,7 +147,7 @@ export const PropertiesProjectionMap: Record<Properties, {
         field: 'workspace',
     },
     [Properties.WORK_ORDER]: {
-        label: 'Work order',
+        label: 'Work order name',
         projection: [Projections.WORK_ORDER_NAME, Projections.WORK_ORDER_ID],
         field: 'workOrderId',
     },
@@ -197,7 +197,7 @@ export const PropertiesProjectionMap: Record<Properties, {
         field: 'systemId',
     },
     [Properties.TEMPLATE]: {
-        label: 'Test plan template',
+        label: 'Test plan template name',
         projection: [Projections.TEMPLATE_ID],
         field: 'templateId',
     },

--- a/src/datasources/work-orders/types.ts
+++ b/src/datasources/work-orders/types.ts
@@ -45,17 +45,17 @@ export const WorkOrderProperties: Record<WorkOrderPropertiesOptions, {
   field: keyof WorkOrder;
 }> = {
   [WorkOrderPropertiesOptions.ID]: {
-    label: 'ID',
+    label: 'Work order ID',
     value: WorkOrderPropertiesOptions.ID,
     field: 'id',
   },
   [WorkOrderPropertiesOptions.NAME]: {
-    label: 'Name',
+    label: 'Work order name',
     value: WorkOrderPropertiesOptions.NAME,
     field: 'name',
   },
   [WorkOrderPropertiesOptions.TYPE]: {
-    label: 'Type',
+    label: 'Work order type',
     value: WorkOrderPropertiesOptions.TYPE,
     field: 'type',
   },


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To rename some fields and value mappings in datasource

## 👩‍💻 Implementation

- Updated field names
- Updated value mapping to return only work order name and template name

## 🧪 Testing

- Update unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).