### PR TITLE
DRAFT: fix(dataframe): apply "Use time range" for non-INDEX TIMESTAMP columns

### DIFF
--- a/src/datasources/data-frame/DataFrameDataSource.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.ts
@@ -167,7 +167,7 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery, DataSour
   }
 
   private constructTimeFilters(columns: Column[], timeRange: TimeRange): ColumnFilter[] {
-    const timeIndex = columns.find(c => c.dataType === 'TIMESTAMP' && c.columnType === 'INDEX');
+    const timeIndex = columns.find(c => c.dataType === 'TIMESTAMP');
 
     if (!timeIndex) {
       return [];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In the "SystemLink Data Frames" data source, the "Use time range" option works only when the TIMESTAMP column is an INDEX column. 

But it should work even when the TIMESTAMP column is a non INDEX column. 


<img width="390" height="105" alt="image" src="https://github.com/user-attachments/assets/9e78dac3-7b55-47e7-8331-b0b647f9539a" />

### Related bugs

[Bug 3151208](https://dev.azure.com/ni/DevCentral/_workitems/edit/3151208): Use time range does nothing when the timestamp column isn't the index column

[Bug 3153240](https://dev.azure.com/ni/DevCentral/_workitems/edit/3153240): Grafana data frame data source - Dashboard's global time range is used for decimation only if the time stamp is an index column

### Systemlink Data Spaces
In Data spaces, even for non-INDEX TIMESTAMP columns, the time filters are applied.

## 👩‍💻 Implementation
Updates the functionality that constructs time filters to choose the TIMESTAMP column irrespective of the column type.


## 🧪 Testing
TBD


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).