### PR TITLE
feat(results): extend the take from 500 to 1000 when number of measurements < 25

### DIFF
--- a/src/datasources/results/constants/QuerySteps.constants.ts
+++ b/src/datasources/results/constants/QuerySteps.constants.ts
@@ -1,3 +1,4 @@
 export const QUERY_STEPS_REQUEST_PER_SECOND = 6;
-export const MAX_TAKE_PER_REQUEST = 500;
+export const MAX_TAKE_PER_REQUEST = 1000;
+export const MIN_TAKE_PER_REQUEST = 500;
 export const TAKE_LIMIT = 10000;

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -25,7 +25,7 @@ import { Workspace } from 'core/types';
 import { DataSourceBase } from 'core/DataSourceBase';
 
 const mockSteps = Array(1000).fill({ stepId: '1', name: 'Step 1' });
-const mockPaths = Array(1000).fill({ path: 'path1'});
+const mockPaths = Array(1000).fill({ path: 'path1' });
 
 const mockQueryStepsResponse: QueryStepsResponse = {
   steps: [
@@ -36,7 +36,7 @@ const mockQueryStepsResponse: QueryStepsResponse = {
         key1: 'value1',
         key2: 'value2',
       },
-      workspace: '1'
+      workspace: '1',
     },
   ],
   continuationToken: undefined,
@@ -266,13 +266,11 @@ describe('QueryStepsDataSource', () => {
       backendServer.fetch
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-steps', method: 'POST' }))
         .mockReturnValue(createFetchResponse(mockQueryStepsResponse));
-        const query = buildQuery(
-          {
-            refId: 'A',
-            outputType: OutputType.Data,
-            properties: [StepsProperties.workspace]
-          },
-        );
+      const query = buildQuery({
+        refId: 'A',
+        outputType: OutputType.Data,
+        properties: [StepsProperties.workspace],
+      });
 
       const response = await datastore.query(query);
 
@@ -288,20 +286,17 @@ describe('QueryStepsDataSource', () => {
       backendServer.fetch
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-steps', method: 'POST' }))
         .mockReturnValue(createFetchResponse(mockQueryStepsResponse));
-      const query = buildQuery(
-        {
-          refId: 'A',
-          outputType: OutputType.Data,
-          properties: [StepsProperties.workspace]
-        },
-      );
+      const query = buildQuery({
+        refId: 'A',
+        outputType: OutputType.Data,
+        properties: [StepsProperties.workspace],
+      });
 
       const response = await datastore.query(query);
 
       const fields = response.data[0].fields as Field[];
       expect(fields).toMatchSnapshot();
     });
-
 
     describe('show measurements is enabled', () => {
       describe('duplicate measurement names', () => {
@@ -912,7 +907,7 @@ describe('QueryStepsDataSource', () => {
           totalCount: 2000,
         }),
         createFetchResponse({
-          steps:mockSteps.slice(0, 500),
+          steps: mockSteps.slice(0, 500),
           continuationToken: null,
           totalCount: 2000,
         }),
@@ -965,7 +960,7 @@ describe('QueryStepsDataSource', () => {
 
       const measurements: StepData = {
         text: 'Step with many measurements',
-        parameters: Array(30).fill({ name: `Measurement`, measurement: '1.0' })
+        parameters: Array(30).fill({ name: `Measurement`, measurement: '1.0' }),
       };
 
       const stepsWithManyMeasurements = mockSteps.map(step => ({
@@ -983,7 +978,7 @@ describe('QueryStepsDataSource', () => {
           continuationToken: 'token2',
         }),
         createFetchResponse({
-          steps:stepsWithManyMeasurements.slice(0, 500),
+          steps: stepsWithManyMeasurements.slice(0, 500),
           continuationToken: null,
         }),
       ];
@@ -999,7 +994,7 @@ describe('QueryStepsDataSource', () => {
         undefined,
         1500,
         undefined,
-        undefined,
+        undefined
       );
 
       await jest.advanceTimersByTimeAsync(0);
@@ -1126,7 +1121,7 @@ describe('QueryStepsDataSource', () => {
 
       expect(response.steps).toHaveLength(2000);
       expect(backendServer.fetch).toHaveBeenCalledTimes(3);
-      expect(spyDelay).toHaveBeenCalledTimes(2); 
+      expect(spyDelay).toHaveBeenCalledTimes(2);
       expect(spyDelay).toHaveBeenCalledWith(expect.any(Function), 800); // delay for 1000 - 200 = 800ms
     });
   });

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -27,7 +27,7 @@ import { DataSourceBase } from 'core/DataSourceBase';
 const mockSteps = Array(1000).fill({ stepId: '1', name: 'Step 1' });
 const mockPaths = Array(1000).fill({ path: 'path1' });
 
-const mockQueryStepsResponse: QueryStepsResponse = {
+const mockQueryStepsResponse = {
   steps: [
     {
       stepId: '1',
@@ -825,14 +825,7 @@ describe('QueryStepsDataSource', () => {
         }),
       ];
       backendServer.fetch.mockImplementationOnce(() => mockResponses[0]);
-      const responsePromise = datastore.queryStepsInBatches(
-        undefined,
-        undefined,
-        undefined,
-        100,
-        undefined,
-        undefined,
-      );
+      const responsePromise = datastore.queryStepsInBatches(undefined, undefined, undefined, 100, undefined, undefined);
       const response = await responsePromise;
 
       expect(response.steps).toHaveLength(100);
@@ -863,7 +856,7 @@ describe('QueryStepsDataSource', () => {
         undefined,
         10000,
         undefined,
-        undefined,
+        undefined
       );
       const response = await responsePromise;
 
@@ -878,7 +871,7 @@ describe('QueryStepsDataSource', () => {
       expect(backendServer.fetch).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
-          data: expect.objectContaining({ take: 500, continuationToken: 'token1' }),
+          data: expect.objectContaining({ take: 1000, continuationToken: 'token1' }),
         })
       );
     });
@@ -913,7 +906,7 @@ describe('QueryStepsDataSource', () => {
         undefined,
         2000,
         undefined,
-        undefined,
+        undefined
       );
 
       await jest.advanceTimersByTimeAsync(0);
@@ -1021,14 +1014,7 @@ describe('QueryStepsDataSource', () => {
       ];
 
       backendServer.fetch.mockImplementationOnce(() => mockResponses[0]);
-      const response = await datastore.queryStepsInBatches(
-        undefined,
-        undefined,
-        undefined,
-        3000,
-        undefined,
-        undefined,
-      );
+      const response = await datastore.queryStepsInBatches(undefined, undefined, undefined, 3000, undefined, undefined);
 
       expect(response.steps).toHaveLength(500);
       expect(backendServer.fetch).toHaveBeenCalledTimes(1);
@@ -1095,7 +1081,7 @@ describe('QueryStepsDataSource', () => {
         undefined,
         2000,
         undefined,
-        undefined,
+        undefined
       );
 
       const response = await responsePromise;

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -164,10 +164,10 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
       );
 
       // Check if the first step has more than 25 measurements and reduce the max take per request accordingly
-      const {steps} = response;
+      const { steps } = response;
       const firstStep = steps[0];
-      const {data} = firstStep || {data: {parameters: []}};
-      const {parameters} = data || { parameters: [] };
+      const { data } = firstStep || { data: { parameters: [] } };
+      const { parameters } = data || { parameters: [] };
       const maxTakePerRequest = parameters.length >= 25 ? MIN_TAKE_PER_REQUEST : MAX_TAKE_PER_REQUEST;
 
       batchQueryConfig.maxTakePerRequest = maxTakePerRequest;
@@ -570,10 +570,8 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
       case StepsPropertiesOptions.STATUS:
         return (value as any)?.statusType || '';
       case StepsPropertiesOptions.WORKSPACE:
-            const workspaceId = value as string;
-            return this.workspaceValues.length 
-              ? getWorkspaceName(this.workspaceValues, workspaceId)
-              : workspaceId;
+        const workspaceId = value as string;
+        return this.workspaceValues.length ? getWorkspaceName(this.workspaceValues, workspaceId) : workspaceId;
       default:
         return value.toString();
     }

--- a/src/datasources/results/types/QuerySteps.types.ts
+++ b/src/datasources/results/types/QuerySteps.types.ts
@@ -137,7 +137,7 @@ export interface InputOutputValues {
 
 export interface StepData {
   text?: string;
-  parameters?: Array<{ [key: string]: string }>;
+  parameters: Array<{ [key: string]: string }>;
 };
 
 export interface StepsResponseProperties {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The current maximum take per request is 500 considering the response limits from web server when there are more measurements and conditions within a step. This takes too much time for fetching steps as the take is too small.

## 👩‍💻 Implementation

- Updated the implementation to extend the take from 500 to 1000 when the first step has <25 measurements

## 🧪 Testing

- Updated the existing tests and added new unit tests to verify the behavior
- The current implementation of creating the arrays within tests were time consuming and caused intermittent test failures, updated the test setup to create mock step/path arrays before the tests
- Verified the behavior across different use cases manually

## ✅ Checklist

- [X] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).