### PR TITLE
fix(workorders,testplans): Sort variable options by their label

### DIFF
--- a/src/datasources/test-plans/TestPlansDataSource.test.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.test.ts
@@ -1632,4 +1632,31 @@ describe('metricFindQuery', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  it('should sort testplan options by name', async () => {
+    const mockQuery = {
+      refId: 'A',
+      outputType: OutputType.Properties,
+      properties: [Properties.NAME],
+      recordCount: 1000,
+    };
+
+    const testPlansResponse = {
+      testPlans: [
+        { id: '1', name: 'Test Plan B' },
+        { id: '3', name: 'Test Plan C' },
+        { id: '2', name: 'Test Plan A' },
+      ],
+    };
+
+    jest.spyOn(datastore, 'queryTestPlansInBatches').mockResolvedValue(testPlansResponse);
+
+    const result = await datastore.metricFindQuery(mockQuery, {} as DataQueryRequest);
+
+    expect(result).toEqual([
+      { text: 'Test Plan A (2)', value: '2' },
+      { text: 'Test Plan B (1)', value: '1' },
+      { text: 'Test Plan C (3)', value: '3' }
+    ]);
+  });
 });

--- a/src/datasources/test-plans/TestPlansDataSource.ts
+++ b/src/datasources/test-plans/TestPlansDataSource.ts
@@ -313,7 +313,8 @@ export class TestPlansDataSource extends DataSourceBase<TestPlansQuery> {
       variableQuery.recordCount,
       variableQuery.descending
     )).testPlans;
-    return metadata ? metadata.map(frame => ({ text: `${frame.name} (${frame.id})`, value: frame.id })) : [];
+    const testPlansOptions = metadata ? metadata.map(frame => ({ text: `${frame.name} (${frame.id})`, value: frame.id })) : [];
+    return testPlansOptions.sort((a, b) => a.text.localeCompare(b.text));
   }
 
   readonly testPlansComputedDataFields = new Map<string, ExpressionTransformFunction>(

--- a/src/datasources/work-orders/WorkOrdersDataSource.test.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.test.ts
@@ -1010,6 +1010,26 @@ describe('WorkOrdersDataSource', () => {
 
       expect(result).toEqual([]);
     });
+
+    test('should sort work order options by name', async () => {
+      const mockQuery = {
+        refId: 'A',
+        take: 1000,
+      };
+      jest.spyOn(datastore, 'queryWorkordersData').mockResolvedValue([
+        { id: '2', name: 'WorkOrder B' },
+        { id: '1', name: 'WorkOrder C' },
+        { id: '3', name: 'WorkOrder A' },
+      ] as WorkOrder[]);
+
+      const results = await datastore.metricFindQuery(mockQuery, {} as LegacyMetricFindQueryOptions);
+
+      expect(results).toEqual([
+        { text: 'WorkOrder A (3)', value: '3' },
+        { text: 'WorkOrder B (2)', value: '2' },
+        { text: 'WorkOrder C (1)', value: '1' },
+      ]);
+    });
   });
 
   describe('testDataSource', () => {

--- a/src/datasources/work-orders/WorkOrdersDataSource.ts
+++ b/src/datasources/work-orders/WorkOrdersDataSource.ts
@@ -107,7 +107,10 @@ export class WorkOrdersDataSource extends DataSourceBase<WorkOrdersQuery> {
       variableQuery.take
     );
 
-    return metadata ? metadata.map(frame => ({ text: `${frame.name} (${frame.id})`, value: frame.id })) : [];
+    const workOrderOptions = metadata
+      ? metadata.map(frame => ({ text: `${frame.name} (${frame.id})`, value: frame.id }))
+      : [];
+    return workOrderOptions.sort((a, b) => a.text.localeCompare(b.text));
   }
 
   async processWorkOrdersQuery(query: WorkOrdersQuery): Promise<DataFrameDTO> {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
[Bug 3190329](https://dev.azure.com/ni/DevCentral/_workitems/edit/3190329): Sort variables in OOTB dashboards in alphabetical order
This pull request introduces functionality to sort options (workorders, testplans) alphabetically by their display text across multiple data sources. It also includes corresponding test cases to validate the sorting behavior.

## 👩‍💻 Implementation
  - Updated `WorkOrdersDataSource` and `TestPlansDataSource` to sort options alphabetically by their `text` values before returning them. 
<img width="538" height="446" alt="image" src="https://github.com/user-attachments/assets/48018652-4347-4c4f-b3b1-5c3b665536a5" />

## 🧪 Testing
- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).