### PR TITLE
fix: add showErrorAlert option to POST requests across data sources

### DIFF
--- a/src/core/DataSourceBase.ts
+++ b/src/core/DataSourceBase.ts
@@ -72,8 +72,8 @@ export abstract class DataSourceBase<TQuery extends DataQuery, TOptions extends 
     return this.fetch<T>({ method: 'GET', url, params });
   }
 
-  post<T>(url: string, body: Record<string, any>) {
-    return this.fetch<T>({ method: 'POST', url, data: body });
+  post<T>(url: string, body: Record<string, any>, showErrorAlert = true) {
+    return this.fetch<T>({ method: 'POST', url, data: body, showErrorAlert });
   }
 
   static Workspaces: Workspace[];

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -65,14 +65,18 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
     returnCount = false
   ): Promise<QueryProductResponse> {
     try {
-      const response = await this.post<QueryProductResponse>(this.queryProductsUrl, {
-        filter,
-        orderBy,
-        descending,
-        projection,
-        take,
-        returnCount
-      });
+      const response = await this.post<QueryProductResponse>(
+        this.queryProductsUrl,
+        {
+          filter,
+          orderBy,
+          descending,
+          projection,
+          take,
+          returnCount
+        },
+        false
+      );
       return response;
     } catch (error) {
       const errorDetails = extractErrorInfo((error as Error).message);
@@ -95,9 +99,13 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
   }
 
   async queryProductValues(fieldName: string): Promise<string[]> {
-    return await this.post<string[]>(this.queryProductValuesUrl, {
-      field: fieldName
-    });
+    return await this.post<string[]>(
+      this.queryProductValuesUrl,
+      {
+        field: fieldName
+      },
+      false
+    );
   }
 
   async runQuery(query: ProductQuery, options: DataQueryRequest): Promise<DataFrameDTO> {

--- a/src/datasources/results/ResultsDataSourceBase.ts
+++ b/src/datasources/results/ResultsDataSourceBase.ts
@@ -89,18 +89,26 @@ export abstract class ResultsDataSourceBase extends DataSourceBase<ResultsQuery>
   }
 
   async queryResultsValues(fieldName: string, filter?: string): Promise<string[]> {
-    return await this.post<string[]>(this.queryResultsValuesUrl, {
-      field: fieldName,
-      filter
-    });
+    return await this.post<string[]>(
+      this.queryResultsValuesUrl,
+      {
+        field: fieldName,
+        filter
+      },
+      false
+    );
   }
 
   async queryProducts(
     projection?: ProductProperties[],
   ): Promise<QueryProductResponse> {
-    const response = await this.post<QueryProductResponse>(this.queryProductsUrl, {
-      projection,
-    });
+    const response = await this.post<QueryProductResponse>(
+      this.queryProductsUrl,
+      {
+        projection,
+      },
+      false
+    );
     return response;
   }
 

--- a/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-results/QueryResultsDataSource.ts
@@ -36,14 +36,18 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
     returnCount = false
   ): Promise<QueryResultsResponse> {
     try {
-      return await this.post<QueryResultsResponse>(`${this.queryResultsUrl}`, {
-        filter,
-        orderBy,
-        descending,
-        projection,
-        take,
-        returnCount,
-      });
+      return await this.post<QueryResultsResponse>(
+        `${this.queryResultsUrl}`,
+        {
+          filter,
+          orderBy,
+          descending,
+          projection,
+          take,
+          returnCount,
+        },
+        false
+      );
     } catch (error) {
       const errorDetails = extractErrorInfo((error as Error).message);
       let errorMessage: string;
@@ -156,8 +160,8 @@ export class QueryResultsDataSource extends ResultsDataSourceBase {
             }
           default:
             return {
-              name: resultsProjectionLabelLookup[field].label, 
-              values: values.map(value => value?.toString()), 
+              name: resultsProjectionLabelLookup[field].label,
+              values: values.map(value => value?.toString()),
               type: fieldType
             };
         }

--- a/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
+++ b/src/datasources/results/query-handlers/query-steps/QueryStepsDataSource.ts
@@ -83,16 +83,20 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
     returnCount = false
   ): Promise<QueryStepsResponse> {
     try {
-      const response = await this.post<QueryStepsResponse>(`${this.queryStepsUrl}`, {
-        filter,
-        orderBy,
-        descending,
-        projection,
-        take,
-        resultFilter,
-        continuationToken,
-        returnCount,
-      });
+      const response = await this.post<QueryStepsResponse>(
+        `${this.queryStepsUrl}`,
+        {
+          filter,
+          orderBy,
+          descending,
+          projection,
+          take,
+          resultFilter,
+          continuationToken,
+          returnCount,
+        },
+        false
+      );
       return response;
     } catch (error) {
       const errorDetails = extractErrorInfo((error as Error).message);
@@ -132,13 +136,17 @@ export class QueryStepsDataSource extends ResultsDataSourceBase {
     continuationToken?: string,
   ): Promise<QueryStepPathsResponse> {
     const defaultOrderBy = StepsPathProperties.path;
-    return await this.post<QueryStepPathsResponse>(this.queryPathsUrl, {
-      filter,
-      projection,
-      take,
-      orderBy: defaultOrderBy,
-      continuationToken,
-    });
+    return await this.post<QueryStepPathsResponse>(
+      this.queryPathsUrl,
+      {
+        filter,
+        projection,
+        take,
+        orderBy: defaultOrderBy,
+        continuationToken,
+      },
+      false
+    );
   }
 
   async queryStepsInBatches(

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -407,15 +407,19 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
     returnCount = false
   ): Promise<QueryTestPlansResponse> {
     try {
-      const response = await this.post<QueryTestPlansResponse>(this.queryTestPlansUrl, {
-        filter,
-        orderBy,
-        descending,
-        projection,
-        take,
-        continuationToken,
-        returnCount
-      });
+      const response = await this.post<QueryTestPlansResponse>(
+        this.queryTestPlansUrl,
+        {
+          filter,
+          orderBy,
+          descending,
+          projection,
+          take,
+          continuationToken,
+          returnCount
+        },
+        false
+      );
       return response;
     } catch (error) {
       const errorDetails = extractErrorInfo((error as Error).message);
@@ -472,9 +476,11 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   async queryTestPlanTemplates(templateIds: string[]): Promise<TemplateResponseProperties[]> {
     try {
       const filter = templateIds.map(id => `id = "${id}"`).join(' || ');
-      const response = await this.post<QueryTemplatesResponse>(this.queryTemplatesUrl, {
-        filter
-      });
+      const response = await this.post<QueryTemplatesResponse>(
+        this.queryTemplatesUrl,
+        { filter },
+        false
+      );
       return response.testPlanTemplates;
     } catch (error) {
       throw new Error(`An error occurred while querying test plan templates: ${error} `);

--- a/src/datasources/test-plans/asset.utils.ts
+++ b/src/datasources/test-plans/asset.utils.ts
@@ -54,7 +54,11 @@ export class AssetUtils {
             returnCount: true
         };
         try {
-            let response = await this.backendSrv.post<QueryAssetNameResponse>(this.queryAssetsUrl, body);
+            let response = await this.backendSrv.post<QueryAssetNameResponse>(
+                this.queryAssetsUrl,
+                body,
+                { showErrorAlert: false }
+            );
             return response;
         } catch (error) {
             throw new Error(`An error occurred while querying assets: ${error}`);

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -224,7 +224,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
 
   async queryWorkOrders(body: QueryWorkOrdersRequestBody): Promise<WorkOrdersResponse> {
     try {
-      let response = await this.post<WorkOrdersResponse>(this.queryWorkOrdersUrl, body);
+      let response = await this.post<WorkOrdersResponse>(this.queryWorkOrdersUrl, body, false);
       return response;
     } catch (error) {
       const errorDetails = extractErrorInfo((error as Error).message);
@@ -287,7 +287,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
   }
 
   async testDatasource(): Promise<TestDataSourceResponse> {
-    await this.post(this.queryWorkOrdersUrl, { take: 1 });
+    await this.post(this.queryWorkOrdersUrl, { take: 1 }, false);
     return { status: 'success', message: 'Data source connected and authentication successful!' };
   }
 

--- a/src/shared/product.utils.ts
+++ b/src/shared/product.utils.ts
@@ -59,14 +59,18 @@ export class ProductUtils {
         returnCount = true
     ): Promise<QueryProductResponse> {
         try {
-            const response = await this.backendSrv.post<QueryProductResponse>(this.queryProductsUrl, {
+        const response = await this.backendSrv.post<QueryProductResponse>(
+            this.queryProductsUrl,
+            {
                 descending,
                 projection,
                 take,
                 continuationToken,
                 returnCount
-            });
-            return response;
+            },
+            { showErrorAlert: false }
+        );
+        return response;
         } catch (error) {
             throw new Error(`An error occurred while querying products: ${error} `);
         }

--- a/src/shared/system.utils.ts
+++ b/src/shared/system.utils.ts
@@ -54,11 +54,15 @@ export class SystemUtils {
         skip?: number
     ): Promise<QuerySystemsResponse> {
         try {
-            const response = await this.backendSrv.post<QuerySystemsResponse>(this.querySystemsUrl, {
-                projection: QUERY_SYSTEMS_ALIAS_PROJECTION,
-                skip,
-                take
-            });
+            const response = await this.backendSrv.post<QuerySystemsResponse>(
+                this.querySystemsUrl,
+                {
+                    projection: QUERY_SYSTEMS_ALIAS_PROJECTION,
+                    skip,
+                    take
+                },
+                { showErrorAlert: false }
+            );
             return response;
         } catch (error) {
             throw new Error(`An error occurred while querying systems: ${error}`);

--- a/src/shared/users.utils.ts
+++ b/src/shared/users.utils.ts
@@ -100,6 +100,10 @@ export class UsersUtils {
    * @returns A promise that resolves to the user query response.
    */
   private queryUsers(body: QueryUsersRequest): Promise<QueryUsersResponse> {
-    return this.backendSrv.post<QueryUsersResponse>(`${this.instanceSettings.url}/niuser/v1/users/query`, body);
+    return this.backendSrv.post<QueryUsersResponse>(
+      `${this.instanceSettings.url}/niuser/v1/users/query`,
+      body,
+      { showErrorAlert: false }
+    );
   }
 }

--- a/src/shared/workspace.utils.ts
+++ b/src/shared/workspace.utils.ts
@@ -29,7 +29,12 @@ export class WorkspaceUtils {
     }
 
     private async fetchWorkspaces(): Promise<Workspace[]> {
-        const response = await this.backendSrv.get<{ workspaces: Workspace[] }>(this.queryWorkspacesUrl);
+        const response = await this.backendSrv.get<{ workspaces: Workspace[] }>(
+            this.queryWorkspacesUrl,
+            undefined,
+            undefined,
+            { showErrorAlert: false }
+        );
         return response.workspaces;
     }
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

When an error occurs during a request made using backendSrv.fetch, we see two error messages appear. This happens because the error is being handled both by backendSrv and the internal fetch method. To fix this, we should set showErrorAlert to false in the options passed to backendSrv.

![image](https://github.com/user-attachments/assets/c57a324d-8274-48da-89d7-178fd07d399a)


## 👩‍💻 Implementation

* Updated the `post` method to include a `showErrorAlert` parameter, defaulting to `true`. This enables callers to suppress error alerts when necessary.

* Modified calls to the `post` method in the products, results, testplans and workorder datasources instances

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).