### PR TITLE
fix(products,results,workorders,testplans): Expand properties dropdown height on adding property

### DIFF
--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -107,8 +107,6 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
               onChange={onPropertiesChange}
               value={query.properties}
               defaultValue={query.properties!}
-              maxVisibleValues={5}
-              noMultiValueWrap={true}
               width={65}
               allowCustomValue={false}
               closeMenuOnSelect={false}

--- a/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
+++ b/src/datasources/results/components/editors/query-results/QueryResultsEditor.tsx
@@ -102,8 +102,6 @@ export function QueryResultsEditor({ query, handleQueryChange, datasource }: Pro
               onChange={onPropertiesChange}
               value={query.properties}
               defaultValue={query.properties!}
-              noMultiValueWrap={true}
-              maxVisibleValues={5}
               width={65}
               allowCustomValue={false}
               closeMenuOnSelect={false}

--- a/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
+++ b/src/datasources/results/components/editors/query-steps/QueryStepsEditor.tsx
@@ -103,8 +103,6 @@ export function QueryStepsEditor({ query, handleQueryChange, datasource }: Props
               onChange={onPropertiesChange}
               value={query.properties}
               defaultValue={query.properties!}
-              noMultiValueWrap={true}
-              maxVisibleValues={5}
               width={65}
               allowCustomValue={false}
               closeMenuOnSelect={false}

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -138,7 +138,7 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
               onChange={onPropertiesChange}
               value={query.properties}
               defaultValue={query.properties}
-              width={60}
+              width={65}
               allowCustomValue={false}
               closeMenuOnSelect={false}
             />

--- a/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
+++ b/src/datasources/test-plans/components/TestPlansQueryEditor.tsx
@@ -138,8 +138,6 @@ export function TestPlansQueryEditor({ query, onChange, onRunQuery, datasource }
               onChange={onPropertiesChange}
               value={query.properties}
               defaultValue={query.properties}
-              noMultiValueWrap={true}
-              maxVisibleValues={5}
               width={60}
               allowCustomValue={false}
               closeMenuOnSelect={false}

--- a/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
+++ b/src/datasources/work-orders/components/WorkOrdersQueryEditor.tsx
@@ -136,8 +136,6 @@ export function WorkOrdersQueryEditor({ query, onChange, onRunQuery, datasource 
               onChange={onPropertiesChange}
               value={query.properties}
               defaultValue={query.properties!}
-              noMultiValueWrap={true}
-              maxVisibleValues={5}
               width={65}
               allowCustomValue={false}
               closeMenuOnSelect={false}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR update modifies the "Properties" dropdown so that its height expands dynamically when new properties are added.

## 👩‍💻 Implementation

- Removed `maxVisibleValues` and `noMultiWrap` that limited the dropdown’s height from increasing when new properties were added.

Before
![image](https://github.com/user-attachments/assets/9c9e9e7e-3739-4d62-8231-190ae7af7b8e)

After
![image](https://github.com/user-attachments/assets/ecd4e6e5-2970-4eb4-841c-45340d988af2)


## 🧪 Testing

NA as it is a UI change

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).