### PR TITLE
refactor(products): Refactor run query to make it concise

### DIFF
--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -226,12 +226,12 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
     products: ProductResponseProperties[],
     field: Properties
   ): string[] {
-    const values = products.map(data => data[field as unknown as keyof ProductResponseProperties]);
-    return values.map(value => {
+    return products.map(product => {
+      const value = product[field];
       switch (field) {
-        case PropertiesOptions.PROPERTIES:
+        case Properties.properties:
           return value && Object.keys(value).length > 0 ? JSON.stringify(value) : '';
-        case PropertiesOptions.WORKSPACE:
+        case Properties.workspace:
           const workspace = this.workspacesCache.get(value);
           return workspace ? getWorkspaceName([workspace], value) : value;
         default:

--- a/src/datasources/products/ProductsDataSource.ts
+++ b/src/datasources/products/ProductsDataSource.ts
@@ -146,25 +146,9 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
         ? FieldType.time
         : FieldType.string;
 
-      const values = products
-        .map(data => data[field as unknown as keyof ProductResponseProperties]);
-
-      const fieldValues = values.map(value => {
-        switch (field) {
-          case PropertiesOptions.PROPERTIES:
-            return value && (Object.keys(value).length > 0)
-              ? JSON.stringify(value)
-              : '';
-          case PropertiesOptions.WORKSPACE:
-            const workspace = this.workspacesCache.get(value);
-            return workspace ? getWorkspaceName([workspace], value) : value;
-          default:
-            return value == null ? '' : value;
-        }
-      });
       return {
         name: productsProjectionLabelLookup[field].label,
-        values: fieldValues,
+        values: this.getFieldValues(products, field),
         type: fieldType
       };
     });
@@ -236,6 +220,24 @@ export class ProductsDataSource extends DataSourceBase<ProductQuery> {
         .map(val => `${field} ${operation} "${val}"`)
         .join(` ${logicalOperator} `)})` : `${field} ${operation} "${value}"`;
     }
+  }
+
+  private getFieldValues(
+    products: ProductResponseProperties[],
+    field: Properties
+  ): string[] {
+    const values = products.map(data => data[field as unknown as keyof ProductResponseProperties]);
+    return values.map(value => {
+      switch (field) {
+        case PropertiesOptions.PROPERTIES:
+          return value && Object.keys(value).length > 0 ? JSON.stringify(value) : '';
+        case PropertiesOptions.WORKSPACE:
+          const workspace = this.workspacesCache.get(value);
+          return workspace ? getWorkspaceName([workspace], value) : value;
+        default:
+          return value == null ? '' : value;
+      }
+    });
   }
 
   private getVariableOptions() {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR refactors the `runQuery` method in the products datasource to improve conciseness.
Refer to [this comment](https://github.com/ni/systemlink-grafana-plugins/pull/365#discussion_r2239021627) for the context and origin of this discussion.

## 👩‍💻 Implementation

- Introduced a private method, `getFieldValues` which takes the products response and a field as parameters to retrieve values for the selected products.

## 🧪 Testing

NA

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).