### PR TITLE
feat(alarms): Add alarms query builder

### DIFF
--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
@@ -1,0 +1,72 @@
+import React, { ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { AlarmsQueryBuilder } from './AlarmsQueryBuilder';
+import { QueryBuilderOption } from 'core/types';
+
+describe('AlarmsQueryBuilder', () => {
+  let reactNode: ReactNode;
+  const containerClass = 'smart-filter-group-condition-container';
+
+  function renderElement(filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
+    reactNode = React.createElement(AlarmsQueryBuilder, { filter, globalVariableOptions, onChange: jest.fn() });
+    const renderResult = render(reactNode);
+    return {
+      renderResult,
+      conditionsContainer: renderResult.container.getElementsByClassName(`${containerClass}`),
+    };
+  }
+
+  it('should render empty query builder', () => {
+    const { renderResult, conditionsContainer } = renderElement('');
+
+    expect(conditionsContainer.length).toBe(1);
+    expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
+  });
+
+  [['true', 'True'], ['false', 'False']].forEach(([value, label]) => {
+
+    it(`should select ${label} for acknowledged in query builder`, () => {
+        const { conditionsContainer } = renderElement(`acknowledged = \"${value}\"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+    it(`should select ${label} for active in query builder`, () => {
+        const { conditionsContainer } = renderElement(`active = \"${value}\"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+
+    it(`should select ${label} for clear in query builder`, () => {
+        const { conditionsContainer } = renderElement(`clear = \"${value}\"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+  });
+
+  [[-1, 'Clear'], [1, 'Low (1)'], [2, 'Moderate (2)'], [3, 'High (3)'], [4, 'Critical (4)']].forEach(([value, label]) => {
+    it(`should select ${label} for current severity in query builder`, () => {
+        const { conditionsContainer } = renderElement(`currentSeverityLevel = "${value}"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+
+    it(`should select ${label} for highest severity in query builder`, () => {
+        const { conditionsContainer } = renderElement(`highestSeverityLevel = "${value}"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+  });
+
+  it('should select global variable option', () => {
+    const globalVariableOption = { label: 'Global variable', value: '$global_variable' };
+    const { conditionsContainer } = renderElement('currentSeverityLevel = \"$global_variable\"', [globalVariableOption]);
+
+    expect(conditionsContainer?.length).toBe(1);
+    expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
+  });
+});

--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
@@ -1,0 +1,79 @@
+import { SlQueryBuilder } from 'core/components/SlQueryBuilder/SlQueryBuilder';
+import { queryBuilderMessages, QueryBuilderOperations } from 'core/query-builder.constants';
+import { expressionBuilderCallbackWithRef, expressionReaderCallbackWithRef } from 'core/query-builder.utils';
+import { QBField, QueryBuilderOption } from 'core/types';
+import { filterXSSField } from 'core/utils';
+import { AlarmsQueryBuilderStaticFields } from 'datasources/alarms/constants/AlarmsQueryBuilder.constants';
+import React, { useState, useEffect, useMemo } from 'react';
+import { QueryBuilderCustomOperation, QueryBuilderProps } from 'smart-webcomponents-react/querybuilder';
+
+type AlarmsQueryBuilderProps = QueryBuilderProps &
+  React.HTMLAttributes<Element> & {
+    filter?: string;
+    globalVariableOptions: QueryBuilderOption[];
+  };
+
+export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, onChange, globalVariableOptions }) => {
+  const [fields, setFields] = useState<QBField[]>([]);
+  const [operations, setOperations] = useState<QueryBuilderCustomOperation[]>([]);
+  const optionsRef = React.useRef<Record<string, QueryBuilderOption[]>>({});
+
+  const callbacks = useMemo(
+    () => ({
+      expressionBuilderCallback: expressionBuilderCallbackWithRef(optionsRef),
+      expressionReaderCallback: expressionReaderCallbackWithRef(optionsRef),
+    }),
+    [optionsRef]
+  );
+
+  useEffect(() => {
+    const updatedFields = AlarmsQueryBuilderStaticFields.map(field => {
+      if (field.lookup?.dataSource) {
+        return {
+          ...field,
+          lookup: {
+            dataSource: [...globalVariableOptions, ...field.lookup?.dataSource].map(filterXSSField),
+          },
+        };
+      }
+      return field;
+    });
+
+    setFields(updatedFields);
+
+    const options = Object.values(updatedFields).reduce((accumulator, fieldConfig) => {
+      if (fieldConfig.lookup) {
+        accumulator[fieldConfig.dataField!] = fieldConfig.lookup.dataSource;
+      }
+
+      return accumulator;
+    }, {} as Record<string, QueryBuilderOption[]>);
+    optionsRef.current = options;
+
+    const customOperations = [
+      QueryBuilderOperations.EQUALS,
+      QueryBuilderOperations.DOES_NOT_EQUAL,
+      QueryBuilderOperations.CONTAINS,
+      QueryBuilderOperations.DOES_NOT_CONTAIN,
+      QueryBuilderOperations.IS_BLANK,
+      QueryBuilderOperations.IS_NOT_BLANK,
+    ].map(operation => {
+      return {
+        ...operation,
+        ...callbacks,
+      };
+    });
+
+    setOperations([...customOperations]);
+  }, [globalVariableOptions, callbacks]);
+
+  return (
+    <SlQueryBuilder
+      customOperations={operations}
+      fields={fields}
+      messages={queryBuilderMessages}
+      onChange={onChange}
+      value={filter}
+    />
+  );
+};

--- a/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
+++ b/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
@@ -1,0 +1,159 @@
+import { QueryBuilderOperations } from 'core/query-builder.constants';
+import { QBField } from 'core/types';
+
+export enum AlarmsQueryBuilderFieldNames {
+  Acknowledged = 'acknowledged',
+  Active = 'active',
+  AlarmID = 'alarmId',
+  AlarmName = 'displayName',
+  Channel = 'channel',
+  Clear = 'clear',
+  CreatedBy = 'createdBy',
+  CurrentSeverity = 'currentSeverityLevel',
+  Description = 'description',
+  HighestSeverity = 'highestSeverityLevel',
+  ResourceType = 'resourceType',
+}
+
+export const AlarmsQueryBuilderFields: Record<string, QBField> = {
+  ACKNOWLEDGED: {
+    label: 'Acknowledged',
+    dataField: AlarmsQueryBuilderFieldNames.Acknowledged,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'True', value: 'true' },
+        { label: 'False', value: 'false' },
+      ],
+    },
+  },
+  ACTIVE: {
+    label: 'Active',
+    dataField: AlarmsQueryBuilderFieldNames.Active,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'True', value: 'true' },
+        { label: 'False', value: 'false' },
+      ],
+    },
+  },
+  ALARM_ID: {
+    label: 'Alarm ID',
+    dataField: AlarmsQueryBuilderFieldNames.AlarmID,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+    ],
+  },
+  ALARM_NAME: {
+    label: 'Alarm name',
+    dataField: AlarmsQueryBuilderFieldNames.AlarmName,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  CHANNEL: {
+    label: 'Channel',
+    dataField: AlarmsQueryBuilderFieldNames.Channel,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  CLEAR: {
+    label: 'Clear',
+    dataField: AlarmsQueryBuilderFieldNames.Clear,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'True', value: 'true' },
+        { label: 'False', value: 'false' },
+      ],
+    },
+  },
+  CREATED_BY: {
+    label: 'Created by',
+    dataField: AlarmsQueryBuilderFieldNames.CreatedBy,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  CURRENT_SEVERITY: {
+    label: 'Current Severity',
+    dataField: AlarmsQueryBuilderFieldNames.CurrentSeverity,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'Clear', value: '-1' },
+        { label: 'Low (1)', value: '1' },
+        { label: 'Moderate (2)', value: '2' },
+        { label: 'High (3)', value: '3' },
+        { label: 'Critical (4)', value: '4' },
+      ],
+    },
+  },
+  DESCRIPTION: {
+    label: 'Description',
+    dataField: AlarmsQueryBuilderFieldNames.Description,
+    filterOperations: [
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  HIGHEST_SEVERITY: {
+    label: 'Highest Severity',
+    dataField: AlarmsQueryBuilderFieldNames.HighestSeverity,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'Clear', value: '-1' },
+        { label: 'Low (1)', value: '1' },
+        { label: 'Moderate (2)', value: '2' },
+        { label: 'High (3)', value: '3' },
+        { label: 'Critical (4)', value: '4' },
+      ],
+    },
+  },
+  RESOURCE_TYPE: {
+    label: 'Resource type',
+    dataField: AlarmsQueryBuilderFieldNames.ResourceType,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+    ],
+  },
+};
+
+export const AlarmsQueryBuilderStaticFields = [
+  AlarmsQueryBuilderFields.ACKNOWLEDGED,
+  AlarmsQueryBuilderFields.ACTIVE,
+  AlarmsQueryBuilderFields.ALARM_ID,
+  AlarmsQueryBuilderFields.ALARM_NAME,
+  AlarmsQueryBuilderFields.CHANNEL,
+  AlarmsQueryBuilderFields.CLEAR,
+  AlarmsQueryBuilderFields.CURRENT_SEVERITY,
+  AlarmsQueryBuilderFields.DESCRIPTION,
+  AlarmsQueryBuilderFields.HIGHEST_SEVERITY,
+  AlarmsQueryBuilderFields.RESOURCE_TYPE,
+];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
[User Story 3209135](https://dev.azure.com/ni/DevCentral/_workitems/edit/3209135): FE | Add query builder
[Task 3249466](https://dev.azure.com/ni/DevCentral/_workitems/edit/3249466): Create alarms query builder with fields of type string and boolean

To add query builder for alarms

## 👩‍💻 Implementation

- Created component for alarms query builder
- Added support for String, Boolean and enum fields

## 🧪 Testing

- Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).