### PR TITLE
fix(asset): Update the request body and include projection in Query Assets Variable

### DIFF
--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -23,7 +23,7 @@ import { AssetSummaryDataSource } from './data-sources/asset-summary/AssetSummar
 import { AssetModel, AssetsResponse } from 'datasources/asset-common/types';
 import { transformComputedFieldsQuery } from 'core/query-builder.utils';
 import { AssetVariableQuery } from './types/AssetVariableQuery.types';
-import { defaultListAssetsVariable } from './defaults';
+import { defaultListAssetsVariable, defaultProjectionForListAssetsVariable } from './defaults';
 import { TAKE_LIMIT } from './constants/ListAssets.constants';
 
 export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceOptions> {
@@ -111,7 +111,7 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
       this.listAssetsDataSource.assetComputedDataFields,
       this.listAssetsDataSource.queryTransformationOptions
     );
-    const assetsResponse: AssetsResponse = await this.listAssetsDataSource.queryAssets(assetFilter, listAssetsTake);
+    const assetsResponse: AssetsResponse = await this.listAssetsDataSource.queryAssets(assetFilter, listAssetsTake, false, defaultProjectionForListAssetsVariable);
     return assetsResponse.assets.map((asset) => this.getAssetNameForMetricQuery(asset));
   }
 
@@ -122,7 +122,7 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
     let assetValue: string;
 
     const assetName = !asset.name ? `${serial}` : `${asset.name} (${serial})`;
-    
+
     if (this.assetQueryReturnType === AssetQueryReturnType.AssetId) {
       assetValue = asset.id;
     } else {

--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
@@ -109,8 +109,8 @@ export class ListAssetsDataSource extends AssetDataSourceBase {
   }
 
   async queryAssets(filter = '', take = -1, returnCount = false, projectionFields?: string[]): Promise<AssetsResponse> {
-    const formattedProjection = `new(${projectionFields})`;
-    let data: QueryListAssetRequestBody = { filter, take, returnCount, formattedProjection };
+    const projection = `new(${projectionFields})`;
+    let data: QueryListAssetRequestBody = { filter, take, returnCount, projection };
     try {
       const response = await this.post<AssetsResponse>(this.baseUrl + '/query-assets', data);
       return response;

--- a/src/datasources/asset/defaults.ts
+++ b/src/datasources/asset/defaults.ts
@@ -23,6 +23,8 @@ export const defaultListAssetsQueryForOldPannels = {
     properties: Object.values(AssetFilterPropertiesOption),
 }
 
+export const defaultProjectionForListAssetsVariable = [AssetFilterPropertiesOption.VendorName, AssetFilterPropertiesOption.VendorNumber, AssetFilterPropertiesOption.ModelName, AssetFilterPropertiesOption.ModelNumber, AssetFilterPropertiesOption.SerialNumber, AssetFilterPropertiesOption.AssetIdentifier]
+
 export const defaultListAssetsVariable = {
     filter: "",
     take: QUERY_LIMIT,

--- a/src/datasources/asset/types/ListAssets.types.ts
+++ b/src/datasources/asset/types/ListAssets.types.ts
@@ -12,7 +12,7 @@ export interface QueryListAssetRequestBody {
     filter?: string;
     returnCount?: boolean;
     take?: number;
-    formattedProjection?: string;
+    projection?: string;
 }
 
 export enum AssetFilterPropertiesOption {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR changes the request's body "formattedProjection" element to "projection" and it also updates the Query Asset Variable request body to contain the projection field with a default list of properties.

## 👩‍💻 Implementation

- in ListAssetsDatasource.ts: changed the request's body "formattedProjection" element to "projection" in queryAssets function
- in ListAssets.types.ts: updated QueryListAssetRequestBody interface to contain "projection" instead of "formattedProjection"
- in defaults.ts: added "defaultProjectionForListAssetsVariable" that contains all the necessary properties for Query Asset Variable
- in AssetDataSource.ts: updated metricFindQuery to call "queryAssets" function with projection set to "defaultProjectionForListAssetsVariable"

## 🧪 Testing

Manual testing:
- Verify that:
 1. valid values trigger the query and limit the results accordingly
 2. checked the console response for different take values
 3. checked the projection field in the console response when different properties were selected
 
<img width="947" height="1208" alt="image" src="https://github.com/user-attachments/assets/87abcb07-a612-4837-8268-ecdf97b98850" />

<img width="1423" height="1182" alt="image" src="https://github.com/user-attachments/assets/207c1a99-1b12-401e-b474-d65bbf46cd5f" />


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).