### PR TITLE
feat(asset):  add take support for query variables for ListAssets data source

### DIFF
--- a/src/datasources/asset/AssetDataSource.test.ts
+++ b/src/datasources/asset/AssetDataSource.test.ts
@@ -132,7 +132,7 @@ const assetsResponseMock: AssetsResponse =
       "isSystemController": false,
       "workspace": "e73fcd94-649b-4d0a-b164-bf647a5d0946",
       "properties": {},
-      "keywords": [ "Kw1", "Kw2" ],
+      "keywords": ["Kw1", "Kw2"],
       "lastUpdatedTimestamp": "2024-02-21T12:54:20.072Z",
       "fileIds": [],
       "supportsSelfTest": false,
@@ -371,7 +371,8 @@ describe('queries', () => {
       const query: AssetVariableQuery = {
         filter: '',
         type: AssetQueryType.None,
-        refId: ""
+        refId: "",
+        take: 10,
       }
 
       backendSrv.fetch
@@ -391,7 +392,8 @@ describe('queries', () => {
       const query: AssetVariableQuery = {
         filter: '',
         type: AssetQueryType.None,
-        refId: ""
+        refId: "",
+        take: 10,
       }
 
       backendSrv.fetch
@@ -405,6 +407,89 @@ describe('queries', () => {
       const result = await ds.metricFindQuery(query, options)
 
       expect(result).toMatchSnapshot();
+    })
+
+    it('should return expected data when take is 10000', async () => {
+      const query: AssetVariableQuery = {
+        filter: '',
+        type: AssetQueryType.ListAssets,
+        refId: "",
+        take: 10000,
+      }
+
+      backendSrv.fetch
+        .calledWith(requestMatching({ url: '/niapm/v1/query-assets' }))
+        .mockReturnValue(createFetchResponse(assetsWithoutNameResponseMock as AssetsResponse))
+
+      const options = {
+        scopedVars: {}
+      }
+
+      const result = await ds.metricFindQuery(query, options);
+
+      expect(result).toMatchSnapshot();
+    })
+
+    it('should return empty data when take is invalid', async () => {
+      const query: AssetVariableQuery = {
+        filter: '',
+        type: AssetQueryType.ListAssets,
+        refId: "",
+        take: undefined,
+      }
+
+      backendSrv.fetch
+        .calledWith(requestMatching({ url: '/niapm/v1/query-assets' }))
+        .mockReturnValue(createFetchResponse(assetsWithoutNameResponseMock as AssetsResponse))
+
+      const options = {
+        scopedVars: {}
+      }
+
+      const result = await ds.metricFindQuery(query, options)
+
+      expect(result).toEqual([]);
+    })
+
+    it('should return empty data when take is less than 0', async () => {
+      const query: AssetVariableQuery = {
+        filter: '',
+        type: AssetQueryType.ListAssets,
+        refId: "",
+        take: -1,
+      }
+      backendSrv.fetch
+        .calledWith(requestMatching({ url: '/niapm/v1/query-assets' }))
+        .mockReturnValue(createFetchResponse(assetsWithoutNameResponseMock as AssetsResponse))
+
+      const options = {
+        scopedVars: {}
+      }
+
+      const result = await ds.metricFindQuery(query, options)
+
+      expect(result).toEqual([]);
+    })
+
+    it('should return empty data when take is less than 10000', async () => {
+      const query: AssetVariableQuery = {
+        filter: '',
+        type: AssetQueryType.ListAssets,
+        refId: "",
+        take: 10001,
+      }
+
+      backendSrv.fetch
+        .calledWith(requestMatching({ url: '/niapm/v1/query-assets' }))
+        .mockReturnValue(createFetchResponse(assetsWithoutNameResponseMock as AssetsResponse))
+
+      const options = {
+        scopedVars: {}
+      }
+
+      const result = await ds.metricFindQuery(query, options)
+
+      expect(result).toEqual([]);
     })
   })
 })

--- a/src/datasources/asset/AssetDataSource.test.ts
+++ b/src/datasources/asset/AssetDataSource.test.ts
@@ -471,7 +471,7 @@ describe('queries', () => {
       expect(result).toEqual([]);
     })
 
-    it('should return empty data when take is less than 10000', async () => {
+    it('should return empty data when take is greater than 10000', async () => {
       const query: AssetVariableQuery = {
         filter: '',
         type: AssetQueryType.ListAssets,

--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -120,7 +120,7 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
     return { ...defaultListAssetsVariable, ...query } as AssetVariableQuery;
   }
 
-  private isTakeValid(take: number | undefined): boolean {
+  private isTakeValid(take?: number): boolean {
     return take !== undefined && take >= 0 && take <= TAKE_LIMIT;
   }
 }

--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -24,7 +24,6 @@ import { transformComputedFieldsQuery } from 'core/query-builder.utils';
 import { AssetVariableQuery } from './types/AssetVariableQuery.types';
 import { defaultListAssetsVariable } from './defaults';
 import { TAKE_LIMIT } from './constants/ListAssets.constants';
-import { QUERY_LIMIT } from './constants/constants';
 
 export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceOptions> {
   private assetSummaryDataSource: AssetSummaryDataSource;
@@ -92,7 +91,7 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
   }
 
   async metricFindQuery(query: AssetVariableQuery, options: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
-    let listAssetsTake = query?.take ?? QUERY_LIMIT;
+    let listAssetsTake = this.patchListAssetQueryVariable(query).take;
     if (!this.isTakeValid(listAssetsTake)) {
       return [];
     }
@@ -121,7 +120,7 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
     return { ...defaultListAssetsVariable, ...query } as AssetVariableQuery;
   }
 
-  private isTakeValid(take: number): boolean {
+  private isTakeValid(take: number | undefined): boolean {
     return take !== undefined && take >= 0 && take <= TAKE_LIMIT;
   }
 }

--- a/src/datasources/asset/__snapshots__/AssetDataSource.test.ts.snap
+++ b/src/datasources/asset/__snapshots__/AssetDataSource.test.ts.snap
@@ -34,6 +34,19 @@ exports[`queries metricFindQuery returns name/alias when asset name field is pre
 ]
 `;
 
+exports[`queries metricFindQuery should return expected data when take is 10000 1`] = `
+[
+  {
+    "text": "01FE20D1",
+    "value": "Assets.National Instruments.sbRIO-9629.01FE20D1",
+  },
+  {
+    "text": "2222",
+    "value": "Assets.3333.1111.2222",
+  },
+]
+`;
+
 exports[`queries run metadata query 1`] = `
 [
   {

--- a/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.test.tsx
+++ b/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.test.tsx
@@ -1,11 +1,13 @@
-import { screen, waitFor } from '@testing-library/react';
-import { AssetQuery, AssetQueryType } from '../../types/types';
+import { act, screen, waitFor } from '@testing-library/react';
+import { AssetQueryType } from '../../types/types';
 import { SystemProperties } from '../../../system/types'
 import { AssetVariableQueryEditor } from './AssetVariableQueryEditor';
 import { Workspace } from 'core/types';
 import { setupRenderer } from 'test/fixtures';
 import { ListAssetsDataSource } from '../../data-sources/list-assets/ListAssetsDataSource';
 import { AssetDataSource } from 'datasources/asset/AssetDataSource';
+import { AssetVariableQuery } from 'datasources/asset/types/AssetVariableQuery.types';
+import userEvent from '@testing-library/user-event';
 
 const fakeSystems: SystemProperties[] = [
     {
@@ -50,12 +52,91 @@ class FakeAssetDataSource extends AssetDataSource {
     }
 }
 
-const render = setupRenderer(AssetVariableQueryEditor, FakeAssetDataSource, () => {});
+const render = async (query: AssetVariableQuery) => {
+    return await act(async () => setupRenderer(AssetVariableQueryEditor, FakeAssetDataSource, () => { })(query))
+}
+
 
 it('renders the variable query builder', async () => {
-    render({  refId: '', type: AssetQueryType.ListAssets, filter: "" } as AssetQuery);
+    render({ refId: '', type: AssetQueryType.ListAssets, filter: "" } as AssetVariableQuery);
 
     await waitFor(() => expect(screen.getAllByText('Property').length).toBe(1));
     await waitFor(() => expect(screen.getAllByText('Operator').length).toBe(1));
     await waitFor(() => expect(screen.getAllByText('Value').length).toBe(1));
 });
+
+it('should render take', async () => {
+    await render({ type: AssetQueryType.ListAssets } as AssetVariableQuery)
+    expect(screen.queryByRole('spinbutton')).toBeInTheDocument();
+});
+
+it('only allows numbers input in Take field', async () => {
+    await render({ type: AssetQueryType.ListAssets, take: 1000 } as AssetVariableQuery);
+
+    const take = screen.getByRole('spinbutton');
+
+    await userEvent.clear(take);
+    await userEvent.type(take, 'aaa');
+    await waitFor(() => {
+        expect(take).toHaveValue(null);
+    });
+
+    await userEvent.clear(take);
+    await userEvent.type(take, '5');
+    await waitFor(() => {
+        expect(take).toHaveValue(5);
+    });
+})
+
+it('should call onChange with take when user changes take', async () => {
+    const [onChange] = await render({ type: AssetQueryType.ListAssets, take: 1000 } as AssetVariableQuery);
+    const take = screen.getByRole('spinbutton');
+
+    await userEvent.clear(take);
+    await userEvent.type(take, '5');
+    await userEvent.tab();
+    await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ take: 5 }));
+    });
+})
+
+it('should display error message when user changes take to number greater than max take', async () => {
+    const [onChange] = await render({} as AssetVariableQuery);
+    const take = screen.getByRole('spinbutton');
+    onChange.mockClear();
+
+    await userEvent.clear(take);
+    await userEvent.type(take, '10001');
+    await userEvent.tab();
+    await waitFor(() => {
+        expect(screen.getByText('Enter a value less than or equal to 10,000')).toBeInTheDocument();
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ take: undefined }));
+    });
+})
+
+it('should display error message when user changes take to number less than 0', async () => {
+    const [onChange] = await render({} as AssetVariableQuery);
+    const take = screen.getByRole('spinbutton');
+    onChange.mockClear();
+
+    await userEvent.clear(take);
+    await userEvent.tab();
+    await waitFor(() => {
+        expect(screen.getByText('Enter a value greater than or equal to 0')).toBeInTheDocument();
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ take: undefined }));
+    });
+})
+
+it('should not display error message when user changes value to number between 0 and max take', async () => {
+    const [onChange] = await render({} as AssetVariableQuery);
+    const take = screen.getByRole('spinbutton');
+    onChange.mockClear();
+
+    await userEvent.clear(take);
+    await userEvent.type(take, '5')
+    await userEvent.tab();
+    await waitFor(() => {
+        expect(screen.queryByText('Enter a value greater than or equal to 0')).not.toBeInTheDocument();
+        expect(screen.queryByText('Enter a value less than or equal to 10,000')).not.toBeInTheDocument();
+    });
+})

--- a/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.tsx
+++ b/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.tsx
@@ -7,15 +7,22 @@ import { AssetQueryBuilder } from '../editors/list-assets/query-builder/AssetQue
 import { Workspace } from '../../../../core/types';
 import { SystemProperties } from '../../../system/types';
 import { AssetVariableQuery } from '../../../asset/types/AssetVariableQuery.types';
+import { AutoSizeInput, InlineField, Stack } from '@grafana/ui';
+import { takeErrorMessages } from 'datasources/asset/constants/constants';
+import { TAKE_LIMIT } from 'datasources/asset/constants/ListAssets.constants';
+import { validateNumericInput } from 'core/utils';
 
 type Props = QueryEditorProps<AssetDataSource, AssetQuery, AssetDataSourceOptions>;
 
 export function AssetVariableQueryEditor({ datasource, query, onChange }: Props) {
+  query = datasource.patchListAssetQueryVariable(query);
+
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [systems, setSystems] = useState<SystemProperties[]>([]);
   const [areDependenciesLoaded, setAreDependenciesLoaded] = useState<boolean>(false);
   const assetVariableQuery = query as AssetVariableQuery;
   const assetListDatasource = useRef(datasource.getListAssetsSource());
+  const [recordCountInvalidMessage, setRecordCountInvalidMessage] = useState<string>('');
 
   useEffect(() => {
     Promise.all([assetListDatasource.current.areSystemsLoaded$, assetListDatasource.current.areWorkspacesLoaded$]).then(() => {
@@ -31,17 +38,63 @@ export function AssetVariableQueryEditor({ datasource, query, onChange }: Props)
     }
   }
 
+  function validateTakeValue(value: number, TAKE_LIMIT: number) {
+    if (isNaN(value) || value < 0) {
+      return { message: takeErrorMessages.greaterOrEqualToZero };
+    }
+    if (value > TAKE_LIMIT) {
+      return { message: takeErrorMessages.lessOrEqualToTenThousand };
+    }
+    return { message: '', take: value };
+  }
+
+  function onTakeChange(event: React.FormEvent<HTMLInputElement>) {
+    const value = parseInt((event.target as HTMLInputElement).value, 10);
+    const { message, take } = validateTakeValue(value, TAKE_LIMIT);
+
+    setRecordCountInvalidMessage(message);
+    if (assetVariableQuery.take !== take) {
+      onChange({ ...assetVariableQuery, take: take } as AssetVariableQuery);
+    }
+  };
+
   return (
-    <div style={{ width: "525px" }}>
-      <AssetQueryBuilder
-        filter={assetVariableQuery.filter}
-        workspaces={workspaces}
-        systems={systems}
-        globalVariableOptions={assetListDatasource.current.globalVariableOptions()}
-        areDependenciesLoaded={areDependenciesLoaded}
-        onChange={(event: any) => onParameterChange(event)}
-      ></AssetQueryBuilder>
+    <Stack direction="column">
+      <InlineField label="Filter" labelWidth={25} tooltip={tooltips.listAssets.filter}>
+        <AssetQueryBuilder
+          filter={assetVariableQuery.filter}
+          workspaces={workspaces}
+          systems={systems}
+          globalVariableOptions={assetListDatasource.current.globalVariableOptions()}
+          areDependenciesLoaded={areDependenciesLoaded}
+          onChange={(event: any) => onParameterChange(event)}
+        ></AssetQueryBuilder>
+      </InlineField>
       <FloatingError message={assetListDatasource.current.error} />
-    </div>
+      <InlineField
+        label="Take"
+        labelWidth={25}
+        tooltip={tooltips.listAssets.take}
+        invalid={!!recordCountInvalidMessage}
+        error={recordCountInvalidMessage}
+      >
+        <AutoSizeInput
+          minWidth={26}
+          maxWidth={26}
+          type="number"
+          value={assetVariableQuery.take}
+          onChange={onTakeChange}
+          placeholder="Enter record count"
+          onKeyDown={(event) => { validateNumericInput(event) }}
+        />
+      </InlineField>
+    </Stack>
   );
 }
+
+const tooltips = {
+  listAssets: {
+    filter: `Filter the assets by various properties. This is an optional field.`,
+    take: 'This field specifies the maximum number of assets to return.'
+  },
+};

--- a/src/datasources/asset/defaults.ts
+++ b/src/datasources/asset/defaults.ts
@@ -1,3 +1,4 @@
+import { QUERY_LIMIT } from "./constants/constants"
 import { OutputType } from "./types/ListAssets.types"
 
 export const defaultAssetSummaryQuery = {
@@ -11,5 +12,10 @@ export const defaultCalibrationForecastQuery = {
 export const defaultListAssetsQuery = {
     filter: "",
     outputType: OutputType.Properties,
-    take: 1000,
+    take: QUERY_LIMIT,
+}
+
+export const defaultListAssetsVariable = {
+    filter: "",
+    take: QUERY_LIMIT,
 }

--- a/src/datasources/asset/types/AssetVariableQuery.types.ts
+++ b/src/datasources/asset/types/AssetVariableQuery.types.ts
@@ -2,4 +2,5 @@ import { AssetQuery } from './types';
 
 export interface AssetVariableQuery extends AssetQuery {
   filter: string;
+  take?: number;
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR adds support for the take parameter in ListAssets data source variable queries, allowing users to limit the number of returned results when defining dashboard variables.
The take value can be configured from the UI, with proper validation to avoid invalid or excessive limits.
A default value is provided via defaultListAssetsVariable.

## 👩‍💻 Implementation

Query handling:
  Added patchListAssetQueryVariable(query) function in AssetDataSource.ts:
    1. Merges the provided query with defaultListAssetsVariable to ensure backward compatibility with existing dashboards.
    2. Default values: filter: "", take: QUERY_LIMIT (1000)
  Integrated patchListAssetsVariableQuery into metricFindQuery for ListAssets variable queries.
  
  Added validation function isTakeValid(take: number | undefined), which is valid if:
    1. take is defined
    2. take >= 0
    3. take <= TAKE_LIMIT. If invalid, returns empty array instead of query results.
  
UI:
  Updated variable editor UI to include an AutoSizeInput for take.
  On change:
   1. Validate input (NaN, < 0, > TAKE_LIMIT are invalid)
   2. Show error message next to field if invalid
   3. If valid, update query .

Backward compatibility:
  Old dashboard variables will work without modification due to the patch function as missing take will be replaced with QUERY_LIMIT 

## 🧪 Testing

Unit testing:
 1. Showing correct error message when take is invalid.
 2. Returning an empty array when take is invalid.
 3. Returning correct results when: take = TAKE_LIMIT
 
Manual Verification:
 1. Add or edit a variable using ListAssets query type.
 2. Verify that: 
    -  the take input field is visible in the editor.
    -  default value is 1000
    -  entering invalid values (< 0, > TAKE_LIMIT) shows the correct error message in the UI and does not trigger a query
    -  valid values trigger the query and limit the results accordingly.
 3. Save dashboard and reload:
    - verify that variables without an explicit take use the default value.
 4. Edge case validation:
    - take = 0 returns all data (based on backend behavior)
    - take = TAKE_LIMIT returns the maximum allowed.
    
![TakeQueryVariable](https://github.com/user-attachments/assets/39888f10-6c70-4a8b-9ad2-5587ae202d84)

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).