### PR TITLE
fix(results): fix ResultsQueryEditor to handle undefined queryType in Explore mode

### DIFF
--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -83,15 +83,12 @@ describe('ResultsQueryEditor', () => {
       });
     });
 
-     test('should call onChange with defaultResultsQuery and queryType Results when queryType is undefined', () => {
-    render(
-      <ResultsQueryEditor
-        {...defaultProps}
-        query={{ refId: 'A' } as ResultsQuery}
-      />
-    );
-    expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({...defaultResultsQuery, queryType: QueryType.Results, refId: 'A' }));
-  })
+    test('should call onChange with defaultResultsQuery and queryType Results when queryType is undefined', () => {
+      render(<ResultsQueryEditor {...defaultProps} query={{ refId: 'A' } as ResultsQuery} />);
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({ ...defaultResultsQuery, queryType: QueryType.Results, refId: 'A' })
+      );
+    });
   });
 
   test('should save stepsQuery value only when switched from steps query type to results', async () => {

--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -82,6 +82,16 @@ describe('ResultsQueryEditor', () => {
         expect(mockOnRunQuery).toHaveBeenCalled();
       });
     });
+
+     test('should call onChange with defaultResultsQuery and queryType Results when queryType is undefined', () => {
+    render(
+      <ResultsQueryEditor
+        {...defaultProps}
+        query={{ refId: 'A' } as ResultsQuery}
+      />
+    );
+    expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({...defaultResultsQuery, queryType: QueryType.Results, refId: 'A' }));
+  })
   });
 
   test('should save stepsQuery value only when switched from steps query type to results', async () => {
@@ -216,6 +226,18 @@ describe('ResultsQueryEditor', () => {
       expect(mockOnRunQuery).toHaveBeenCalled();
       expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ ...defaultResultsQuery, queryType: QueryType.Results, refId: 'A' }));
       
+    })
+
+    test('should set query Type when query type is selected', () => {
+      const query = {
+        refId: 'A',
+        queryType: QueryType.Results,
+        customProperty: 'customValue',
+      };
+
+    renderElement(query);
+      expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ 
+        ...defaultResultsQuery, queryType: QueryType.Results, refId: 'A' , customProperty: 'customValue'}));
     })
   });
 

--- a/src/datasources/results/components/ResultsQueryEditor.test.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.test.tsx
@@ -227,18 +227,6 @@ describe('ResultsQueryEditor', () => {
       expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ ...defaultResultsQuery, queryType: QueryType.Results, refId: 'A' }));
       
     })
-
-    test('should set query Type when query type is selected', () => {
-      const query = {
-        refId: 'A',
-        queryType: QueryType.Results,
-        customProperty: 'customValue',
-      };
-
-    renderElement(query);
-      expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ 
-        ...defaultResultsQuery, queryType: QueryType.Results, refId: 'A' , customProperty: 'customValue'}));
-    })
   });
 
   describe('Datasource', () => {

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -33,8 +33,8 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
           setStepsQuery(query as QuerySteps);
         }
         handleQueryChange({
-          ...query,
           queryType,
+          ...query,
           ...defaultResultsQuery,
           ...resultsQuery,
           refId: query.refId,
@@ -46,8 +46,8 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
           setResultsQuery(query as QueryResults);
         }
         handleQueryChange({
-          ...query,
           queryType,
+          ...query,
           ...defaultStepsQuery,
           ...stepsQuery,
           refId: query.refId,

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -33,8 +33,8 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
           setStepsQuery(query as QuerySteps);
         }
         handleQueryChange({
-          queryType,
           ...query,
+          queryType,
           ...defaultResultsQuery,
           ...resultsQuery,
           refId: query.refId,
@@ -46,8 +46,8 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
           setResultsQuery(query as QueryResults);
         }
         handleQueryChange({
-          queryType,
           ...query,
+          queryType,
           ...defaultStepsQuery,
           ...stepsQuery,
           refId: query.refId,

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -15,8 +15,6 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
   const [resultsQuery, setResultsQuery] = React.useState<QueryResults>();
   const [stepsQuery, setStepsQuery] = React.useState<QuerySteps>();
 
-  query = datasource.prepareQuery(query);
-
   const handleQueryChange = useCallback(
     (query: ResultsQuery, runQuery = true): void => {
       onChange(query);
@@ -35,9 +33,10 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
           setStepsQuery(query as QuerySteps);
         }
         handleQueryChange({
-          ...defaultResultsQuery,
+          ...query,
+          queryType,
           ...resultsQuery,
-          queryType: QueryType.Results,
+          ...defaultResultsQuery,
           refId: query.refId,
         });
         break;
@@ -47,8 +46,10 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
           setResultsQuery(query as QueryResults);
         }
         handleQueryChange({
-          ...defaultStepsQuery,
+          ...query,
+          queryType,
           ...stepsQuery,
+          ...defaultStepsQuery,
           refId: query.refId,
         });
         break;

--- a/src/datasources/results/components/ResultsQueryEditor.tsx
+++ b/src/datasources/results/components/ResultsQueryEditor.tsx
@@ -35,8 +35,8 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
         handleQueryChange({
           ...query,
           queryType,
-          ...resultsQuery,
           ...defaultResultsQuery,
+          ...resultsQuery,
           refId: query.refId,
         });
         break;
@@ -48,8 +48,8 @@ export function ResultsQueryEditor({ query, onChange, onRunQuery, datasource }: 
         handleQueryChange({
           ...query,
           queryType,
-          ...stepsQuery,
           ...defaultStepsQuery,
+          ...stepsQuery,
           refId: query.refId,
         });
         break;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In the current implementation, the Results datasource in Explore mode was throwing an error and couldn’t be used. To fix this, the query needs to be passed as an additional parameter into the handleQueryChange function.
![image](https://github.com/user-attachments/assets/c0d42860-40ae-411a-ab0d-4b2c8aa9fc82)

## 👩‍💻 Implementation

* Removed the `datasource.prepareQuery` call from the `ResultsQueryEditor` component, simplifying the query initialization process.
* Updated query merging logic to prioritize existing `query` properties over defaults when switching query types, ensuring more predictable behavior

## 🧪 Testing

* Added a test to verify that `onChange` is called with `defaultResultsQuery` and `queryType: Results` when `queryType` is undefined.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).