### PR TITLE
perf(asset): Update processTotalCountAssetsQuery so only one asset with one property is returned

### DIFF
--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.test.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.test.ts
@@ -178,7 +178,7 @@ describe('shouldRunQuery', () => {
 
         await datastore.query(query);
 
-        expect(queryAssetSpy).toHaveBeenCalledWith('', 1000, true, ["AssetIdentifier"]);
+        expect(queryAssetSpy).toHaveBeenCalledWith('', 1, true, ["AssetIdentifier"]);
     })
 
     test('should call queryAsset with returnCount set to false when outpuType is set to Properties', async () => {

--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.test.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.test.ts
@@ -12,6 +12,7 @@ import { MockProxy } from "jest-mock-extended";
 import { BackendSrv } from "@grafana/runtime";
 import { Field } from "@grafana/data";
 import { AssetsResponse } from "datasources/asset-common/types";
+import { QUERY_LIMIT } from "datasources/asset/constants/constants";
 
 let datastore: ListAssetsDataSource, backendServer: MockProxy<BackendSrv>;
 const mockListAssets = {
@@ -178,7 +179,7 @@ describe('shouldRunQuery', () => {
 
         await datastore.query(query);
 
-        expect(queryAssetSpy).toHaveBeenCalledWith('', 1, true, ["AssetIdentifier"]);
+        expect(queryAssetSpy).toHaveBeenCalledWith('', 1, true, [AssetFilterPropertiesOption.AssetIdentifier]);
     })
 
     test('should call queryAsset with returnCount set to false when outpuType is set to Properties', async () => {
@@ -193,7 +194,7 @@ describe('shouldRunQuery', () => {
 
         await datastore.query(query);
 
-        expect(queryAssetSpy).toHaveBeenCalledWith('', 1000, false, ["AssetIdentifier"]);
+        expect(queryAssetSpy).toHaveBeenCalledWith('', QUERY_LIMIT, false, ["AssetIdentifier"]);
     })
 
     test('should match snapshot for TotalCount outputType', async () => {
@@ -350,7 +351,7 @@ describe('shouldRunQuery', () => {
 
         await datastore.query(query);
 
-        expect(queryAssetSpy).toHaveBeenCalledWith('', 1000, false, Object.values(AssetFilterPropertiesOption));
+        expect(queryAssetSpy).toHaveBeenCalledWith('', QUERY_LIMIT, false, Object.values(AssetFilterPropertiesOption));
     })
 
     test('should convert properties to Grafana fields', async () => {

--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
@@ -5,7 +5,6 @@ import { AssetDataSourceOptions, AssetQuery, AssetQueryType } from '../../types/
 import { AssetFilterProperties, AssetFilterPropertiesOption, ListAssetsQuery, OutputType, QueryListAssetRequestBody } from '../../types/ListAssets.types';
 import { AssetModel, AssetsResponse } from '../../../asset-common/types';
 import { transformComputedFieldsQuery } from '../../../../core/query-builder.utils';
-import { QUERY_LIMIT } from 'datasources/asset/constants/constants';
 import { defaultListAssetsQuery, defaultListAssetsQueryForOldPannels } from 'datasources/asset/defaults';
 import { TAKE_LIMIT } from 'datasources/asset/constants/ListAssets.constants';
 import { getWorkspaceName } from 'core/utils';

--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
@@ -103,7 +103,7 @@ export class ListAssetsDataSource extends AssetDataSourceBase {
   }
 
   async processTotalCountAssetsQuery(query: ListAssetsQuery) {
-    const response: AssetsResponse = await this.queryAssets(query.filter, QUERY_LIMIT, true, query.properties);
+    const response: AssetsResponse = await this.queryAssets(query.filter, 1, true, [AssetFilterPropertiesOption.AssetIdentifier]);
     const result: DataFrameDTO = { refId: query.refId, fields: [{ name: "Total count", values: [response.totalCount] }] };
     return result;
   }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR changes the variables with which we are calling queryAssets function, so only one asset with one property is returned and also the total count of assets returned.

## 👩‍💻 Implementation

In ListAssetsDataSource.ts I've updated processTotalCountAssetsQuery so:
- "response" variable contains a list of assets with only one asset with the id property selected and also the total count of assets returned
- changed "await this.queryAssets(query.filter, QUERY_LIMIT, true, query.properties)" into "await this.queryAssets(query.filter, 1, true, [AssetFilterPropertiesOption.AssetIdentifier])"
- updated "should call queryAsset with returnCount set to true when outpuType is set to TotalCount" test to call the function with take field set to 1 instead of 1000

## 🧪 Testing

Manual testing:
- Verify that:
 1. when Total Count is selected the number of assets is displayed
 2. checked the console response when Total Count is selected to display the right result

<img width="1852" height="985" alt="image" src="https://github.com/user-attachments/assets/bf9b39da-c370-496b-9064-3decbacdcf2d" />

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).