### PR TITLE
fix(workorders,testplans): Don't clear take in variable editor when take is invalid

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -1572,4 +1572,26 @@ describe('metricFindQuery', () => {
 
     expect(result).toEqual([]);
   });
+
+  test('should return empty array when record count is less than 0', async () => {
+    const mockQuery = {
+      refId: 'A',
+      recordCount: -1,
+    };
+
+    const result = await datastore.metricFindQuery(mockQuery, {} as LegacyMetricFindQueryOptions);
+
+    expect(result).toEqual([]);
+  });
+
+  test('should return empty array when record count is greater than max take', async () => {
+    const mockQuery = {
+      refId: 'A',
+      recordCount: 1000000,
+    };
+
+    const result = await datastore.metricFindQuery(mockQuery, {} as LegacyMetricFindQueryOptions);
+
+    expect(result).toEqual([]);
+  });
 });

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -513,7 +513,7 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
   }
 
   private isRecordCountValid(query: TestPlansQuery): boolean {
-    return query.recordCount !== undefined
+    return query.recordCount !== undefined && query.recordCount >= 0 && query.recordCount <= QUERY_TEST_PLANS_MAX_TAKE;
   }
 
   private isPropertiesValid(query: TestPlansQuery): boolean {

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.test.tsx
@@ -216,7 +216,7 @@ describe('TestPlansVariableQueryEditor', () => {
 
       await waitFor(() => {
         expect(container.getByText('Enter a value less than or equal to 10,000')).toBeInTheDocument();
-        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
+        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: 1000000 }));
       });
     });
 

--- a/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansVariableQueryEditor.tsx
@@ -69,10 +69,10 @@ export function TestPlansVariableQueryEditor({ query, onChange, datasource }: Pr
 
   const validateRecordCoundValue = (value: number, TAKE_LIMIT: number) => {
     if (isNaN(value) || value < 0) {
-      return { message: recordCountErrorMessages.greaterOrEqualToZero, take: undefined };
+      return { message: recordCountErrorMessages.greaterOrEqualToZero, take: value };
     }
     if (value > TAKE_LIMIT) {
-      return { message: recordCountErrorMessages.lessOrEqualToTenThousand, take: undefined };
+      return { message: recordCountErrorMessages.lessOrEqualToTenThousand, take: value };
     }
     return {message: '', recordCount: value };
   };

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -910,6 +910,28 @@ describe('WorkOrdersDataSource', () => {
 
       expect(result).toEqual([]);
     });
+
+    test('should return empty array when take is less than 0', async () => {
+      const mockQuery = {
+        refId: 'A',
+        take: -1,
+      };
+
+      const result = await datastore.metricFindQuery(mockQuery, {} as LegacyMetricFindQueryOptions);
+
+      expect(result).toEqual([]);
+    });
+
+    test('should return empty array when take is greater than max take', async () => {
+      const mockQuery = {
+        refId: 'A',
+        take: 100000,
+      };
+
+      const result = await datastore.metricFindQuery(mockQuery, {} as LegacyMetricFindQueryOptions);
+
+      expect(result).toEqual([]);
+    });
   });
 
   describe('testDataSource', () => {

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -334,7 +334,7 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
   }
 
   private isTakeValid(query: WorkOrdersQuery): boolean {
-    return query.take !== undefined
+    return query.take !== undefined && query.take >= 0 && query.take <= QUERY_WORK_ORDERS_MAX_TAKE;
   }
 
   private isPropertiesValid(query: WorkOrdersQuery): boolean {

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.test.tsx
@@ -200,7 +200,7 @@ describe('WorkOrdersVariableQueryEditor', () => {
 
       await waitFor(() => {
         expect(container.getByText('Enter a value less than or equal to 10,000')).toBeInTheDocument();
-        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ take: undefined }));
+        expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ take: 1000000 }));
       });
     });
 

--- a/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersVariableQueryEditor.tsx
@@ -59,10 +59,10 @@ export function WorkOrdersVariableQueryEditor({ query, onChange, datasource }: P
 
   const validateTakeValue = (value: number, TAKE_LIMIT: number) => {
     if (isNaN(value) || value < 0) {
-      return { message: takeErrorMessages.greaterOrEqualToZero, take: undefined };
+      return { message: takeErrorMessages.greaterOrEqualToZero, take: value };
     }
     if (value > TAKE_LIMIT) {
-      return { message: takeErrorMessages.lessOrEqualToTenThousand, take: undefined };
+      return { message: takeErrorMessages.lessOrEqualToTenThousand, take: value };
     }
     return {message: '', take: value };
   };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To retain the take value instead of clearing it on invalidity

## 👩‍💻 Implementation

- Return invalid take value in variable editor
- Update method to validate min and max take

## 🧪 Testing

- Manually verified
- Updated unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).