### PR TITLE
fix(asset): Update projection for Asset Variable Query 

### DIFF
--- a/src/datasources/asset/defaults.ts
+++ b/src/datasources/asset/defaults.ts
@@ -23,7 +23,7 @@ export const defaultListAssetsQueryForOldPannels = {
     properties: Object.values(AssetFilterPropertiesOption),
 }
 
-export const defaultProjectionForListAssetsVariable = [AssetFilterPropertiesOption.VendorName, AssetFilterPropertiesOption.VendorNumber, AssetFilterPropertiesOption.ModelName, AssetFilterPropertiesOption.ModelNumber, AssetFilterPropertiesOption.SerialNumber, AssetFilterPropertiesOption.AssetIdentifier]
+export const defaultProjectionForListAssetsVariable = [AssetFilterPropertiesOption.VendorName, AssetFilterPropertiesOption.VendorNumber, AssetFilterPropertiesOption.ModelName, AssetFilterPropertiesOption.ModelNumber, AssetFilterPropertiesOption.SerialNumber, AssetFilterPropertiesOption.AssetIdentifier, AssetFilterPropertiesOption.AssetName]
 
 export const defaultListAssetsVariable = {
     filter: "",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR updates "projection" for Asset Variable Query.

## 👩‍💻 Implementation

In defaults.ts, I've updated defaultProjectionForListAssetsVariable to contain AssetFilterPropertiesOption.AssetName.

## 🧪 Testing

Manual testing:

1. Verify that the query-assets projection contains the asset name as well, in the console's payload.
2. Verify in the result if the assets name is displayed 

<img width="1144" height="1225" alt="image" src="https://github.com/user-attachments/assets/6847f3c5-035d-4997-be7f-38395b83c9cd" />

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).