### PR TITLE
fix(products): Display empty cell for properties when API returns empty object

### DIFF
--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -391,7 +391,7 @@ describe('query', () => {
     ]);
   });
 
-  test('should display an empty cell when properties is returned as empty objects', async () => {
+  test('should display an empty cell when properties is returned as empty object', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-products' }))
       .mockReturnValue(createFetchResponse({

--- a/src/datasources/products/ProductsDataSource.test.ts
+++ b/src/datasources/products/ProductsDataSource.test.ts
@@ -391,6 +391,36 @@ describe('query', () => {
     ]);
   });
 
+  test('should display an empty cell when properties is returned as empty objects', async () => {
+    backendServer.fetch
+      .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-products' }))
+      .mockReturnValue(createFetchResponse({
+        products: [
+          {
+            id: '1',
+            name: 'Product 1',
+            properties: {}
+          }
+        ], continuationToken: null, totalCount: 0
+      } as unknown as QueryProductResponse));
+
+    const query = buildQuery(
+      {
+        refId: 'A',
+        properties: [
+          PropertiesOptions.PROPERTIES
+        ] as Properties[],
+        orderBy: undefined
+      },
+    );
+
+    const response = await datastore.query(query);
+    const fields = response.data[0].fields as Field[];
+    expect(fields).toEqual([
+      { name: 'Properties', values: [''], type: 'string' },
+    ]);
+  });
+
   test('should not query product values if cache exists', async () => {
     backendServer.fetch
       .calledWith(requestMatching({ url: '/nitestmonitor/v2/query-product-values' }))

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -152,7 +152,9 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
       const fieldValues = values.map(value => {
         switch (field) {
           case PropertiesOptions.PROPERTIES:
-            return value == null ? '' : JSON.stringify(value);
+            return value && (Object.keys(value).length > 0)
+              ? JSON.stringify(value)
+              : '';
           case PropertiesOptions.WORKSPACE:
             const workspace = this.workspacesCache.get(value);
             return workspace ? getWorkspaceName([workspace], value) : value;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR contains fix for _[Bug 3195350](https://dev.azure.com/ni/DevCentral/_workitems/edit/3195350): Grafana | Product datasource properties shows empty object instead of empty cell_

## 👩‍💻 Implementation

- Updated the logic to display an empty value when the properties field in the response is an empty object.

Before
<img width="1918" height="860" alt="image" src="https://github.com/user-attachments/assets/684fd3f5-aa0b-4271-a842-7fa502dbb16c" />


After
<img width="1918" height="886" alt="image" src="https://github.com/user-attachments/assets/930d01e3-cca9-4678-8ae8-047f69dc7267" />

## 🧪 Testing

Added unit test case

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).