### PR TITLE
feat(results): add custom theme support for horizontal scrollbar in query-builder

### DIFF
--- a/src/datasources/results/components/query-builders/QueryBuilder.scss
+++ b/src/datasources/results/components/query-builders/QueryBuilder.scss
@@ -1,0 +1,32 @@
+.smart-input-drop-down-menu[theme=custom-theme] {
+    overflow: auto;
+    max-block-size: 197px;
+    max-width: 333px;
+    scrollbar-width: auto;
+    scrollbar-color: #b3b3b3 #f5f5f5;
+
+    .smart-container {
+        inline-size: max-content;
+        max-inline-size: max-content;
+        max-block-size: max-content;
+        
+        .smart-scroll-viewer-container {
+            inline-size: max-content;
+            max-inline-size: max-content;
+
+            .smart-scroll-viewer-content-container{
+                inline-size: max-content;
+                max-inline-size: max-content;
+
+                ul {
+                    display: grid;
+                    grid-auto-columns: max-content;
+                    li {
+                        min-inline-size: calc(var(--smart-input-drop-down-menu-width));
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/datasources/results/components/query-builders/QueryBuilder.scss
+++ b/src/datasources/results/components/query-builders/QueryBuilder.scss
@@ -1,4 +1,6 @@
 .smart-input-drop-down-menu[theme=custom-theme] {
+    // Sets up the main drop-down menu container with custom theme.
+    // Enables scrolling if content overflows, limits height and width, and customizes scrollbar appearance.
     overflow: auto;
     max-block-size: 197px;
     max-width: 333px;
@@ -6,22 +8,27 @@
     scrollbar-color: #b3b3b3 #f5f5f5;
 
     .smart-container {
+        // Ensures the container adapts its width and height to fit its content.
         inline-size: max-content;
         max-inline-size: max-content;
         max-block-size: max-content;
         
         .smart-scroll-viewer-container {
+            // Maintains content-based sizing for the scroll viewer container.
             inline-size: max-content;
             max-inline-size: max-content;
 
             .smart-scroll-viewer-content-container{
+                // Ensures the scrollable content container also sizes to its content.
                 inline-size: max-content;
                 max-inline-size: max-content;
 
                 ul {
+                    // Uses CSS grid to lay out list items, with columns sized to fit content.
                     display: grid;
                     grid-auto-columns: max-content;
                     li {
+                        // Sets a minimum width for each list item based on a CSS variable, ensuring consistent sizing.
                         min-inline-size: calc(var(--smart-input-drop-down-menu-width));
                     }
                 }

--- a/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-results/ResultsQueryBuilder.tsx
@@ -16,6 +16,7 @@ import {
   ResultsQueryBuilderFields,
   ResultsQueryBuilderStaticFields,
 } from 'datasources/results/constants/ResultsQueryBuilder.constants';
+import '../QueryBuilder.scss'
 
 type ResultsQueryBuilderProps = QueryBuilderProps &
   React.HTMLAttributes<Element> & {
@@ -217,6 +218,7 @@ export const ResultsQueryBuilder: React.FC<ResultsQueryBuilderProps> = ({
       onChange={onChange}
       value={sanitizedFilter}
       fieldsMode="static"
+      theme='custom-theme'
     />
   );
 };

--- a/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.tsx
+++ b/src/datasources/results/components/query-builders/query-steps/StepsQueryBuilder.tsx
@@ -13,6 +13,7 @@ import 'smart-webcomponents-react/source/styles/components/smart.base.css';
 import 'smart-webcomponents-react/source/styles/components/smart.common.css';
 import 'smart-webcomponents-react/source/styles/components/smart.querybuilder.css';
 import { StepsQueryBuilderFields, StepsQueryBuilderStaticFields } from 'datasources/results/constants/StepsQueryBuilder.constants';
+import '../QueryBuilder.scss';
 
 type StepsQueryBuilderProps = QueryBuilderProps &
   React.HTMLAttributes<Element> & {
@@ -195,6 +196,7 @@ export const StepsQueryBuilder: React.FC<StepsQueryBuilderProps> = ({
       value={sanitizedFilter}
       fieldsMode="static"
       disabled={disableQueryBuilder}
+      theme='custom-theme'
     />
   );
 };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
In cases where the dropdown contains a value that's too long to fit within the visible area, users are unable to see the full text. To address this, a horizontal scrollbar should be added to allow users to scroll and view the entire value.
![image](https://github.com/user-attachments/assets/f64cc022-a31e-45df-8265-647f0df6524d)

This pull request introduces a custom theme for dropdown menus in query builders, improving both styling and usability—especially when handling longer values in the dropdown options. 

The CSS is adapted from the Dataspace implementation of the query builder that includes a scrollbar : https://dev.azure.com/ni/DevCentral/_git/Skyline?path=/Web/Workspaces/TestInsights/src/app/dataspaces/components/dataspaces-query-builder/dataspaces-query-builder.component.scss


## 👩‍💻 Implementation

- Added SCSS definitions for the `custom-theme`, including properties for dropdown menu dimensions, scrollbar styling, and grid layout for menu items.
- Applied the Custom Theme to Results and Steps Query-builder

Here is the Implemented query builder with horizontal scroll: 
![image](https://github.com/user-attachments/assets/b616a5b4-771f-4e7a-823f-8de053b3fbf5)

## 🧪 Testing

- Manually verified

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).