### PR TITLE
fix(results): Remove showIcons from query builder

### DIFF
--- a/src/datasources/products/components/query-builder/ProductsQueryBuilder.tsx
+++ b/src/datasources/products/components/query-builder/ProductsQueryBuilder.tsx
@@ -175,8 +175,7 @@ export const ProductsQueryBuilder: React.FC<ProductsQueryBuilderProps> = ({
       fields={fields}
       messages={queryBuilderMessages}
       onChange={onChange}
-      value={sanitizedFilter}
-      showIcons
+      value={sanitizedFilter}      
     />
   );
 }

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -216,8 +216,7 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
       messages={queryBuilderMessages}
       onChange={onChange}
       value={sanitizedFilter}
-      fieldsMode="static"
-      showIcons
+      fieldsMode="static"      
     />
   );
 };

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -217,6 +217,7 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
       onChange={onChange}
       value={sanitizedFilter}
       fieldsMode="static"
+      showIcons
     />
   );
 };

--- a/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.tsx
@@ -195,6 +195,7 @@ export const StepsQueryBuilder: React.FC<StepsQueryBuilderProps> = ({
       value={sanitizedFilter}
       fieldsMode="static"
       disabled={disableQueryBuilder}
+      showIcons
     />
   );
 };

--- a/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.tsx
@@ -195,7 +195,6 @@ export const StepsQueryBuilder: React.FC<StepsQueryBuilderProps> = ({
       value={sanitizedFilter}
       fieldsMode="static"
       disabled={disableQueryBuilder}
-      showIcons
     />
   );
 };

--- a/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.tsx
+++ b/src/datasources/test-plans/components/query-builder/TestPlansQueryBuilder.tsx
@@ -205,7 +205,6 @@ export const TestPlansQueryBuilder: React.FC<TestPlansQueryBuilderProps> = ({
             messages={queryBuilderMessages}
             onChange={onChange}
             value={filter}
-            showIcons
         />
     );
 }

--- a/src/datasources/work-orders/components/query-builder/WorkOrdersQueryBuilder.tsx
+++ b/src/datasources/work-orders/components/query-builder/WorkOrdersQueryBuilder.tsx
@@ -154,7 +154,6 @@ export const WorkOrdersQueryBuilder: React.FC<WorkOrdersQueryBuilderProps> = ({
       messages={queryBuilderMessages}
       onChange={onChange}
       value={filter}
-      showIcons
     />
   );
 };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR removes the `showIcons` from query builder for consistency

## 👩‍💻 Implementation

- Removed 'showIcons` from the Products, Workorders and Testplans query builder.

## 🧪 Testing

NA as it is an UI change

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).