### PR TITLE
fix(workorders,testplans): Display empty cell for empty properties

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -573,6 +573,30 @@ describe('runQuery', () => {
     ]);
   });
 
+  it('should display empty cell when properties is empty', async () => {
+    const query = {
+      refId: 'A',
+      outputType: OutputType.Properties,
+      properties: [Properties.PROPERTIES],
+      orderBy: OrderByOptions.UPDATED_AT,
+      recordCount: 10,
+      descending: true,
+    };
+    const testPlansResponse = {
+      testPlans: [
+        { id: '1', properties: {} }
+      ],
+    };
+
+    jest.spyOn(datastore, 'queryTestPlansInBatches').mockResolvedValue(testPlansResponse);
+
+    const result = await datastore.runQuery(query, mockOptions);
+
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0].name).toEqual('Properties');
+    expect(result.fields[0].values).toEqual(['']);
+  });
+
   it('should convert systemIds to system names for system name property', async () => {
     const query = {
       refId: 'A',

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -140,7 +140,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
               const user = users.get(value);
               return user ? UsersUtils.getUserFullName(user) : '';
             case PropertiesProjectionMap.PROPERTIES.label:
-              return value == null ? '' : JSON.stringify(value);
+              return !!value && Object.keys(value).length > 0 ? JSON.stringify(value) : '';
             default:
               return value == null ? '' : value;
           }

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -162,6 +162,46 @@ describe('WorkOrdersDataSource', () => {
       const fields = response.fields as Field[];
       expect(fields).toMatchSnapshot();
     });
+
+    it('should handle test plan custom properties', async () => {
+      const query = {
+        refId: 'A',
+        outputType: OutputType.Properties,
+        properties: [WorkOrderPropertiesOptions.PROPERTIES],
+        take: 1000,
+      };
+      const workordersResponse = [
+        { id: '1', properties: { customProp1: 'value1', customProp2: 'value2' } },
+        { id: '2', properties: { customProp1: 'value3' } },
+      ];
+      jest.spyOn(datastore, 'queryWorkordersData').mockResolvedValue(workordersResponse as unknown as WorkOrder[]);
+
+      const result = await datastore.runQuery(query, {} as DataQueryRequest);
+
+      expect(result.fields).toHaveLength(1);
+      expect(result.fields[0].name).toEqual('Properties');
+      expect(result.fields[0].values).toEqual([
+        JSON.stringify({ customProp1: 'value1', customProp2: 'value2' }),
+        JSON.stringify({ customProp1: 'value3' }),
+      ]);
+    });
+
+    it('should display empty cell when properties is empty', async () => {
+      const query = {
+        refId: 'A',
+        outputType: OutputType.Properties,
+        properties: [WorkOrderPropertiesOptions.PROPERTIES],
+        take: 1000,
+      };
+      const workordersResponse = [{ id: '1', properties: {} }];
+      jest.spyOn(datastore, 'queryWorkordersData').mockResolvedValue(workordersResponse as unknown as WorkOrder[]);
+
+      const result = await datastore.runQuery(query, {} as DataQueryRequest);
+
+      expect(result.fields).toHaveLength(1);
+      expect(result.fields[0].name).toEqual('Properties');
+      expect(result.fields[0].values).toEqual(['']);
+    });    
     
     it('should convert user Ids to user names for assigned to field', async () => {
       const query = {

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -139,7 +139,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
             return user ? UsersUtils.getUserFullName(user) : userId;
           case WorkOrderPropertiesOptions.PROPERTIES:
               const properties = workOrder.properties || {};
-              return JSON.stringify(properties);
+              return Object.keys(properties).length > 0 ? JSON.stringify(properties) : '';
           default:
             return workOrder[field.field] ?? '';
         }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To display empty cells in table when object is empty

## 👩‍💻 Implementation

- Updated datasources to check the number of keys before stringifying JSON. If the object has no keys, an empty string is returned.

## 🧪 Testing

- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).