### PR TITLE
refactor(products): Clean up Properties options for order by

### DIFF
--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -333,12 +333,12 @@ describe('query', () => {
 
     const fields = response.data[0].fields as Field[];
     expect(fields).toEqual([
-      { name: 'partNumber', values: ['123'], type: 'string' },
-      { name: 'family', values: ['Family 1'], type: 'string' },
-      { name: 'name', values: ['Product 1'], type: 'string' },
-      { name: 'workspace', values: ['Workspace 1'], type: 'string' },
-      { name: 'updatedAt', values: ['2021-08-01T00:00:00Z'], type: 'time' },
-      { name: 'properties', values: ['{"prop1":"value1"}'], type: 'string' },
+      { name: 'Part number', values: ['123'], type: 'string' },
+      { name: 'Family', values: ['Family 1'], type: 'string' },
+      { name: 'Product name', values: ['Product 1'], type: 'string' },
+      { name: 'Workspace', values: ['Workspace 1'], type: 'string' },
+      { name: 'Updated at', values: ['2021-08-01T00:00:00Z'], type: 'time' },
+      { name: 'Properties', values: ['{"prop1":"value1"}'], type: 'string' },
     ]);
   });
 
@@ -358,7 +358,7 @@ describe('query', () => {
 
     const fields = response.data[0].fields as Field[];
     expect(fields).toEqual([
-      { name: 'workspace', values: ['WorkspaceName'], type: 'string' },
+      { name: 'Workspace', values: ['WorkspaceName'], type: 'string' },
     ]);
   });
 
@@ -387,7 +387,7 @@ describe('query', () => {
     const response = await datastore.query(query);
     const fields = response.data[0].fields as Field[];
     expect(fields).toEqual([
-      { name: 'properties', values: [''], type: 'string' },
+      { name: 'Properties', values: [''], type: 'string' },
     ]);
   });
 
@@ -498,7 +498,7 @@ describe('query', () => {
           data: {
             descending: false,
             orderBy: "partNumber",
-            projection: ["PART_NUMBER", "NAME"],
+            projection: [PropertiesOptions.PART_NUMBER, PropertiesOptions.NAME],
             returnCount: false,
           }
         })
@@ -520,7 +520,7 @@ describe('query', () => {
             descending: false,
             filter: "partNumber = \"123\"",
             orderBy: "partNumber",
-            projection: ["PART_NUMBER", "NAME"],
+            projection: [PropertiesOptions.PART_NUMBER, PropertiesOptions.NAME],
             returnCount: false,
           }
         })
@@ -575,7 +575,7 @@ describe('query', () => {
             descending: false,
             filter:"(PartNumber = \"partNumber1\" || PartNumber = \"partNumber2\")",
             orderBy: "partNumber",
-            projection: ["PART_NUMBER", "NAME"],
+            projection: [PropertiesOptions.PART_NUMBER, PropertiesOptions.NAME],
             returnCount: false,
           }
         })

--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -1,6 +1,6 @@
 import { BackendSrv } from '@grafana/runtime';
 import { ProductsDataSource } from './ProductsDataSource';
-import { ProductQuery, ProductVariableQuery, Properties, PropertiesOptions, QueryProductResponse } from './types';
+import { ProductQuery, ProductVariableQuery, Properties, QueryProductResponse } from './types';
 import { Field, LegacyMetricFindQueryOptions } from '@grafana/data';
 import { createFetchError, createFetchResponse, getQueryBuilder, requestMatching, setupDataSource } from 'test/fixtures';
 import { MockProxy } from 'jest-mock-extended';
@@ -218,13 +218,13 @@ describe('query', () => {
       {
         refId: 'A',
         properties: [
-          PropertiesOptions.PART_NUMBER,
-          PropertiesOptions.FAMILY,
-          PropertiesOptions.NAME,
-          PropertiesOptions.WORKSPACE
-        ] as Properties[],
+          Properties.partNumber,
+          Properties.family,
+          Properties.name,
+          Properties.workspace
+        ],
         queryBy: `${ProductsQueryBuilderFieldNames.PART_NUMBER} = "123"`,
-        orderBy: PropertiesOptions.ID,
+        orderBy: Properties.id,
         descending: false,
         recordCount: 1
       },
@@ -251,10 +251,10 @@ describe('query', () => {
     const query = buildQuery({
       refId: 'A',
       properties: [
-          PropertiesOptions.PART_NUMBER,
-          PropertiesOptions.FAMILY,
-          PropertiesOptions.NAME,
-          PropertiesOptions.WORKSPACE
+          Properties.partNumber,
+          Properties.family,
+          Properties.name,
+          Properties.workspace
         ] as Properties[],
       recordCount: undefined
     });
@@ -279,11 +279,11 @@ describe('query', () => {
       {
         refId: 'A',
         properties: [
-          PropertiesOptions.PART_NUMBER,
-          PropertiesOptions.FAMILY,
-          PropertiesOptions.NAME,
-          PropertiesOptions.WORKSPACE
-        ] as Properties[], 
+          Properties.partNumber,
+          Properties.family,
+          Properties.name,
+          Properties.workspace
+        ], 
       }
     );
 
@@ -301,10 +301,10 @@ describe('query', () => {
       {
         refId: 'A',
         properties: [
-          PropertiesOptions.PART_NUMBER,
-          PropertiesOptions.FAMILY,
-          PropertiesOptions.NAME,
-          PropertiesOptions.WORKSPACE
+          Properties.partNumber,
+          Properties.family,
+          Properties.name,
+          Properties.workspace
         ] as Properties[], orderBy: undefined
       },
     );
@@ -319,12 +319,12 @@ describe('query', () => {
       {
         refId: 'A',
         properties: [
-          PropertiesOptions.PART_NUMBER,
-          PropertiesOptions.FAMILY,
-          PropertiesOptions.NAME,
-          PropertiesOptions.WORKSPACE,
-          PropertiesOptions.UPDATEDAT,
-          PropertiesOptions.PROPERTIES
+          Properties.partNumber,
+          Properties.family,
+          Properties.name,
+          Properties.workspace,
+          Properties.updatedAt,
+          Properties.properties
         ] as Properties[], orderBy: undefined
       },
     );
@@ -349,7 +349,7 @@ describe('query', () => {
       {
         refId: 'A',
         properties: [
-          PropertiesOptions.WORKSPACE
+          Properties.workspace
         ] as Properties[], orderBy: undefined
       },
     );
@@ -379,7 +379,7 @@ describe('query', () => {
       {
         refId: 'A',
         properties: [
-          PropertiesOptions.PROPERTIES
+          Properties.properties
         ] as Properties[], orderBy: undefined
       },
     );
@@ -421,9 +421,9 @@ describe('query', () => {
         {
           refId: 'A',
           properties: [
-            PropertiesOptions.PART_NUMBER
+            Properties.partNumber
           ] as Properties[],
-          queryBy: `${PropertiesOptions.PART_NUMBER} = '123'`,
+          queryBy: `${Properties.partNumber} = '123'`,
           descending: false
         },
       );
@@ -448,7 +448,7 @@ describe('query', () => {
         {
           refId: 'A',
           properties: [
-            PropertiesOptions.PART_NUMBER
+            Properties.partNumber
           ] as Properties[],
           queryBy: `${ProductsQueryBuilderFieldNames.PART_NUMBER} = "{partNumber1,partNumber2}"`,
           descending: false
@@ -498,7 +498,7 @@ describe('query', () => {
           data: {
             descending: false,
             orderBy: "partNumber",
-            projection: [PropertiesOptions.PART_NUMBER, PropertiesOptions.NAME],
+            projection: [Properties.partNumber, Properties.name],
             returnCount: false,
           }
         })
@@ -520,7 +520,7 @@ describe('query', () => {
             descending: false,
             filter: "partNumber = \"123\"",
             orderBy: "partNumber",
-            projection: [PropertiesOptions.PART_NUMBER, PropertiesOptions.NAME],
+            projection: [Properties.partNumber, Properties.name],
             returnCount: false,
           }
         })
@@ -575,7 +575,7 @@ describe('query', () => {
             descending: false,
             filter:"(PartNumber = \"partNumber1\" || PartNumber = \"partNumber2\")",
             orderBy: "partNumber",
-            projection: [PropertiesOptions.PART_NUMBER, PropertiesOptions.NAME],
+            projection: [Properties.partNumber, Properties.name],
             returnCount: false,
           }
         })
@@ -587,10 +587,10 @@ describe('query', () => {
 const buildQuery = getQueryBuilder<ProductQuery>()({
   refId: 'A',
   properties: [
-    PropertiesOptions.PART_NUMBER,
-    PropertiesOptions.FAMILY,
-    PropertiesOptions.NAME,
-    PropertiesOptions.WORKSPACE
+    Properties.partNumber,
+    Properties.family,
+    Properties.name,
+    Properties.workspace
   ] as Properties[],
   orderBy: undefined
 });

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -1,7 +1,7 @@
 import { AppEvents, DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, FieldType, LegacyMetricFindQueryOptions, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
-import { ProductQuery, ProductResponseProperties, ProductVariableQuery, Properties, PropertiesOptions, QueryProductResponse } from './types';
+import { ProductQuery, ProductResponseProperties, productsProjectionLabelLookup, ProductVariableQuery, Properties, PropertiesOptions, QueryProductResponse } from './types';
 import { QueryBuilderOption, Workspace } from 'core/types';
 import { extractErrorInfo } from 'core/errors';
 import { ExpressionTransformFunction, transformComputedFieldsQuery } from 'core/query-builder.utils';
@@ -160,7 +160,7 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
         }
       });
       return {
-        name: field,
+        name: productsProjectionLabelLookup[field].label,
         values: fieldValues,
         type: fieldType
       };

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -1,7 +1,7 @@
 import { AppEvents, DataFrameDTO, DataQueryRequest, DataSourceInstanceSettings, FieldType, LegacyMetricFindQueryOptions, MetricFindValue, TestDataSourceResponse } from '@grafana/data';
 import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
-import { ProductQuery, ProductResponseProperties, productsProjectionLabelLookup, ProductVariableQuery, Properties, PropertiesOptions, QueryProductResponse } from './types';
+import { ProductQuery, ProductResponseProperties, productsProjectionLabelLookup, ProductVariableQuery, Properties, QueryProductResponse } from './types';
 import { QueryBuilderOption, Workspace } from 'core/types';
 import { extractErrorInfo } from 'core/errors';
 import { ExpressionTransformFunction, transformComputedFieldsQuery } from 'core/query-builder.utils';
@@ -33,11 +33,11 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
 
   defaultQuery = {
     properties: [
-      PropertiesOptions.PART_NUMBER,
-      PropertiesOptions.NAME,
-      PropertiesOptions.FAMILY,
-      PropertiesOptions.WORKSPACE
-    ] as Properties[],
+      Properties.partNumber,
+      Properties.name,
+      Properties.family,
+      Properties.workspace
+    ],
     descending: true,
     recordCount: 1000,
     queryBy: ''
@@ -140,7 +140,7 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
       ) ?? [])
       : (query.properties ?? []);
     const fields = selectedFields.map((field) => {
-      const isTimeField = field === PropertiesOptions.UPDATEDAT;
+      const isTimeField = field === Properties.updatedAt;
       const fieldType = isTimeField
         ? FieldType.time
         : FieldType.string;
@@ -150,9 +150,9 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
 
       const fieldValues = values.map(value => {
         switch (field) {
-          case PropertiesOptions.PROPERTIES:
+          case Properties.properties:
             return value == null ? '' : JSON.stringify(value);
-          case PropertiesOptions.WORKSPACE:
+          case Properties.workspace:
             const workspace = this.workspacesCache.get(value);
             return workspace ? getWorkspaceName([workspace], value) : value;
           default:
@@ -185,7 +185,7 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
       return;
     }
 
-    const familyNames = await this.queryProductValues(PropertiesOptions.FAMILY)
+    const familyNames = await this.queryProductValues(Properties.family)
       .catch(error => {
         if (!this.errorTitle) {
           this.handleQueryProductValuesError(error);
@@ -204,7 +204,7 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
       : undefined;
 
     const metadata = (await this.queryProducts(
-      PropertiesOptions.PART_NUMBER,
+      Properties.partNumber,
       [Properties.partNumber, Properties.name],
       filter
     )).products;
@@ -276,7 +276,7 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
     if (this.partNumbersCache.size > 0) {
       return;
     }
-    const partNumbers = await this.queryProductValues(PropertiesOptions.PART_NUMBER)
+    const partNumbers = await this.queryProductValues(Properties.partNumber)
       .catch(error => {
         if (!this.errorTitle) {
           this.handleQueryProductValuesError(error);

--- a/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
+++ b/src/datasources/products/__snapshots__/ProductsDataSource.test.ts.snap
@@ -44,22 +44,22 @@ exports[`query returns column headers with no data when Query Products returns n
   {
     "fields": [
       {
-        "name": "partNumber",
+        "name": "Part number",
         "type": "string",
         "values": [],
       },
       {
-        "name": "family",
+        "name": "Family",
         "type": "string",
         "values": [],
       },
       {
-        "name": "name",
+        "name": "Product name",
         "type": "string",
         "values": [],
       },
       {
-        "name": "workspace",
+        "name": "Workspace",
         "type": "string",
         "values": [],
       },
@@ -74,28 +74,28 @@ exports[`query returns data when there are valid queries 1`] = `
   {
     "fields": [
       {
-        "name": "partNumber",
+        "name": "Part number",
         "type": "string",
         "values": [
           "123",
         ],
       },
       {
-        "name": "family",
+        "name": "Family",
         "type": "string",
         "values": [
           "Family 1",
         ],
       },
       {
-        "name": "name",
+        "name": "Product name",
         "type": "string",
         "values": [
           "Product 1",
         ],
       },
       {
-        "name": "workspace",
+        "name": "Workspace",
         "type": "string",
         "values": [
           "Workspace 1",

--- a/src/datasources/products/components/ProductsQueryEditor.tsx
+++ b/src/datasources/products/components/ProductsQueryEditor.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { AutoSizeInput, HorizontalGroup, InlineField, InlineSwitch, MultiSelect, Select, VerticalGroup } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { ProductsDataSource } from '../ProductsDataSource';
-import { DefaultProductsOrderBy, OrderBy, ProductPropertiesProjectionMap, ProductQuery, Properties } from '../types';
+import { DefaultProductsOrderBy, OrderBy, ProductQuery, productsProjectionLabelLookup, Properties } from '../types';
 import { Workspace } from 'core/types';
 import { ProductsQueryBuilder } from 'datasources/products/components/query-builder/ProductsQueryBuilder';
 import { FloatingError } from 'core/errors';
@@ -110,8 +110,8 @@ export function ProductsQueryEditor({ query, onChange, onRunQuery, datasource }:
             error='You must select at least one property.'>
             <MultiSelect
               placeholder="Select properties to fetch"
-              options={Object.entries(ProductPropertiesProjectionMap)
-                .map(([key, value]) => ({ label: key, value })) as SelectableValue[]}
+              options={Object.entries(productsProjectionLabelLookup)
+                .map(([_, value]) => ({ label: value.label, value: value.projection })) as SelectableValue[]}
               onChange={onPropertiesChange}
               value={query.properties}
               defaultValue={query.properties!}

--- a/src/datasources/products/components/ProductsVariableQueryEditor.test.tsx
+++ b/src/datasources/products/components/ProductsVariableQueryEditor.test.tsx
@@ -1,6 +1,6 @@
 import { Workspace } from "core/types";
 import { ProductsDataSource } from "../ProductsDataSource";
-import { ProductVariableQuery, PropertiesOptions } from "../types";
+import { ProductVariableQuery, Properties } from "../types";
 import { setupRenderer } from "test/fixtures";
 import { ProductsVariableQueryEditor } from "./ProductsVariableQueryEditor";
 import { screen, waitFor } from "@testing-library/react";
@@ -29,7 +29,7 @@ class FakeProductsDataSource extends ProductsDataSource {
     }
 
     queryProductValues(fieldName: string): Promise<string[]> {
-        if (fieldName === PropertiesOptions.PART_NUMBER) {
+        if (fieldName === Properties.partNumber) {
             return Promise.resolve(fakePartNumbers);
         }
         return Promise.resolve(fakeFamilyNames);
@@ -51,7 +51,7 @@ it('fetches the product values on mount', async () => {
     render({ refId: '', queryBy: '' } as ProductVariableQuery);
 
     expect(queryProductValuesSpy).toHaveBeenCalledTimes(2);
-    expect(queryProductValuesSpy).toHaveBeenCalledWith(PropertiesOptions.PART_NUMBER);
-    expect(queryProductValuesSpy).toHaveBeenCalledWith(PropertiesOptions.FAMILY);
+    expect(queryProductValuesSpy).toHaveBeenCalledWith(Properties.partNumber);
+    expect(queryProductValuesSpy).toHaveBeenCalledWith(Properties.family);
 });
 

--- a/src/datasources/products/types.ts
+++ b/src/datasources/products/types.ts
@@ -14,15 +14,15 @@ export interface ProductVariableQuery extends DataQuery {
 }
 
 export enum Properties {
-  id = 'ID',
-  partNumber = 'PART_NUMBER',
-  name = 'NAME',
-  family = 'FAMILY',
-  updatedAt = 'UPDATED_AT',
-  workspace = 'WORKSPACE',
-  keywords = 'KEYWORDS',
-  properties = 'PROPERTIES',
-  fileIds = 'FILE_IDS',
+  id = 'id',
+  partNumber = 'partNumber',
+  name = 'name',
+  family = 'family',
+  updatedAt = 'updatedAt',
+  workspace = 'workspace',
+  keywords = 'keywords',
+  properties = 'properties',
+  fileIds = 'fileIds',
 }
 
 export const PropertiesOptions = {
@@ -37,16 +37,18 @@ export const PropertiesOptions = {
   FILE_IDS: 'fileIds',
 };
 
-export const ProductPropertiesProjectionMap = {
-  'Product ID': PropertiesOptions.ID,
-  'Part number': PropertiesOptions.PART_NUMBER,
-  'Product name': PropertiesOptions.NAME,
-  'Family': PropertiesOptions.FAMILY,
-  'Updated at': PropertiesOptions.UPDATEDAT,
-  'Workspace': PropertiesOptions.WORKSPACE,
-  'Keywords': PropertiesOptions.KEYWORDS,
-  'Properties': PropertiesOptions.PROPERTIES,
-  'File IDs': PropertiesOptions.FILE_IDS
+export const productsProjectionLabelLookup: Record<Properties, {
+  label: string;
+  projection: string;}> = {
+  [Properties.id]: { label: 'Product ID', projection: PropertiesOptions.ID},
+  [Properties.partNumber]: { label: 'Part number', projection: PropertiesOptions.PART_NUMBER },
+  [Properties.name]: { label: 'Product name', projection:  PropertiesOptions.NAME },
+  [Properties.family]: { label: 'Family', projection:  PropertiesOptions.FAMILY },
+  [Properties.updatedAt]: { label: 'Updated at', projection: PropertiesOptions.UPDATEDAT },
+  [Properties.workspace]: { label: 'Workspace', projection: PropertiesOptions.WORKSPACE },
+  [Properties.keywords]: { label: 'Keywords', projection: PropertiesOptions.KEYWORDS },
+  [Properties.properties]: { label: 'Properties', projection: PropertiesOptions.PROPERTIES },
+  [Properties.fileIds]: { label: 'File IDs', projection: PropertiesOptions.FILE_IDS },
 }
 
 export const OrderBy = [

--- a/src/datasources/products/types.ts
+++ b/src/datasources/products/types.ts
@@ -26,29 +26,29 @@ export enum Properties {
 }
 
 export const PropertiesOptions = {
-  ID: 'id',
-  PART_NUMBER: 'partNumber',
-  NAME: 'name',
-  FAMILY: 'family',
-  UPDATEDAT: 'updatedAt',
-  WORKSPACE: 'workspace',
-  KEYWORDS: 'keywords',
-  PROPERTIES: 'properties',
-  FILE_IDS: 'fileIds',
+  ID: Properties.id,
+  PART_NUMBER: Properties.partNumber,
+  NAME: Properties.name,
+  FAMILY: Properties.family,
+  UPDATEDAT: Properties.updatedAt,
+  WORKSPACE: Properties.workspace,
+  KEYWORDS: Properties.keywords,
+  PROPERTIES: Properties.properties,
+  FILE_IDS: Properties.fileIds,
 };
 
 export const productsProjectionLabelLookup: Record<Properties, {
   label: string;
-  projection: string;}> = {
-  [Properties.id]: { label: 'Product ID', projection: PropertiesOptions.ID},
-  [Properties.partNumber]: { label: 'Part number', projection: PropertiesOptions.PART_NUMBER },
-  [Properties.name]: { label: 'Product name', projection:  PropertiesOptions.NAME },
-  [Properties.family]: { label: 'Family', projection:  PropertiesOptions.FAMILY },
-  [Properties.updatedAt]: { label: 'Updated at', projection: PropertiesOptions.UPDATEDAT },
-  [Properties.workspace]: { label: 'Workspace', projection: PropertiesOptions.WORKSPACE },
-  [Properties.keywords]: { label: 'Keywords', projection: PropertiesOptions.KEYWORDS },
-  [Properties.properties]: { label: 'Properties', projection: PropertiesOptions.PROPERTIES },
-  [Properties.fileIds]: { label: 'File IDs', projection: PropertiesOptions.FILE_IDS },
+  projection: Properties;}> = {
+  [Properties.id]: { label: 'Product ID', projection: Properties.id},
+  [Properties.partNumber]: { label: 'Part number', projection: Properties.partNumber },
+  [Properties.name]: { label: 'Product name', projection: Properties.name },
+  [Properties.family]: { label: 'Family', projection: Properties.family },
+  [Properties.updatedAt]: { label: 'Updated at', projection: Properties.updatedAt },
+  [Properties.workspace]: { label: 'Workspace', projection: Properties.workspace },
+  [Properties.keywords]: { label: 'Keywords', projection: Properties.keywords },
+  [Properties.properties]: { label: 'Properties', projection: Properties.properties },
+  [Properties.fileIds]: { label: 'File IDs', projection: Properties.fileIds },
 }
 
 export const OrderBy = [

--- a/src/datasources/products/types.ts
+++ b/src/datasources/products/types.ts
@@ -25,22 +25,10 @@ export enum Properties {
   fileIds = 'fileIds',
 }
 
-export const PropertiesOptions = {
-  ID: Properties.id,
-  PART_NUMBER: Properties.partNumber,
-  NAME: Properties.name,
-  FAMILY: Properties.family,
-  UPDATEDAT: Properties.updatedAt,
-  WORKSPACE: Properties.workspace,
-  KEYWORDS: Properties.keywords,
-  PROPERTIES: Properties.properties,
-  FILE_IDS: Properties.fileIds,
-};
-
 export const productsProjectionLabelLookup: Record<Properties, {
   label: string;
   projection: Properties;}> = {
-  [Properties.id]: { label: 'Product ID', projection: Properties.id},
+  [Properties.id]: { label: 'Product ID', projection: Properties.id },
   [Properties.partNumber]: { label: 'Part number', projection: Properties.partNumber },
   [Properties.name]: { label: 'Product name', projection: Properties.name },
   [Properties.family]: { label: 'Family', projection: Properties.family },


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
This pull request refactors the `ProductsDataSource` codebase to replace the use of `PropertiesOptions` with `Properties`.

## 👩‍💻 Implementation
 - Updated all references to `PropertiesOptions`  to use `Properties` for consistency and clarity. 
 - Removed the `PropertiesOptions` from the type file.

## 🧪 Testing

- Refactored test cases in `ProductsDataSource.test.ts` to use `Properties` instead of `PropertiesOptions` and updated field names to match new labels.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).