### PR TITLE
fix(asset): hide query options from table combo box when query is hidden

### DIFF
--- a/src/datasources/asset/data-sources/asset-summary/AssetSummaryDataSource.test.ts
+++ b/src/datasources/asset/data-sources/asset-summary/AssetSummaryDataSource.test.ts
@@ -1,0 +1,49 @@
+import {
+    getQueryBuilder,
+    setupDataSource,
+} from "test/fixtures";
+import { AssetQueryType } from "../../types/types";
+import { AssetSummaryDataSource } from "./AssetSummaryDataSource";
+import { AssetSummaryQuery } from "datasources/asset/types/AssetSummaryQuery.types";
+
+let datastore: AssetSummaryDataSource;
+
+beforeEach(() => {
+    [datastore] = setupDataSource(AssetSummaryDataSource);
+});
+
+const buildAssetSummaryQuery = getQueryBuilder<AssetSummaryQuery>()({
+    refId: '',
+});
+
+describe('Process summary queries', () => {
+    let processSummaryQuerySpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        processSummaryQuerySpy = jest.spyOn(datastore, 'processSummaryQuery').mockImplementation();
+    });
+
+    test('should process query if query is not hidden', async () => {
+        const query = buildAssetSummaryQuery({
+            refId: '',
+            type: AssetQueryType.AssetSummary,
+            hide: false
+        });
+
+        await datastore.query(query);
+
+        expect(processSummaryQuerySpy).toHaveBeenCalled();
+    });
+
+    test('should not process query if query is hidden', async () => {
+        const query = buildAssetSummaryQuery({
+            refId: '',
+            type: AssetQueryType.AssetSummary,
+            hide: true
+        });
+
+        await datastore.query(query);
+
+        expect(processSummaryQuerySpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/datasources/asset/data-sources/asset-summary/AssetSummaryDataSource.ts
+++ b/src/datasources/asset/data-sources/asset-summary/AssetSummaryDataSource.ts
@@ -1,4 +1,4 @@
-import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@grafana/data';
+import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings, DataQueryErrorType } from '@grafana/data';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import { AssetSummaryResponse } from 'datasources/asset/types/AssetSummaryQuery.types';
@@ -24,8 +24,8 @@ export class AssetSummaryDataSource extends AssetDataSourceBase {
         return this.processSummaryQuery(query as AssetQuery);
     }
 
-    shouldRunQuery(_: AssetQuery): boolean {
-        return true;
+    shouldRunQuery(query: AssetQuery): boolean {
+        return !query?.hide;
     }
 
     async processSummaryQuery(query: AssetQuery) {

--- a/src/datasources/asset/data-sources/asset-summary/AssetSummaryDataSource.ts
+++ b/src/datasources/asset/data-sources/asset-summary/AssetSummaryDataSource.ts
@@ -1,4 +1,4 @@
-import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings, DataQueryErrorType } from '@grafana/data';
+import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings } from '@grafana/data';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import { AssetSummaryResponse } from 'datasources/asset/types/AssetSummaryQuery.types';

--- a/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.test.ts
+++ b/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.test.ts
@@ -713,3 +713,38 @@ describe('Time based data links', () => {
     expect(builtUrl).toMatchSnapshot();
   });
 });
+
+describe('shouldRunQuery', () => {
+  test('returns true for visible calibration forecast query', () => {
+    const query: CalibrationForecastQuery = {
+      refId: 'A',
+      type: AssetQueryType.CalibrationForecast,
+      groupBy: [AssetCalibrationTimeBasedGroupByType.Month],
+      hide: false
+    };
+
+    expect(datastore.shouldRunQuery(query)).toBe(true);
+  });
+
+  test('returns false for hidden forecast query', () => {
+    const query = {
+      refId: 'A',
+      type: AssetQueryType.CalibrationForecast,
+      groupBy: [AssetCalibrationTimeBasedGroupByType.Month],
+      hide: true
+    };
+
+    expect(datastore.shouldRunQuery(query)).toBe(false);
+  });
+
+  test('returns false for empty grouping query', () => {
+    const query = {
+      refId: 'A',
+      type: AssetQueryType.CalibrationForecast,
+      groupBy: [],
+      hide: false
+    };
+
+    expect(datastore.shouldRunQuery(query)).toBe(false);
+  })
+});

--- a/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.ts
+++ b/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.ts
@@ -56,7 +56,7 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
     }
 
     shouldRunQuery(calibrationQuery: CalibrationForecastQuery): boolean {
-        return calibrationQuery.groupBy.length > 0;
+        return !calibrationQuery?.hide && (calibrationQuery.groupBy.length > 0);
     }
 
     async testDatasource(): Promise<TestDataSourceResponse> {

--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.test.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.test.ts
@@ -77,3 +77,38 @@ describe('List assets location queries', () => {
         );
     });
 });
+
+describe('shouldRunQuery', () => {
+    let processlistAssetsQuerySpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        processlistAssetsQuerySpy = jest.spyOn(datastore, 'processListAssetsQuery').mockImplementation();
+
+    });
+
+    test('should not process query for hidden queries', async () => {
+        const query = buildListAssetsQuery({
+            refId: '',
+            type: AssetQueryType.ListAssets,
+            filter: `${ListAssetsFieldNames.LOCATION} = "Location1"`,
+            hide: true
+        });
+
+        await datastore.query(query);
+
+        expect(processlistAssetsQuerySpy).not.toHaveBeenCalled();
+    });
+
+    test('should process query for non-hidden queries', async () => {
+        const query = buildListAssetsQuery({
+            refId: '',
+            type: AssetQueryType.ListAssets,
+            filter: `${ListAssetsFieldNames.LOCATION} = "Location1"`,
+            hide: false
+        });
+
+        await datastore.query(query);
+
+        expect(processlistAssetsQuerySpy).toHaveBeenCalled();
+    });
+});

--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
@@ -43,7 +43,7 @@ export class ListAssetsDataSource extends AssetDataSourceBase {
   }
 
   shouldRunQuery(query: AssetQuery): boolean {
-    return true;
+    return !query?.hide;
   }
 
   async processListAssetsQuery(query: ListAssetsQuery) {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Bug: disabled queries still appeared in table combo box and were run, even when they were disabled 

e.g.: 
![image](https://github.com/user-attachments/assets/4091750c-b643-41c8-a8a1-15f42698f2dc)


## 👩‍💻 Implementation

Don't run the query when it is set on hidden

## 🧪 Testing

![image](https://github.com/user-attachments/assets/3bd63cdf-17a5-4317-9eaf-2d1fbd809045)

+ some unit tests
## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).