### PR TITLE
fix(shared): use common fetch method for get and post API calls

### DIFF
--- a/src/core/DataSourceBase.ts
+++ b/src/core/DataSourceBase.ts
@@ -44,7 +44,7 @@ export abstract class DataSourceBase<TQuery extends DataQuery, TOptions extends 
   }
 
   get<T>(url: string, params?: Record<string, any>) {
-    return get<T>(this.backendSrv,  url, params);
+    return get<T>(this.backendSrv, url, params);
   }
 
   

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -558,7 +558,7 @@ describe('get', () => {
       .mockReturnValueOnce(throwError(() => ({ status: 429, data: {} })))
       .mockReturnValueOnce(of(expectedResponse));
 
-      const response = await get(mockBackendSrv, url, params);
+    const response = await get(mockBackendSrv, url, params);
 
     expect(mockBackendSrv.fetch).toHaveBeenCalledTimes(3);
     expect(response).toEqual('test');
@@ -567,7 +567,7 @@ describe('get', () => {
   it('should stop retrying after 3 failed attempts with 429', async () => {
     (mockBackendSrv.fetch as jest.Mock).mockReturnValue(throwError(() => ({ status: 429, data: {} })));
 
-    await expect(get(mockBackendSrv, url, params)).rejects.toThrow('Request failed with status code 429');
+    await expect(get(mockBackendSrv, url, params)).rejects.toThrow('Request to url \"/api/test\" failed with status code: 429. Error message: {}');
     expect(mockBackendSrv.fetch).toHaveBeenCalledTimes(4);
   });
 });
@@ -602,7 +602,7 @@ describe('post', () => {
     (mockBackendSrv.fetch as jest.Mock)
       .mockReturnValueOnce(throwError(() => ({ status: 429, data: {} })))
       .mockReturnValueOnce(throwError(() => ({ status: 429, data: {} })))
-      .mockResolvedValueOnce(of(expectedResponse));
+      .mockReturnValueOnce(of(expectedResponse));
 
     const response = await post(mockBackendSrv, url, body);
 
@@ -613,7 +613,7 @@ describe('post', () => {
   it('should stop retrying after 3 failed attempts with 429', async () => {
     (mockBackendSrv.fetch as jest.Mock).mockReturnValue(throwError(() => ({ status: 429, data: {} })));
 
-    await expect(get(mockBackendSrv, url, body)).rejects.toThrow('Request failed with status code 429');
+    await expect(post(mockBackendSrv, url, body)).rejects.toThrow('Request to url \"/api/test\" failed with status code: 429. Error message: {}');
     expect(mockBackendSrv.fetch).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -7,6 +7,14 @@ const mockBackendSrv = {
   fetch: jest.fn(),
 } as unknown as BackendSrv;
 
+jest.mock('./utils', () => {
+  const actual = jest.requireActual('./utils');
+  return {
+    ...actual,
+    sleep: jest.fn(() => Promise.resolve()),
+  };
+});
+
 test('enumToOptions', () => {
   enum fakeStringEnum {
     Label1 = 'Value1',
@@ -534,6 +542,7 @@ describe('get', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('should call backendSrv.fetch with correct URL and params', async () => {
@@ -580,6 +589,7 @@ describe('post', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('should call backendSrv.fetch with correct URL and params', async () => {

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -558,11 +558,12 @@ describe('get', () => {
   it('should retry up to 3 times on 429 before succeeding', async () => {
     const url = '/api/test';
     const params = { key: 'value' };
+    const expectedResponse = { data: 'test' };
 
     (mockBackendSrv.fetch as jest.Mock)
       .mockReturnValueOnce(throwError(() => ({ status: 429, data: {} })))
       .mockReturnValueOnce(throwError(() => ({ status: 429, data: {} })))
-      .mockResolvedValueOnce({ data: 'final-success' });
+      .mockReturnValueOnce(of(expectedResponse));
 
       const response = await get(mockBackendSrv, url, params);
 
@@ -603,11 +604,12 @@ describe('post', () => {
   it('should retry up to 3 times on 429 before succeeding', async () => {
     const url = '/api/test';
     const params = { key: 'value' };
+    const expectedResponse = { data: 'test' };
 
     (mockBackendSrv.fetch as jest.Mock)
       .mockReturnValueOnce(throwError(() => ({ status: 429, data: {} })))
       .mockReturnValueOnce(throwError(() => ({ status: 429, data: {} })))
-      .mockResolvedValueOnce({ data: 'final-success' });
+      .mockResolvedValueOnce(of(expectedResponse));
 
       const response = await post(mockBackendSrv, url, params);
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -2,7 +2,8 @@ import { SelectableValue, textUtil } from '@grafana/data';
 import { useAsync } from 'react-use';
 import { DataSourceBase } from './DataSourceBase';
 import { BatchQueryConfig, QueryResponse, SystemLinkError, Workspace } from './types';
-import { TemplateSrv } from '@grafana/runtime';
+import { BackendSrv, BackendSrvRequest, FetchError, isFetchError, TemplateSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
 
 export function enumToOptions<T>(stringEnum: { [name: string]: T }): Array<SelectableValue<T>> {
   const RESULT = [];
@@ -268,4 +269,53 @@ export async function queryUsingSkip<T>(
 
 async function delay(timeout: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, timeout));
+}
+
+
+async function fetch<T>(backendSrv: BackendSrv, options: BackendSrvRequest, retries = 0): Promise<T> {
+  // URL is stored and reused for each retry to ensure consistency
+  // and prevent accidental URL changes during retries
+  const url = options.url;
+
+  try {
+    return (await lastValueFrom(backendSrv.fetch<T>(options))).data;
+  } catch (error) {
+    if (isFetchError(error) && error.status === 404 && retries < 3) {
+      await sleep(Math.random() * 1000 * 2 ** retries);
+      return fetch(backendSrv, {...options, url}, retries + 1);
+    }
+    if (isFetchError(error)) {
+      const fetchError = error as FetchError;
+      const statusCode = fetchError.status;
+      const genericErrorMessage = `Request to url "${options.url}" failed with status code: ${statusCode}.`;
+      if (statusCode === 504) {
+        throw new Error(genericErrorMessage);
+      } else {
+        const data = fetchError.data;
+        const errorMessage = data.error?.message || JSON.stringify(data);
+        throw new Error(`${genericErrorMessage} Error message: ${errorMessage}`);
+      }
+    }
+    throw error;
+  }
+}
+
+export function get<T>(backendSrv: BackendSrv, url: string, params?: Record<string, any>) {
+  return fetch<T>(backendSrv, { method: 'GET', url, params });
+}
+
+
+/**
+ * Sends a POST request to the specified URL with the provided request body and options.
+ *
+ * @template T - The expected response type.
+ * @param url - The endpoint URL to which the POST request is sent.
+ * @param body - The request payload as a key-value map.
+ * @param options - Optional configuration for the request. This can include:
+ *   - `showingErrorAlert` (boolean): If true, displays an error alert on request failure.
+ *   - Any other properties supported by {@link BackendSrvRequest}, such as headers, credentials, etc.
+ * @returns A promise resolving to the response of type `T`.
+ */
+export function post<T>(backendSrv: BackendSrv, url: string, body: Record<string, any>, options: Partial<BackendSrvRequest> = {}) {
+  return fetch<T>(backendSrv, { method: 'POST', url, data: body, ...options });
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -308,7 +308,7 @@ async function fetch<T>(backendSrv: BackendSrv, options: BackendSrvRequest, retr
   try {
     return (await lastValueFrom(backendSrv.fetch<T>(options))).data;
   } catch (error) {
-    if (isFetchError(error) && error.status === 404 && retries < 3) {
+    if (isFetchError(error) && error.status === 429 && retries < 3) {
       await sleep(Math.random() * 1000 * 2 ** retries);
       return fetch(backendSrv, {...options, url}, retries + 1);
     }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -267,10 +267,38 @@ export async function queryUsingSkip<T>(
   };
 }
 
+/**
+ * Sends a GET request to the specified URL with the provided parameters.
+ *
+ * @template T - The expected response type.
+ * @param backendSrv - The Backend Service instance {@link BackendSrv} used to make the request.
+ * @param url - The endpoint URL to which the GET request is sent.
+ * @param params - The query parameters to be included in the request.
+ * @returns A promise resolving to the response of type `T`.
+ */
+export function get<T>(backendSrv: BackendSrv, url: string, params?: Record<string, any>) {
+  return fetch<T>(backendSrv, { method: 'GET', url, params });
+}
+
+/**
+ * Sends a POST request to the specified URL with the provided request body and options.
+ *
+ * @template T - The expected response type.
+ * @param backendSrv - The Backend Service instance {@link BackendSrv} used to make the request.
+ * @param url - The endpoint URL to which the POST request is sent.
+ * @param body - The request payload as a key-value map.
+ * @param options - Optional configuration for the request. This can include:
+ *   - `showingErrorAlert` (boolean): If true, displays an error alert on request failure.
+ *   - Any other properties supported by {@link BackendSrvRequest}, such as headers, credentials, etc.
+ * @returns A promise resolving to the response of type `T`.
+ */
+export function post<T>(backendSrv: BackendSrv, url: string, body: Record<string, any>, options: Partial<BackendSrvRequest> = {}) {
+  return fetch<T>(backendSrv, { method: 'POST', url, data: body, ...options });
+}
+
 async function delay(timeout: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, timeout));
 }
-
 
 async function fetch<T>(backendSrv: BackendSrv, options: BackendSrvRequest, retries = 0): Promise<T> {
   // URL is stored and reused for each retry to ensure consistency
@@ -298,24 +326,4 @@ async function fetch<T>(backendSrv: BackendSrv, options: BackendSrvRequest, retr
     }
     throw error;
   }
-}
-
-export function get<T>(backendSrv: BackendSrv, url: string, params?: Record<string, any>) {
-  return fetch<T>(backendSrv, { method: 'GET', url, params });
-}
-
-
-/**
- * Sends a POST request to the specified URL with the provided request body and options.
- *
- * @template T - The expected response type.
- * @param url - The endpoint URL to which the POST request is sent.
- * @param body - The request payload as a key-value map.
- * @param options - Optional configuration for the request. This can include:
- *   - `showingErrorAlert` (boolean): If true, displays an error alert on request failure.
- *   - Any other properties supported by {@link BackendSrvRequest}, such as headers, credentials, etc.
- * @returns A promise resolving to the response of type `T`.
- */
-export function post<T>(backendSrv: BackendSrv, url: string, body: Record<string, any>, options: Partial<BackendSrvRequest> = {}) {
-  return fetch<T>(backendSrv, { method: 'POST', url, data: body, ...options });
 }

--- a/src/shared/product.utils.ts
+++ b/src/shared/product.utils.ts
@@ -1,7 +1,7 @@
 import { DataSourceInstanceSettings } from "@grafana/data";
 import { BackendSrv } from "@grafana/runtime";
 import { QueryResponse } from "core/types";
-import { queryUntilComplete } from "core/utils";
+import { post, queryUntilComplete } from "core/utils";
 import { QUERY_PRODUCTS_MAX_TAKE, QUERY_PRODUCTS_REQUEST_PER_SECOND } from "./constants/QueryProducts.constants";
 import { Properties, QueryProductResponse } from "datasources/products/types";
 import { ProductPartNumberAndName } from "./types/QueryProducts.types";
@@ -59,7 +59,8 @@ export class ProductUtils {
         returnCount = true
     ): Promise<QueryProductResponse> {
         try {
-        const response = await this.backendSrv.post<QueryProductResponse>(
+        const response = await post<QueryProductResponse>(
+            this.backendSrv,
             this.queryProductsUrl,
             {
                 descending,

--- a/src/shared/system.utils.ts
+++ b/src/shared/system.utils.ts
@@ -2,7 +2,7 @@ import { DataSourceInstanceSettings } from "@grafana/data";
 import { BackendSrv } from "@grafana/runtime";
 import { QUERY_SYSTEMS_ALIAS_PROJECTION, QUERY_SYSTEMS_MAX_TAKE, QUERY_SYSTEMS_REQUEST_PER_SECOND } from "./constants/QuerySystems.constants";
 import { QueryResponse, QuerySystemsResponse } from "core/types";
-import { queryUsingSkip } from "core/utils";
+import { post, queryUsingSkip } from "core/utils";
 import { SystemAlias } from "./types/QuerySystems.types";
 
 export class SystemUtils {
@@ -54,7 +54,8 @@ export class SystemUtils {
         skip?: number
     ): Promise<QuerySystemsResponse> {
         try {
-            const response = await this.backendSrv.post<QuerySystemsResponse>(
+            const response = await post<QuerySystemsResponse>(
+                this.backendSrv,
                 this.querySystemsUrl,
                 {
                     projection: QUERY_SYSTEMS_ALIAS_PROJECTION,

--- a/src/shared/users.utils.ts
+++ b/src/shared/users.utils.ts
@@ -1,6 +1,6 @@
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { BackendSrv } from '@grafana/runtime';
-import { queryUntilComplete } from 'core/utils';
+import { post, queryUntilComplete } from 'core/utils';
 import { QueryResponse } from 'core/types';
 import { User, QueryUsersRequest, QueryUsersResponse } from './types/QueryUsers.types';
 import { QUERY_USERS_MAX_TAKE, QUERY_USERS_REQUEST_PER_SECOND } from './constants/Users.constants';
@@ -100,7 +100,8 @@ export class UsersUtils {
    * @returns A promise that resolves to the user query response.
    */
   private queryUsers(body: QueryUsersRequest): Promise<QueryUsersResponse> {
-    return this.backendSrv.post<QueryUsersResponse>(
+    return post<QueryUsersResponse>(
+      this.backendSrv,
       `${this.instanceSettings.url}/niuser/v1/users/query`,
       body,
       { showErrorAlert: false } // suppress default error alert since we handle errors manually

--- a/src/shared/workspace.utils.test.ts
+++ b/src/shared/workspace.utils.test.ts
@@ -2,16 +2,22 @@ import { DataSourceInstanceSettings } from '@grafana/data';
 import { BackendSrv } from '@grafana/runtime';
 import { Workspace } from 'core/types';
 import { WorkspaceUtils } from './workspace.utils';
+const get = require('core/utils').get;
+
+const mockWorkspaces: Workspace[] = [
+    { id: '1', name: 'Workspace 1', default: true, enabled: true },
+    { id: '2', name: 'Workspace 2', default: false, enabled: true }
+];
+jest.mock('core/utils', () => ({
+  get: jest.fn(() => {
+    return Promise.resolve({ workspaces: mockWorkspaces });
+  }),
+}));
 
 describe('WorkspaceUtils', () => {
     let instanceSettings: DataSourceInstanceSettings;
     let backendSrv: BackendSrv;
     let workspaceUtils: WorkspaceUtils;
-
-    const mockWorkspaces: Workspace[] = [
-        { id: '1', name: 'Workspace 1', default: true, enabled: true },
-        { id: '2', name: 'Workspace 2', default: false, enabled: true }
-    ];
 
     beforeEach(() => {
         instanceSettings = { url: 'http://localhost' } as DataSourceInstanceSettings;
@@ -29,7 +35,7 @@ describe('WorkspaceUtils', () => {
     it('should load workspaces and cache them', async () => {
         const result = await workspaceUtils.getWorkspaces();
 
-        expect(backendSrv.get).toHaveBeenCalledWith(`${instanceSettings.url}/niauth/v1/auth`, undefined, undefined, { showErrorAlert: false });
+        expect(get).toHaveBeenCalledWith(backendSrv, `${instanceSettings.url}/niauth/v1/auth`, { showErrorAlert: false });
         expect(result.size).toBe(2);
         expect(result.get('1')).toEqual(mockWorkspaces[0]);
         expect(result.get('2')).toEqual(mockWorkspaces[1]);
@@ -41,7 +47,7 @@ describe('WorkspaceUtils', () => {
 
         const result = await workspaceUtils.getWorkspaces();
 
-        expect(backendSrv.get).not.toHaveBeenCalled();
+        expect(get).not.toHaveBeenCalled();
         expect(result.size).toBe(2);
         expect(result.get('1')).toEqual(mockWorkspaces[0]);
         expect(result.get('2')).toEqual(mockWorkspaces[1]);
@@ -50,7 +56,7 @@ describe('WorkspaceUtils', () => {
     it('should propagate error when loading workspaces fails', async () => {
         (WorkspaceUtils as any)._workspacesCache = undefined;
         const error = new Error('Failed to fetch workspaces');
-        (backendSrv.get as jest.Mock).mockRejectedValueOnce(error);
+        (get as jest.Mock).mockRejectedValueOnce(error);
 
         await expect(workspaceUtils.getWorkspaces()).rejects.toThrow('Failed to fetch workspaces');
     });

--- a/src/shared/workspace.utils.ts
+++ b/src/shared/workspace.utils.ts
@@ -1,6 +1,7 @@
 import { DataSourceInstanceSettings } from "@grafana/data";
 import { BackendSrv } from "@grafana/runtime";
 import { Workspace } from "core/types";
+import { get } from "core/utils";
 
 export class WorkspaceUtils {
     private static _workspacesCache?: Promise<Map<string, Workspace>>;
@@ -29,10 +30,9 @@ export class WorkspaceUtils {
     }
 
     private async fetchWorkspaces(): Promise<Workspace[]> {
-        const response = await this.backendSrv.get<{ workspaces: Workspace[] }>(
+        const response = await get<{ workspaces: Workspace[] }>(
+            this.backendSrv,
             this.queryWorkspacesUrl,
-            undefined,
-            undefined,
             { showErrorAlert: false } // suppress default error alert since we handle errors manually
         );
         return response.workspaces;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
[Bug 3211809](https://dev.azure.com/ni/DevCentral/_workitems/edit/3211809): Intermittency in the Work Orders and Test Plans data source tests

The `fetch` method is only available on `DataSourceBase` file and cannot be accessed in shared classes. This `fetch` method has error handling and retry logic. This PR holds changes to use common logic for get and post calls, so retry will happen for all APIs

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->

## 👩‍💻 Implementation
- Moved `fetch` from `DataSourceBase` to `utils`
- Utilize the `fetch` method in all shared utility classes

<!---
Describe how the change addresses the problem. Consider factors such as complexity, alternative solutions, performance impact, etc.

Consider listing files with important changes or comment on them directly in the pull request.
-->

## 🧪 Testing

- Added unit tests and updated existing tests
<!---
Detail the testing done to ensure this submission meets requirements.

Include automated test additions or modifications, manual testing done on a local build, and additional testing not covered by automatic pull request validation.
-->

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).