### PR TITLE
fix(asset): Update projection for ListAssetsDataSource

### DIFF
--- a/src/datasources/asset/types/ListAssets.types.ts
+++ b/src/datasources/asset/types/ListAssets.types.ts
@@ -34,7 +34,7 @@ export enum AssetFilterPropertiesOption {
     Properties = 'Properties',
     Location = 'Location',
     MinionId = 'Location.MinionId',
-    ParentName = 'ParentName',
+    ParentName = 'Location.Parent',
     SupportsSelfCalibration = 'SupportsSelfCalibration',
     DiscoveryType = 'DiscoveryType',
     SupportsSelfTest = 'SupportsSelfTest',


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR adds the valid ParentName to "projection".

## 👩‍💻 Implementation

in ListAssets.types.ts: changed " ParentName = 'ParentName' " into " ParentName = 'Location.Parent' " 

## 🧪 Testing

Manual testing:

- Verify that in the query-assets projection, "Location.Parent" appears instead of "ParentName" in the console's payload.

<img width="2554" height="1170" alt="image" src="https://github.com/user-attachments/assets/2919bb5a-6d72-4de0-85bb-739cb9014331" />

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).