### PR TITLE
fix(results): enhance error handling for 429 and 404 API responses 

### DIFF
--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.test.ts
@@ -95,6 +95,26 @@ describe('QueryResultsDataSource', () => {
         });
       });
 
+    test('should throw error when API returns 404 status', async () => {
+        backendServer.fetch
+          .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results' }))
+          .mockReturnValue(createFetchError(404));
+    
+        await expect(datastore.queryResults())
+          .rejects
+          .toThrow('The query to fetch results failed because the requested resource was not found. Please check the query parameters and try again.');
+      });
+
+    test('should throw error when API returns 429 status', async () => {
+        backendServer.fetch
+          .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results' }))
+          .mockReturnValue(createFetchError(429));
+    
+        await expect(datastore.queryResults())
+          .rejects
+          .toThrow('The query to fetch results failed due to too many requests. Please try again later.');
+      });
+
     test('should throw timeOut error when API returns 504 status', async () => {
         backendServer.fetch
           .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-results' }))

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -48,12 +48,22 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
       const errorDetails = extractErrorInfo((error as Error).message);
       let errorMessage: string;
 
-      if (!errorDetails.statusCode) {
-        errorMessage = 'The query failed due to an unknown error.';
-      } else if (errorDetails.statusCode === '504') {
-        errorMessage = 'The query to fetch results experienced a timeout error. Narrow your query with a more specific filter and try again.';
-      } else {
-        errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+      switch (errorDetails.statusCode) {
+        case undefined:
+          errorMessage = 'The query failed due to an unknown error.';
+          break;
+        case '404':
+          errorMessage = 'The query to fetch results failed because the requested resource was not found. Please check the query parameters and try again.';
+          break;
+        case '429':
+          errorMessage = 'The query to fetch results failed due to too many requests. Please try again later.';
+          break;
+        case '504':
+          errorMessage = 'The query to fetch results experienced a timeout error. Narrow your query with a more specific filter and try again.';
+          break;
+        default:
+          errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+          break;
       }
 
       this.appEvents?.publish?.({

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.test.ts
@@ -142,6 +142,26 @@ describe('QueryStepsDataSource', () => {
       });
     });
 
+    it('should throw too many requests error when API returns 429 status', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-steps' }))
+        .mockReturnValue(createFetchError(429));
+
+      await expect(datastore.querySteps()).rejects.toThrow(
+        'The query to fetch steps failed due to too many requests. Please try again later.'
+      );
+    });
+
+    it('should throw not found error when API returns 404 status', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-steps' }))
+        .mockReturnValue(createFetchError(404));
+
+      await expect(datastore.querySteps()).rejects.toThrow(
+        'The query to fetch steps failed because the requested resource was not found. Please check the query parameters and try again.'
+      );
+    })
+
     it('should throw timeOut error when API returns 504 status', async () => {
       backendServer.fetch
         .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-steps' }))

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -98,13 +98,22 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
       const errorDetails = extractErrorInfo((error as Error).message);
 
       let errorMessage: string;
-      if (!errorDetails.statusCode) {
-        errorMessage = 'The query failed due to an unknown error.';
-      } else if (errorDetails.statusCode === '504') {
-        errorMessage =
-          'The query to fetch steps experienced a timeout error. Narrow your query with a more specific filter and try again.';
-      } else {
-        errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+      switch (errorDetails.statusCode) {
+        case undefined:
+          errorMessage = 'The query failed due to an unknown error.';
+          break;
+        case '404':
+          errorMessage = 'The query to fetch steps failed because the requested resource was not found. Please check the query parameters and try again.';
+          break;
+        case '429':
+          errorMessage = 'The query to fetch steps failed due to too many requests. Please try again later.';
+          break;
+        case '504':
+          errorMessage = 'The query to fetch steps experienced a timeout error. Narrow your query with a more specific filter and try again.';
+          break;
+        default:
+          errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+          break;
       }
 
       this.appEvents?.publish?.({


### PR DESCRIPTION

# Pull Request

## 🤨 Rationale

Currently when API's throw an HTTP status codes 404 (Not Found) and 429 (Too Many Requests) the error message is shown as a long HTML error. To fix this we need to add proper custom messages to let the user understand the error better.

## 👩‍💻 Implementation
* Refactored error handling logic to use a `switch` statement for better readability and added specific error messages for 404 and 429 status codes.

## 🧪 Testing

* Added test cases to verify error handling for 404 and 429 HTTP status codes 

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).