### PR TITLE
DRAFT | SystemLink Data Frames Data Source | Enable high resolution zoom for numerical data in Plotly panel

### DIFF
--- a/src/core/url-change-event.ts
+++ b/src/core/url-change-event.ts
@@ -1,0 +1,29 @@
+let isPatched = false;
+
+export function patchHistoryForUrlChange() {
+  if (isPatched) {
+    return;
+  }
+  isPatched = true;
+
+  const originalPushState = history.pushState;
+  const originalReplaceState = history.replaceState;
+
+  const dispatchUrlChange = () => {
+    window.dispatchEvent(new Event('urlchange'));
+  };
+
+  history.pushState = function (...args) {
+    const result = originalPushState.apply(this, args);
+    dispatchUrlChange();
+    return result;
+  };
+
+  history.replaceState = function (...args) {
+    const result = originalReplaceState.apply(this, args);
+    dispatchUrlChange();
+    return result;
+  };
+
+  window.addEventListener('popstate', dispatchUrlChange);
+}

--- a/src/datasources/data-frame/DataFrameDataSource.ts
+++ b/src/datasources/data-frame/DataFrameDataSource.ts
@@ -85,6 +85,16 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery, DataSour
       filters.push(...this.constructNullFilters(columns));
     }
 
+    if (columns.length > 0) {
+      const urlParams = new URLSearchParams(window.location.search);
+      const xField = columns[0].name;
+      const xMin = urlParams.get(`${xField}-min`);
+      const xMax = urlParams.get(`${xField}-max`);
+      if (xMin !== undefined && xMax !== undefined && typeof xMin === 'number' && typeof xMax === 'number') {
+        filters.push(...this.constructXAxisNumberFilters(xField, Math.floor(Number(xMin)), Math.floor(Number(xMax))));
+      }
+    }
+
     return await this.post<TableDataRows>(`${this.baseUrl}/tables/${query.tableId}/query-decimated-data`, {
       columns: query.columns,
       filters,
@@ -176,6 +186,13 @@ export class DataFrameDataSource extends DataSourceBase<DataFrameQuery, DataSour
     return [
       { column: timeIndex.name, operation: 'GREATER_THAN_EQUALS', value: timeRange.from.toISOString() },
       { column: timeIndex.name, operation: 'LESS_THAN_EQUALS', value: timeRange.to.toISOString() },
+    ];
+  }
+
+  private constructXAxisNumberFilters(xField: string, xMin: number, xMax: number): ColumnFilter[] {
+    return [
+      { column: xField, operation: 'GREATER_THAN_EQUALS', value: xMin.toString() },
+      { column: xField, operation: 'LESS_THAN_EQUALS', value: xMax.toString() },
     ];
   }
 

--- a/src/datasources/data-frame/types.ts
+++ b/src/datasources/data-frame/types.ts
@@ -12,7 +12,7 @@ export interface DataFrameQuery extends DataQuery {
   columns?: string[];
   decimationMethod?: string;
   filterNulls?: boolean;
-  applyTimeFilters?: boolean;
+  fetchHighResolutionData?: boolean;
 }
 
 export const defaultQuery: Omit<ValidDataFrameQuery, 'refId'> = {
@@ -21,7 +21,7 @@ export const defaultQuery: Omit<ValidDataFrameQuery, 'refId'> = {
   columns: [],
   decimationMethod: 'LOSSY',
   filterNulls: false,
-  applyTimeFilters: false
+  fetchHighResolutionData: false
 };
 
 export type ValidDataFrameQuery = DataFrameQuery & Required<Omit<DataFrameQuery, keyof DataQuery>>;

--- a/src/panels/plotly/PlotlyPanel.tsx
+++ b/src/panels/plotly/PlotlyPanel.tsx
@@ -28,7 +28,7 @@ interface MenuState {
 interface Props extends PanelProps<PanelOptions> {}
 
 export const PlotlyPanel: React.FC<Props> = (props) => {
-  const { data, width, height, options } = props;
+  const { data, width, height, options, id } = props;
   const [menu, setMenu] = useState<MenuState>({ x: 0, y: 0, show: false, items: [] });
   const theme = useTheme2();
 
@@ -153,12 +153,23 @@ export const PlotlyPanel: React.FC<Props> = (props) => {
         props.onOptionsChange({...options, xAxis: { ...options.xAxis, min: from.valueOf(), max: to.valueOf() } });
       }
     } else {
-      locationService.partial({
-        [`${options.xAxis.field}-min`]: xAxisMin,
-        [`${options.xAxis.field}-max`]: xAxisMax
-      }, true);
-      locationService.reload();
-      props.onOptionsChange({...options, xAxis: { ...options.xAxis, min: xAxisMin, max: xAxisMax } });
+      const queryParams = locationService.getSearchObject();
+      const fetchHighResolutionDataOnZoom = queryParams['fetchHighResolutionData'];
+
+      if (
+        fetchHighResolutionDataOnZoom !== undefined
+        && typeof fetchHighResolutionDataOnZoom === 'string'
+        && fetchHighResolutionDataOnZoom !== ''
+        && fetchHighResolutionDataOnZoom.split(',').includes(id.toString())
+      ) {
+        locationService.partial({
+          [`${options.xAxis.field}-min`]: xAxisMin,
+          [`${options.xAxis.field}-max`]: xAxisMax
+        }, true);
+        locationService.reload();
+      } else {
+        props.onOptionsChange({...options, xAxis: { ...options.xAxis, min: xAxisMin, max: xAxisMax } });
+      }
     }
   };
 

--- a/src/panels/plotly/PlotlyPanel.tsx
+++ b/src/panels/plotly/PlotlyPanel.tsx
@@ -12,7 +12,7 @@ import {
 } from '@grafana/data';
 import { AxisLabels, PanelOptions } from './types';
 import { useTheme2, ContextMenu, MenuItemsGroup, linkModelToContextMenuItems } from '@grafana/ui';
-import { getTemplateSrv, PanelDataErrorView } from '@grafana/runtime';
+import { getTemplateSrv, PanelDataErrorView, locationService } from '@grafana/runtime';
 import { getFieldsByName, notEmpty, Plot, renderMenuItems, useTraceColors } from './utils';
 import { AxisType, Legend, PlotData, PlotType, toImage, Icons, PlotlyHTMLElement } from 'plotly.js-basic-dist-min';
 import { saveAs } from 'file-saver';
@@ -153,6 +153,11 @@ export const PlotlyPanel: React.FC<Props> = (props) => {
         props.onOptionsChange({...options, xAxis: { ...options.xAxis, min: from.valueOf(), max: to.valueOf() } });
       }
     } else {
+      locationService.partial({
+        [`${options.xAxis.field}-min`]: xAxisMin,
+        [`${options.xAxis.field}-max`]: xAxisMax
+      }, true);
+      locationService.reload();
       props.onOptionsChange({...options, xAxis: { ...options.xAxis, min: xAxisMin, max: xAxisMax } });
     }
   };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

To enable high-resolution zoom for the decimated Data table data using the Plotly panel.

## 👩‍💻 Implementation
To be updated


## 🧪 Testing
To be updated in the production version of the PR.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).