### PR TITLE
fix(workorders): Fix typo in state 'Canceled'

### DIFF
--- a/src/datasources/work-orders/constants/WorkOrdersQueryBuilder.constants.ts
+++ b/src/datasources/work-orders/constants/WorkOrdersQueryBuilder.constants.ts
@@ -53,7 +53,7 @@ export const WorkOrdersQueryBuilderFields: Record<string, QBField> = {
         {label: 'In progress', value: 'InProgress'},
         {label: 'Pending approval', value: 'PendingApproval'},
         {label: 'Closed', value: 'Closed'},
-        {label: 'Cancelled', value: 'Cancelled'}
+        {label: 'Canceled', value: 'Canceled'}
       ]
     }
   },


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To fix typo in state 'Canceled' which results in bad request
![image](https://github.com/user-attachments/assets/fa799b87-6847-4f94-b288-2314ae6d54af)

## 👩‍💻 Implementation

- Fixed typo

## 🧪 Testing

Manually verified

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).