### PR TITLE
fix(system): prevent hidden system queries to run

### DIFF
--- a/src/datasources/system/SystemDataSource.test.ts
+++ b/src/datasources/system/SystemDataSource.test.ts
@@ -136,6 +136,17 @@ test('attempts to replace variables in metricFindQuery', async () => {
   expect(templateSrv.replace.mock.calls[0][0]).toBe(workspaceVariable);
 });
 
+test('should not run query if hidden', () => {
+  const query: SystemQuery = {
+      hide: true,
+      queryKind: SystemQueryType.Properties,
+      systemName: '',
+      workspace: '',
+      refId: ''
+  };
+  expect(ds.shouldRunQuery(query)).toBe(false);
+});
+
 const fakeSystems: SystemProperties[] = [
   {
     id: 'system-1',

--- a/src/datasources/system/SystemDataSource.ts
+++ b/src/datasources/system/SystemDataSource.ts
@@ -86,8 +86,8 @@ export class SystemDataSource extends DataSourceBase<SystemQuery, DataSourceJson
     return properties.map(frame => ({ text: frame.alias ?? frame.id, value: frame.id }));
   }
 
-  shouldRunQuery(_: SystemQuery): boolean {
-    return true;
+  shouldRunQuery(query: SystemQuery): boolean {
+    return !query.hide;
   }
 
   async testDatasource(): Promise<TestDataSourceResponse> {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We encountered a bug when the disabled queries would still be run, even though they should not.

## 👩‍💻 Implementation

Update the value returned by the `shouldRunQuery` function in the data source for systems.

## 🧪 Testing

Manual test and a new unit test.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).