### PR TITLE
feat(products): handle invalid queries in Products Query Editor

### DIFF
--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -236,6 +236,17 @@ describe('query', () => {
     expect(response.data).toMatchSnapshot();
   });
 
+  test('returns empty data for invalid query', async () => {
+      const query = buildQuery({
+        refId: 'A',
+        properties: []
+      });
+
+      const response = await datastore.query(query);
+
+      expect(response.data).toMatchSnapshot();
+    });
+
   test('returns column headers with no data when Query Products returns no data', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-products' }))

--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -236,16 +236,33 @@ describe('query', () => {
     expect(response.data).toMatchSnapshot();
   });
 
-  test('returns empty data for invalid query', async () => {
-      const query = buildQuery({
-        refId: 'A',
-        properties: []
-      });
-
-      const response = await datastore.query(query);
-
-      expect(response.data).toMatchSnapshot();
+  test('returns empty data for invalid properties query', async () => {
+    const query = buildQuery({
+      refId: 'A',
+      properties: []
     });
+
+    const response = await datastore.query(query);
+
+    expect(response.data).toMatchSnapshot();
+  });
+  
+  test('returns empty data for invalid take query', async () => {
+    const query = buildQuery({
+      refId: 'A',
+      properties: [
+          PropertiesOptions.PART_NUMBER,
+          PropertiesOptions.FAMILY,
+          PropertiesOptions.NAME,
+          PropertiesOptions.WORKSPACE
+        ] as Properties[],
+      recordCount: undefined
+    });
+
+    const response = await datastore.query(query);
+
+    expect(response.data).toMatchSnapshot();
+  });
 
   test('returns column headers with no data when Query Products returns no data', async () => {
     backendServer.fetch

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -111,6 +111,13 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
     await this.workspaceLoadedPromise;
     await this.partNumberLoadedPromise;
 
+    if( query.properties?.length === 0 || query.recordCount === undefined ) {
+      return {
+        refId: query.refId,
+        fields: [],
+      }
+    }
+
     if (query.queryBy) {
       query.queryBy = transformComputedFieldsQuery(
         this.templateSrv.replace(query.queryBy, options.scopedVars),

--- a/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
+++ b/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
@@ -39,6 +39,36 @@ exports[`query metricFindQuery should return partNumber with family Name when qu
 ]
 `;
 
+exports[`query returns column headers with no data when Query Products returns no data 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "partNumber",
+        "type": "string",
+        "values": [],
+      },
+      {
+        "name": "family",
+        "type": "string",
+        "values": [],
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "values": [],
+      },
+      {
+        "name": "workspace",
+        "type": "string",
+        "values": [],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
 exports[`query returns data when there are valid queries 1`] = `
 [
   {
@@ -77,31 +107,10 @@ exports[`query returns data when there are valid queries 1`] = `
 ]
 `;
 
-exports[`query returns column headers with no data when Query Products returns no data 1`] = `
+exports[`query returns empty data for invalid query 1`] = `
 [
   {
-    "fields": [
-      {
-        "name": "partNumber",
-        "type": "string",
-        "values": [],
-      },
-      {
-        "name": "family",
-        "type": "string",
-        "values": [],
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "values": [],
-      },
-      {
-        "name": "workspace",
-        "type": "string",
-        "values": [],
-      },
-    ],
+    "fields": [],
     "refId": "A",
   },
 ]

--- a/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
+++ b/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
@@ -107,7 +107,16 @@ exports[`query returns data when there are valid queries 1`] = `
 ]
 `;
 
-exports[`query returns empty data for invalid query 1`] = `
+exports[`query returns empty data for invalid properties query 1`] = `
+[
+  {
+    "fields": [],
+    "refId": "A",
+  },
+]
+`;
+
+exports[`query returns empty data for invalid take query 1`] = `
 [
   {
     "fields": [],

--- a/src/datasources/products/components/ProductsQueryEditor.test.ts
+++ b/src/datasources/products/components/ProductsQueryEditor.test.ts
@@ -99,25 +99,25 @@ describe('ProductsQueryEditor', () => {
       );
     });
   
-    it('should show error and not call onChange when Take is greater than Take limit', async () => {
+    it('should show error and call onChange with recordCount as undefined when Take is greater than Take limit', async () => {
       onChange.mockClear();
   
       await userEvent.clear(recordCount);
       await userEvent.type(recordCount, '10001');
       await userEvent.click(document.body);
   
-      expect(onChange).not.toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
       expect(screen.getByText(recordCountErrorMessages.lessOrEqualToTakeLimit)).toBeInTheDocument();
     });
   
-    it('should show error and not call onChange when Take is not a number', async () => {
+    it('should show error and  call onChange with recordCount as undefined when Take is not a number', async () => {
       onChange.mockClear();
   
       await userEvent.clear(recordCount);
       await userEvent.type(recordCount, 'abc');
       await userEvent.click(document.body);
   
-      expect(onChange).not.toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ recordCount: undefined }));
       expect(screen.getByText(recordCountErrorMessages.greaterOrEqualToZero)).toBeInTheDocument();
     });
   });

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -66,6 +66,8 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
     const value = parseInt((event.target as HTMLInputElement).value, 10);
     if (isRecordCountValid(value, TAKE_LIMIT)) {
       handleQueryChange({ ...query, recordCount: value });
+    } else {
+      handleQueryChange({ ...query, recordCount: undefined });
     }
   }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
To improve query handling in the `ProductsDataSource`,  we need to validate invalid query inputs by adding logic for empty or invalid queries.

## 👩‍💻 Implementation

* Added logic to return empty data when the query has no properties or an undefined `recordCount`. This prevents unnecessary processing of invalid queries.

## 🧪 Testing

* Updated snapshot tests to reflect the new behavior for invalid queries, ensuring test coverage for scenarios with empty data.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).