### PR TITLE
refactor(asset): Rename AssetIdentification to AssetTagPath

### DIFF
--- a/src/datasources/asset/AssetDataSource.test.ts
+++ b/src/datasources/asset/AssetDataSource.test.ts
@@ -367,9 +367,9 @@ describe('queries', () => {
   })
 
   describe('queryReturnType', () => {
-    it('should return default QueryReturnType.AssetId', () => {
+    it('should return default QueryReturnType.AssetTagPath', () => {
       const returnType = ds.getQueryReturnType();
-      expect(returnType).toBe(AssetQueryReturnType.AssetIdentification);
+      expect(returnType).toBe(AssetQueryReturnType.AssetTagPath);
     });
 
     it('should set and get QueryReturnType correctly', () => {

--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -30,7 +30,7 @@ export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceO
   private assetSummaryDataSource: AssetSummaryDataSource;
   private calibrationForecastDataSource: CalibrationForecastDataSource;
   private listAssetsDataSource: ListAssetsDataSource;
-  private assetQueryReturnType: AssetQueryReturnType = AssetQueryReturnType.AssetIdentification;
+  private assetQueryReturnType: AssetQueryReturnType = AssetQueryReturnType.AssetTagPath;
 
   constructor(
     readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,

--- a/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.test.tsx
+++ b/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.test.tsx
@@ -70,7 +70,7 @@ it('renders the return type selector', async () => {
     render({  refId: '', type: AssetQueryType.ListAssets, filter: "" } as AssetVariableQuery);
 
     await waitFor(() => expect(screen.getByText('Return Type')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText(AssetQueryReturnType.AssetIdentification)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(AssetQueryReturnType.AssetTagPath)).toBeInTheDocument());
 });
 
 it('should render take', async () => {
@@ -155,7 +155,7 @@ it('should call onChange when return type is changed', async () => {
     await waitFor(async () =>{
         const renderType = screen.getAllByRole('combobox')[0];
 
-        expect(screen.getAllByText(AssetQueryReturnType.AssetIdentification).length).toBe(1);
+        expect(screen.getAllByText(AssetQueryReturnType.AssetTagPath).length).toBe(1);
         await select(renderType, AssetQueryReturnType.AssetId, {
             container: document.body
         });

--- a/src/datasources/asset/types/types.ts
+++ b/src/datasources/asset/types/types.ts
@@ -30,7 +30,7 @@ export const AssetFeatureTogglesDefaults: AssetFeatureToggles = {
 }
 
 export enum AssetQueryReturnType {
-  AssetIdentification = 'Asset Identification',
+  AssetTagPath = 'Asset Tag Path',
   AssetId = 'Asset Id'
 }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

#3250098
Asset Identification and Asset Id mean the same thing to most users.


## 👩‍💻 Implementation

Renamed Asset Identification to Asset Tag Path.

## 🧪 Testing

![AssetQueryReturnTypeRename](https://github.com/user-attachments/assets/eabc2af8-a0f1-4db3-ae6d-47fc73aebbaf)


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).