### PR TITLE
fix(results): Update tooltip description for use time range control

### DIFF
--- a/src/datasources/results/components/editors/time-range/TimeRangeControls.tsx
+++ b/src/datasources/results/components/editors/time-range/TimeRangeControls.tsx
@@ -24,7 +24,7 @@ export function TimeRangeControls({query, handleQueryChange}: Props) {
 }
 
 const tooltips = {
-  useTimeRange: 'This toggle enables querying within the dashboard time range.',
+  useTimeRange: 'This toggle enables querying by started at within the dashboard time range.',
 };
 
 const labels = {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR contains the fix for the _[Bug 3207133](https://dev.azure.com/ni/DevCentral/_workitems/edit/3207133): Test results data source - Help text for 'use time range' doesn't help understand which field the time range is applied to_

## 👩‍💻 Implementation

- Updated tooltip for use time range control in result and step editor to have contain the startedAt field which is the field the time range is applied.

## 🧪 Testing

- Manually tested

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).