### PR TITLE
fix(workorders,testplans): enhance error handling for 429 and 404 API responses

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -1237,6 +1237,26 @@ describe('queryTestPlans', () => {
       );
     });
 
+    it('should throw too many requests error when API returns 429 status', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/niworkorder/v1/query-testplans' }))
+        .mockReturnValue(createFetchError(429));
+
+      await expect(datastore.queryTestPlans()).rejects.toThrow(
+        'The query to fetch testplans failed due to too many requests. Please try again later.'
+      );
+    });
+
+    it('should throw not found error when API returns 404 status', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/niworkorder/v1/query-testplans' }))
+        .mockReturnValue(createFetchError(404));
+
+      await expect(datastore.queryTestPlans()).rejects.toThrow(
+        'The query to fetch testplans failed because the requested resource was not found. Please check the query parameters and try again.'
+      );
+    })
+
     it('should throw error with unknown error when API returns error without status', async () => {
       backendServer.fetch
         .calledWith(requestMatching({ url: '/niworkorder/v1/query-testplans' }))

--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -1027,6 +1027,34 @@ describe('loadWorkspaces', () => {
       `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
     );
   });
+
+  it('should throw too many requests error when API returns 429 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.workspaceUtils, 'getWorkspaces')
+      .mockRejectedValue(new Error('Request failed with status code: 429'));
+
+    await datastore.loadWorkspaces();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups failed due to too many requests. Please try again later.`
+    );
+  });
+
+  it('should throw not found error when API returns 404 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.workspaceUtils, 'getWorkspaces')
+      .mockRejectedValue(new Error('Request failed with status code: 404'));
+
+    await datastore.loadWorkspaces();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups failed because the requested resource was not found. Please check the query parameters and try again.`
+    );
+  });
 });
 
 describe('loadUsers', () => {
@@ -1075,6 +1103,34 @@ describe('loadUsers', () => {
     expect(datastore.errorTitle).toBe('Warning during testplans query');
     expect(datastore.errorDescription).toContain(
       `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
+    );
+  });
+
+  it('should throw too many requests error when API returns 429 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.usersUtils, 'getUsers')
+      .mockRejectedValue(new Error('Request failed with status code: 429'));
+
+    await datastore.loadUsers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups failed due to too many requests. Please try again later.`
+    );
+  });
+
+  it('should throw not found error when API returns 404 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.usersUtils, 'getUsers')
+      .mockRejectedValue(new Error('Request failed with status code: 404'));
+
+    await datastore.loadUsers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups failed because the requested resource was not found. Please check the query parameters and try again.`
     );
   });
 });
@@ -1126,6 +1182,34 @@ describe('loadSystemAliases', () => {
       `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
     );
   });
+
+  it('should throw too many requests error when API returns 429 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.systemUtils, 'getSystemAliases')
+      .mockRejectedValue(new Error('Request failed with status code: 429'));
+
+    await datastore.loadSystemAliases();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups failed due to too many requests. Please try again later.`
+    );
+  });
+
+  it('should throw not found error when API returns 404 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.systemUtils, 'getSystemAliases')
+      .mockRejectedValue(new Error('Request failed with status code: 404'));
+
+    await datastore.loadSystemAliases();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups failed because the requested resource was not found. Please check the query parameters and try again.`
+    );
+  });
 });
 
 describe('loadProductNamesAndPartNumbers', ()=>{
@@ -1174,6 +1258,34 @@ describe('loadProductNamesAndPartNumbers', ()=>{
     expect(datastore.errorTitle).toBe('Warning during testplans query');
     expect(datastore.errorDescription).toContain(
       `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
+    );
+  });
+
+  it('should throw too many requests error when API returns 429 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.productUtils, 'getProductNamesAndPartNumbers')
+      .mockRejectedValue(new Error('Request failed with status code: 429'));
+
+    await datastore.loadProductNamesAndPartNumbers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups failed due to too many requests. Please try again later.`
+    );
+  });
+
+  it('should throw not found error when API returns 404 status', async () => {
+    datastore.errorTitle = '';
+    jest
+      .spyOn(datastore.productUtils, 'getProductNamesAndPartNumbers')
+      .mockRejectedValue(new Error('Request failed with status code: 404'));
+
+    await datastore.loadProductNamesAndPartNumbers();
+
+    expect(datastore.errorTitle).toBe('Warning during testplans query');
+    expect(datastore.errorDescription).toContain(
+      `The query builder lookups failed because the requested resource was not found. Please check the query parameters and try again.`
     );
   });
 })

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -494,12 +494,21 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   private handleDependenciesError(error: unknown): void {
     const errorDetails = extractErrorInfo((error as Error).message);
     this.errorTitle = 'Warning during testplans query';
-    if (errorDetails.statusCode === '504') {
-      this.errorDescription = `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`;
-    } else {
-      this.errorDescription = errorDetails.message
-        ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`
-        : 'Some values may not be available in the query builder lookups due to an unknown error.';
+    switch (errorDetails.statusCode) {
+      case '404':
+        this.errorDescription = 'The query builder lookups failed because the requested resource was not found. Please check the query parameters and try again.';
+        break;
+      case '429':
+        this.errorDescription = 'The query builder lookups failed due to too many requests. Please try again later.';
+        break;
+      case '504':
+        this.errorDescription = `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`;
+        break;
+      default:
+        this.errorDescription = errorDetails.message
+          ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`
+          : 'Some values may not be available in the query builder lookups due to an unknown error.';
+        break;
     }
   }
 

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -420,12 +420,22 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
     } catch (error) {
       const errorDetails = extractErrorInfo((error as Error).message);
       let errorMessage: string;
-      if (!errorDetails.statusCode) {
-        errorMessage = 'The query failed due to an unknown error.';
-      } else if (errorDetails.statusCode === '504') {
-        errorMessage = 'The query to fetch testplans experienced a timeout error. Narrow your query with a more specific filter and try again.';
-      } else {
-        errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+      switch (errorDetails.statusCode) {
+        case '':
+          errorMessage = 'The query failed due to an unknown error.';
+          break;
+        case '404':
+          errorMessage = 'The query to fetch testplans failed because the requested resource was not found. Please check the query parameters and try again.';
+          break;
+        case '429':
+          errorMessage = 'The query to fetch testplans failed due to too many requests. Please try again later.';
+          break;
+        case '504':
+          errorMessage = 'The query to fetch testplans experienced a timeout error. Narrow your query with a more specific filter and try again.';
+          break;
+        default:
+          errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+          break;
       }
 
       this.appEvents?.publish?.({

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -531,6 +531,34 @@ describe('WorkOrdersDataSource', () => {
         `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
       );
     });
+
+    it('should throw too many requests error when API returns 429 status', async () => {
+      datastore.errorTitle = '';
+      jest
+        .spyOn(datastore.workspaceUtils, 'getWorkspaces')
+        .mockRejectedValue(new Error('Request failed with status code: 429'));
+
+      await datastore.loadWorkspaces();
+
+      expect(datastore.errorTitle).toBe('Warning during workorders query');
+      expect(datastore.errorDescription).toContain(
+        `The query builder lookups failed due to too many requests. Please try again later.`
+      );
+    });
+
+    it('should throw not found error when API returns 404 status', async () => {
+      datastore.errorTitle = '';
+      jest
+        .spyOn(datastore.workspaceUtils, 'getWorkspaces')
+        .mockRejectedValue(new Error('Request failed with status code: 404'));
+
+      await datastore.loadWorkspaces();
+
+      expect(datastore.errorTitle).toBe('Warning during workorders query');
+      expect(datastore.errorDescription).toContain(
+        `The query builder lookups failed because the requested resource was not found. Please check the query parameters and try again.`
+      );
+    });
   });
 
   describe('loadUsers', () => {
@@ -579,6 +607,34 @@ describe('WorkOrdersDataSource', () => {
       expect(datastore.errorTitle).toBe('Warning during workorders query');
       expect(datastore.errorDescription).toContain(
         `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`
+      );
+    });
+
+    it('should throw too many requests error when API returns 429 status', async () => {
+      datastore.errorTitle = '';
+      jest
+        .spyOn(datastore.usersUtils, 'getUsers')
+        .mockRejectedValue(new Error('Request failed with status code: 429'));
+
+      await datastore.loadUsers();
+
+      expect(datastore.errorTitle).toBe('Warning during workorders query');
+      expect(datastore.errorDescription).toContain(
+        `The query builder lookups failed due to too many requests. Please try again later.`
+      );
+    });
+
+    it('should throw not found error when API returns 404 status', async () => {
+      datastore.errorTitle = '';
+      jest
+        .spyOn(datastore.usersUtils, 'getUsers')
+        .mockRejectedValue(new Error('Request failed with status code: 404'));
+
+      await datastore.loadUsers();
+
+      expect(datastore.errorTitle).toBe('Warning during workorders query');
+      expect(datastore.errorDescription).toContain(
+        `The query builder lookups failed because the requested resource was not found. Please check the query parameters and try again.`
       );
     });
   });

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -654,6 +654,26 @@ describe('WorkOrdersDataSource', () => {
       );
     });
 
+    it('should throw too many requests error when API returns 429 status', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/niworkorder/v1/query-workorders' }))
+        .mockReturnValue(createFetchError(429));
+
+      await expect(datastore.queryWorkOrders({})).rejects.toThrow(
+        'The query to fetch workorders failed due to too many requests. Please try again later.'
+      );
+    });
+
+    it('should throw not found error when API returns 404 status', async () => {
+      backendServer.fetch
+        .calledWith(requestMatching({ url: '/niworkorder/v1/query-workorders' }))
+        .mockReturnValue(createFetchError(404));
+
+      await expect(datastore.queryWorkOrders({})).rejects.toThrow(
+        'The query to fetch workorders failed because the requested resource was not found. Please check the query parameters and try again.'
+      );
+    })
+
     it('should throw error with unknown error when API returns error without status', async () => {
       backendServer.fetch
         .calledWith(requestMatching({ url: '/niworkorder/v1/query-workorders' }))

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -315,12 +315,21 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
   private handleDependenciesError(error: unknown): void {
     const errorDetails = extractErrorInfo((error as Error).message);
     this.errorTitle = 'Warning during workorders query';
-    if (errorDetails.statusCode === '504') {
-      this.errorDescription = `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`;
-    } else {
-      this.errorDescription = errorDetails.message
-        ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`
-        : 'Some values may not be available in the query builder lookups due to an unknown error.';
+    switch (errorDetails.statusCode) {
+      case '404':
+        this.errorDescription = 'The query builder lookups failed because the requested resource was not found. Please check the query parameters and try again.';
+        break;
+      case '429':
+        this.errorDescription = 'The query builder lookups failed due to too many requests. Please try again later.';
+        break;
+      case '504':
+        this.errorDescription = `The query builder lookups experienced a timeout error. Some values might not be available. Narrow your query with a more specific filter and try again.`;
+        break;
+      default:
+        this.errorDescription = errorDetails.message
+          ? `Some values may not be available in the query builder lookups due to the following error: ${errorDetails.message}.`
+          : 'Some values may not be available in the query builder lookups due to an unknown error.';
+        break;
     }
   }
 

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -229,12 +229,22 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
     } catch (error) {
       const errorDetails = extractErrorInfo((error as Error).message);
       let errorMessage: string;
-      if (!errorDetails.statusCode) {
-        errorMessage = 'The query failed due to an unknown error.';
-      } else if (errorDetails.statusCode === '504') {
-        errorMessage = 'The query to fetch workorders experienced a timeout error. Narrow your query with a more specific filter and try again.';
-      } else {
-        errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+      switch (errorDetails.statusCode) {
+        case '':
+          errorMessage = 'The query failed due to an unknown error.';
+          break;
+        case '404':
+          errorMessage = 'The query to fetch workorders failed because the requested resource was not found. Please check the query parameters and try again.';
+          break;
+        case '429':
+          errorMessage = 'The query to fetch workorders failed due to too many requests. Please try again later.';
+          break;
+        case '504':
+          errorMessage = 'The query to fetch workorders experienced a timeout error. Narrow your query with a more specific filter and try again.';
+          break;
+        default:
+          errorMessage = `The query failed due to the following error: (status ${errorDetails.statusCode}) ${errorDetails.message}.`;
+          break;
       }
 
       this.appEvents?.publish?.({


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Currently when API's throw an HTTP status codes 404 (Not Found) and 429 (Too Many Requests) the error message is shown as a long HTML error. To fix this we need to add proper custom messages to let the user understand the error better.

![image](https://github.com/user-attachments/assets/56d02514-3c95-49a4-bd13-b588e6230d3f)

## 👩‍💻 Implementation
* Refactored error handling logic to use a `switch` statement for better readability and added specific error messages for 404 and 429 status codes.

## 🧪 Testing

- Added unit tests 

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).