### PR TITLE
feat(alarms): support datetime filters, keywords and properties

### DIFF
--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { AlarmsQueryBuilder } from './AlarmsQueryBuilder';
 import { QueryBuilderOption } from 'core/types';
-import { BOOLEAN_OPTIONS, SEVERITY_LEVELS } from 'datasources/alarms/constants/AlarmsQueryBuilder.constants';
+import { BOOLEAN_OPTIONS, SEVERITY_LEVELS, TIME_OPTIONS } from 'datasources/alarms/constants/AlarmsQueryBuilder.constants';
 
 describe('AlarmsQueryBuilder', () => {
-  function renderElement(filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
+  function renderElement (filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
     const reactNode = React.createElement(AlarmsQueryBuilder, { filter, globalVariableOptions, onChange: jest.fn() });
     const renderResult = render(reactNode);
     const containerClass = 'smart-filter-group-condition-container';
 
     return {
       renderResult,
-      conditionsContainer: renderResult.container.getElementsByClassName(`${containerClass}`),
+      conditionsContainer: renderResult.container.getElementsByClassName(`${ containerClass }`),
     };
   }
 
@@ -24,56 +24,56 @@ describe('AlarmsQueryBuilder', () => {
   });
 
   BOOLEAN_OPTIONS.forEach(({ label, value }) => {
-    it(`should select ${label} for acknowledged in query builder`, () => {
-        const { conditionsContainer } = renderElement(`acknowledged = \"${value}\"`);
+    it(`should select ${ label } for acknowledged in query builder`, () => {
+      const { conditionsContainer } = renderElement(`acknowledged = \"${ value }\"`);
 
-        expect(conditionsContainer?.length).toBe(1);
-        const conditionText = conditionsContainer.item(0)?.textContent;
-        expect(conditionText).toContain('Acknowledged');
-        expect(conditionText).toContain('equals');
-        expect(conditionText).toContain(label);       
-    });
-    
-    it(`should select ${label} for active in query builder`, () => {
-        const { conditionsContainer } = renderElement(`active = \"${value}\"`);
-
-        expect(conditionsContainer?.length).toBe(1);
-        const conditionText = conditionsContainer.item(0)?.textContent;
-        expect(conditionText).toContain('Active');
-        expect(conditionText).toContain('equals');
-        expect(conditionText).toContain(label);
+      expect(conditionsContainer?.length).toBe(1);
+      const conditionText = conditionsContainer.item(0)?.textContent;
+      expect(conditionText).toContain('Acknowledged');
+      expect(conditionText).toContain('equals');
+      expect(conditionText).toContain(label);
     });
 
-    it(`should select ${label} for clear in query builder`, () => {
-        const { conditionsContainer } = renderElement(`clear = \"${value}\"`);
+    it(`should select ${ label } for active in query builder`, () => {
+      const { conditionsContainer } = renderElement(`active = \"${ value }\"`);
 
-        expect(conditionsContainer?.length).toBe(1);
-        const conditionText = conditionsContainer.item(0)?.textContent;
-        expect(conditionText).toContain('Clear');
-        expect(conditionText).toContain('equals');
-        expect(conditionText).toContain(label);
+      expect(conditionsContainer?.length).toBe(1);
+      const conditionText = conditionsContainer.item(0)?.textContent;
+      expect(conditionText).toContain('Active');
+      expect(conditionText).toContain('equals');
+      expect(conditionText).toContain(label);
+    });
+
+    it(`should select ${ label } for clear in query builder`, () => {
+      const { conditionsContainer } = renderElement(`clear = \"${ value }\"`);
+
+      expect(conditionsContainer?.length).toBe(1);
+      const conditionText = conditionsContainer.item(0)?.textContent;
+      expect(conditionText).toContain('Clear');
+      expect(conditionText).toContain('equals');
+      expect(conditionText).toContain(label);
     });
   });
 
-  SEVERITY_LEVELS.forEach(({label, value}) => {
-    it(`should select ${label} for current severity in query builder`, () => {
-        const { conditionsContainer } = renderElement(`currentSeverityLevel = "${value}"`);
+  SEVERITY_LEVELS.forEach(({ label, value }) => {
+    it(`should select ${ label } for current severity in query builder`, () => {
+      const { conditionsContainer } = renderElement(`currentSeverityLevel = "${ value }"`);
 
-        expect(conditionsContainer?.length).toBe(1);
-        const conditionText = conditionsContainer.item(0)?.textContent;
-        expect(conditionText).toContain('Current severity');
-        expect(conditionText).toContain('equals');
-        expect(conditionText).toContain(label);
+      expect(conditionsContainer?.length).toBe(1);
+      const conditionText = conditionsContainer.item(0)?.textContent;
+      expect(conditionText).toContain('Current severity');
+      expect(conditionText).toContain('equals');
+      expect(conditionText).toContain(label);
     });
 
-    it(`should select ${label} for highest severity in query builder`, () => {
-        const { conditionsContainer } = renderElement(`highestSeverityLevel = "${value}"`);
+    it(`should select ${ label } for highest severity in query builder`, () => {
+      const { conditionsContainer } = renderElement(`highestSeverityLevel = "${ value }"`);
 
-        expect(conditionsContainer?.length).toBe(1);
-        const conditionText = conditionsContainer.item(0)?.textContent;
-        expect(conditionText).toContain('Highest severity');
-        expect(conditionText).toContain('equals');
-        expect(conditionText).toContain(label);
+      expect(conditionsContainer?.length).toBe(1);
+      const conditionText = conditionsContainer.item(0)?.textContent;
+      expect(conditionText).toContain('Highest severity');
+      expect(conditionText).toContain('equals');
+      expect(conditionText).toContain(label);
     });
   });
 
@@ -137,8 +137,8 @@ describe('AlarmsQueryBuilder', () => {
     expect(conditionText).toContain('Tag');
   });
 
-    [[ '${__from:date}', 'From' ],[ '${__to:date}', 'To' ],[ '${__now:date}', 'Now' ]].forEach(([ value, label ]) => {
-    it(`should select ${label} for acknowledged on`, () => {
+  TIME_OPTIONS.forEach(({ label, value }) => {
+    it(`should select ${ label } for acknowledged on`, () => {
       const { conditionsContainer } = renderElement(`acknowledgedAt > \"${ value }\"`, []);
 
       expect(conditionsContainer?.length).toBe(1);
@@ -147,7 +147,7 @@ describe('AlarmsQueryBuilder', () => {
       expect(conditionsContainer.item(0)?.textContent).toContain(label);
     });
 
-    it(`should select ${label} for first occurrence`, () => {
+    it(`should select ${ label } for first occurrence`, () => {
       const { conditionsContainer } = renderElement(`occurredAt > \"${ value }\"`, []);
 
       expect(conditionsContainer?.length).toBe(1);
@@ -179,7 +179,7 @@ describe('AlarmsQueryBuilder', () => {
 
   it('should select global variable option', () => {
     const globalVariableOption = { label: 'Global variable', value: '$global_variable' };
-    const { conditionsContainer } = renderElement('currentSeverityLevel = \"$global_variable\"', [globalVariableOption]);
+    const { conditionsContainer } = renderElement('currentSeverityLevel = \"$global_variable\"', [ globalVariableOption ]);
 
     expect(conditionsContainer?.length).toBe(1);
     const conditionText = conditionsContainer.item(0)?.textContent;

--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
@@ -1,0 +1,72 @@
+import React, { ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { AlarmsQueryBuilder } from './AlarmsQueryBuilder';
+import { QueryBuilderOption } from 'core/types';
+
+describe('AlarmsQueryBuilder', () => {
+  let reactNode: ReactNode;
+  const containerClass = 'smart-filter-group-condition-container';
+
+  function renderElement(filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
+    reactNode = React.createElement(AlarmsQueryBuilder, { filter, globalVariableOptions, onChange: jest.fn() });
+    const renderResult = render(reactNode);
+    return {
+      renderResult,
+      conditionsContainer: renderResult.container.getElementsByClassName(`${containerClass}`),
+    };
+  }
+
+  it('should render empty query builder', () => {
+    const { renderResult, conditionsContainer } = renderElement('');
+
+    expect(conditionsContainer.length).toBe(1);
+    expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
+  });
+
+  [['true', 'True'], ['false', 'False']].forEach(([value, label]) => {
+
+    it(`should select ${label} for acknowledged in query builder`, () => {
+        const { conditionsContainer } = renderElement(`acknowledged = \"${value}\"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+    it(`should select ${label} for active in query builder`, () => {
+        const { conditionsContainer } = renderElement(`active = \"${value}\"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+
+    it(`should select ${label} for clear in query builder`, () => {
+        const { conditionsContainer } = renderElement(`clear = \"${value}\"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+  });
+
+  [[-1, 'Clear'], [1, 'Low (1)'], [2, 'Moderate (2)'], [3, 'High (3)'], [4, 'Critical (4)']].forEach(([value, label]) => {
+    it(`should select ${label} for current severity in query builder`, () => {
+        const { conditionsContainer } = renderElement(`currentSeverityLevel = "${value}"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+
+    it(`should select ${label} for highest severity in query builder`, () => {
+        const { conditionsContainer } = renderElement(`highestSeverityLevel = "${value}"`);
+
+        expect(conditionsContainer?.length).toBe(1);
+        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+  });
+
+  it('should select global variable option', () => {
+    const globalVariableOption = { label: 'Global variable', value: '$global_variable' };
+    const { conditionsContainer } = renderElement('currentSeverityLevel = \"$global_variable\"', [globalVariableOption]);
+
+    expect(conditionsContainer?.length).toBe(1);
+    expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
+  });
+});

--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
@@ -32,7 +32,7 @@ describe('AlarmsQueryBuilder', () => {
         expect(conditionText).toContain('equals');
         expect(conditionText).toContain(label);       
     });
-    
+
     it(`should select ${label} for active in query builder`, () => {
         const { conditionsContainer } = renderElement(`active = \"${value}\"`);
 
@@ -74,6 +74,46 @@ describe('AlarmsQueryBuilder', () => {
         expect(conditionText).toContain('equals');
         expect(conditionText).toContain(label);
     });
+  });
+
+  [[ '${__from:date}', 'From' ],[ '${__to:date}', 'To' ],[ '${__now:date}', 'Now' ]].forEach(([ value, label ]) => {
+    it(`should select ${label} for acknowledged on`, () => {
+      const { conditionsContainer } = renderElement(`acknowledgedAt > \"${ value }\"`, []);
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain('Acknowledged on');
+      expect(conditionsContainer.item(0)?.textContent).toContain('is after');
+      expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+
+    it(`should select ${label} for first occurrence`, () => {
+      const { conditionsContainer } = renderElement(`occurredAt > \"${ value }\"`, []);
+
+      expect(conditionsContainer?.length).toBe(1);
+      expect(conditionsContainer.item(0)?.textContent).toContain('First occurrence');
+      expect(conditionsContainer.item(0)?.textContent).toContain('is after');
+      expect(conditionsContainer.item(0)?.textContent).toContain(label);
+    });
+  });
+  
+  it('should select keywords in query builder', () => {
+    const { conditionsContainer } = renderElement('keywords.Contains(\"test\")');
+
+    expect(conditionsContainer?.length).toBe(1);
+    const conditionText = conditionsContainer.item(0)?.textContent;
+    expect(conditionText).toContain('Keyword');
+    expect(conditionText).toContain('equals');
+    expect(conditionText).toContain('test');
+  });
+
+  it('should select key and value for properties', () => {
+    const { conditionsContainer } = renderElement("properties[\"key\"] = \"value\"");
+
+    expect(conditionsContainer?.length).toBe(1);
+    expect(conditionsContainer.item(0)?.textContent).toContain('Properties');
+    expect(conditionsContainer.item(0)?.textContent).toContain('matches');
+    expect(conditionsContainer.item(0)?.textContent).toContain('key');
+    expect(conditionsContainer.item(0)?.textContent).toContain('value');
   });
 
   it('should select global variable option', () => {

--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
@@ -1,15 +1,14 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import { AlarmsQueryBuilder } from './AlarmsQueryBuilder';
 import { QueryBuilderOption } from 'core/types';
 
 describe('AlarmsQueryBuilder', () => {
-  let reactNode: ReactNode;
-  const containerClass = 'smart-filter-group-condition-container';
-
   function renderElement(filter: string, globalVariableOptions: QueryBuilderOption[] = []) {
-    reactNode = React.createElement(AlarmsQueryBuilder, { filter, globalVariableOptions, onChange: jest.fn() });
+    const reactNode = React.createElement(AlarmsQueryBuilder, { filter, globalVariableOptions, onChange: jest.fn() });
     const renderResult = render(reactNode);
+    const containerClass = 'smart-filter-group-condition-container';
+
     return {
       renderResult,
       conditionsContainer: renderResult.container.getElementsByClassName(`${containerClass}`),
@@ -20,7 +19,7 @@ describe('AlarmsQueryBuilder', () => {
     const { renderResult, conditionsContainer } = renderElement('');
 
     expect(conditionsContainer.length).toBe(1);
-    expect(renderResult.findByLabelText('Empty condition row')).toBeTruthy();
+    expect(renderResult.getByLabelText('Empty condition row')).toBeTruthy();
   });
 
   [['true', 'True'], ['false', 'False']].forEach(([value, label]) => {
@@ -29,36 +28,51 @@ describe('AlarmsQueryBuilder', () => {
         const { conditionsContainer } = renderElement(`acknowledged = \"${value}\"`);
 
         expect(conditionsContainer?.length).toBe(1);
-        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        const conditionText = conditionsContainer.item(0)?.textContent;
+        expect(conditionText).toContain('Acknowledged');
+        expect(conditionText).toContain('equals');
+        expect(conditionText).toContain(label);       
     });
     it(`should select ${label} for active in query builder`, () => {
         const { conditionsContainer } = renderElement(`active = \"${value}\"`);
 
         expect(conditionsContainer?.length).toBe(1);
-        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        const conditionText = conditionsContainer.item(0)?.textContent;
+        expect(conditionText).toContain('Active');
+        expect(conditionText).toContain('equals');
+        expect(conditionText).toContain(label);
     });
 
     it(`should select ${label} for clear in query builder`, () => {
         const { conditionsContainer } = renderElement(`clear = \"${value}\"`);
 
         expect(conditionsContainer?.length).toBe(1);
-        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        const conditionText = conditionsContainer.item(0)?.textContent;
+        expect(conditionText).toContain('Clear');
+        expect(conditionText).toContain('equals');
+        expect(conditionText).toContain(label);
     });
   });
 
-  [[-1, 'Clear'], [1, 'Low (1)'], [2, 'Moderate (2)'], [3, 'High (3)'], [4, 'Critical (4)']].forEach(([value, label]) => {
+  [[1, 'Low'], [2, 'Moderate'], [3, 'High'], [4, 'Critical'], [-1, 'Clear']].forEach(([value, label]) => {
     it(`should select ${label} for current severity in query builder`, () => {
         const { conditionsContainer } = renderElement(`currentSeverityLevel = "${value}"`);
 
         expect(conditionsContainer?.length).toBe(1);
-        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        const conditionText = conditionsContainer.item(0)?.textContent;
+        expect(conditionText).toContain('Current severity');
+        expect(conditionText).toContain('equals');
+        expect(conditionText).toContain(label);
     });
 
     it(`should select ${label} for highest severity in query builder`, () => {
         const { conditionsContainer } = renderElement(`highestSeverityLevel = "${value}"`);
 
         expect(conditionsContainer?.length).toBe(1);
-        expect(conditionsContainer.item(0)?.textContent).toContain(label);
+        const conditionText = conditionsContainer.item(0)?.textContent;
+        expect(conditionText).toContain('Highest severity');
+        expect(conditionText).toContain('equals');
+        expect(conditionText).toContain(label);
     });
   });
 
@@ -67,6 +81,9 @@ describe('AlarmsQueryBuilder', () => {
     const { conditionsContainer } = renderElement('currentSeverityLevel = \"$global_variable\"', [globalVariableOption]);
 
     expect(conditionsContainer?.length).toBe(1);
-    expect(conditionsContainer.item(0)?.textContent).toContain(globalVariableOption.label);
+    const conditionText = conditionsContainer.item(0)?.textContent;
+    expect(conditionText).toContain('Current severity');
+    expect(conditionText).toContain('equals');
+    expect(conditionText).toContain(globalVariableOption.label);
   });
 });

--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.test.tsx
@@ -23,7 +23,6 @@ describe('AlarmsQueryBuilder', () => {
   });
 
   [['true', 'True'], ['false', 'False']].forEach(([value, label]) => {
-
     it(`should select ${label} for acknowledged in query builder`, () => {
         const { conditionsContainer } = renderElement(`acknowledged = \"${value}\"`);
 
@@ -33,6 +32,7 @@ describe('AlarmsQueryBuilder', () => {
         expect(conditionText).toContain('equals');
         expect(conditionText).toContain(label);       
     });
+    
     it(`should select ${label} for active in query builder`, () => {
         const { conditionsContainer } = renderElement(`active = \"${value}\"`);
 

--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
@@ -3,7 +3,7 @@ import { queryBuilderMessages, QueryBuilderOperations } from 'core/query-builder
 import { expressionBuilderCallbackWithRef, expressionReaderCallbackWithRef } from 'core/query-builder.utils';
 import { QBField, QueryBuilderOption } from 'core/types';
 import { filterXSSField } from 'core/utils';
-import { AlarmsQueryBuilderFields, AlarmsQueryBuilderStaticFields } from 'datasources/alarms/constants/AlarmsQueryBuilder.constants';
+import { AlarmsQueryBuilderFields, AlarmsQueryBuilderStaticFields, TIME_OPTIONS } from 'datasources/alarms/constants/AlarmsQueryBuilder.constants';
 import React, { useState, useEffect, useMemo } from 'react';
 import { QueryBuilderCustomOperation, QueryBuilderProps } from 'smart-webcomponents-react/querybuilder';
 
@@ -40,15 +40,9 @@ export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, 
   };
 
   const timeFields = useMemo(() => {
-    const timeOptions = [
-      { label: 'From', value: '${__from:date}' },
-      { label: 'To', value: '${__to:date}' },
-      { label: 'Now', value: '${__now:date}' },
-    ];
-
     return [
-      addOptionsToLookup(AlarmsQueryBuilderFields.ACKNOWLEDGED_ON, timeOptions),
-      addOptionsToLookup(AlarmsQueryBuilderFields.FIRST_OCCURRENCE, timeOptions),
+      addOptionsToLookup(AlarmsQueryBuilderFields.ACKNOWLEDGED_ON, TIME_OPTIONS),
+      addOptionsToLookup(AlarmsQueryBuilderFields.FIRST_OCCURRENCE, TIME_OPTIONS),
     ];
   }, []);
 
@@ -69,15 +63,9 @@ export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, 
       return field;
     })
 
-    const sortedFields = updatedFields.sort((a, b) => {
-      const labelA = a.label ?? '';
-      const labelB = b.label ?? '';
-      return labelA.localeCompare(labelB);
-    });
+    setFields(updatedFields);
 
-    setFields(sortedFields);
-
-    const options = sortedFields.reduce((accumulator, fieldConfig) => {
+    const options = updatedFields.reduce((accumulator, fieldConfig) => {
       if (fieldConfig.lookup) {
         accumulator[fieldConfig.dataField!] = fieldConfig.lookup.dataSource;
       }

--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
@@ -9,8 +9,8 @@ import { QueryBuilderCustomOperation, QueryBuilderProps } from 'smart-webcompone
 
 type AlarmsQueryBuilderProps = QueryBuilderProps &
   React.HTMLAttributes<Element> & {
-    filter?: string;
     globalVariableOptions: QueryBuilderOption[];
+    filter?: string;
   };
 
 export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, onChange, globalVariableOptions }) => {
@@ -48,6 +48,7 @@ export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, 
 
       return accumulator;
     }, {} as Record<string, QueryBuilderOption[]>);
+    
     optionsRef.current = options;
 
     const customOperations = [

--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
@@ -3,7 +3,7 @@ import { queryBuilderMessages, QueryBuilderOperations } from 'core/query-builder
 import { expressionBuilderCallbackWithRef, expressionReaderCallbackWithRef } from 'core/query-builder.utils';
 import { QBField, QueryBuilderOption } from 'core/types';
 import { filterXSSField } from 'core/utils';
-import { AlarmsQueryBuilderStaticFields } from 'datasources/alarms/constants/AlarmsQueryBuilder.constants';
+import { AlarmsQueryBuilderFields, AlarmsQueryBuilderStaticFields } from 'datasources/alarms/constants/AlarmsQueryBuilder.constants';
 import React, { useState, useEffect, useMemo } from 'react';
 import { QueryBuilderCustomOperation, QueryBuilderProps } from 'smart-webcomponents-react/querybuilder';
 
@@ -26,8 +26,38 @@ export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, 
     [optionsRef]
   );
 
+  const addOptionsToLookup = (field: QBField, options: QueryBuilderOption[]) => {
+    return {
+      ...field,
+      lookup: {
+        ...field.lookup,
+        dataSource: [
+          ...(field.lookup?.dataSource || []),
+          ...options,
+        ],
+      },
+    };
+  };
+
+  const timeFields = useMemo(() => {
+    const timeOptions = [
+      { label: 'From', value: '${__from:date}' },
+      { label: 'To', value: '${__to:date}' },
+      { label: 'Now', value: '${__now:date}' },
+    ];
+
+    return [
+      addOptionsToLookup(AlarmsQueryBuilderFields.ACKNOWLEDGED_ON, timeOptions),
+      addOptionsToLookup(AlarmsQueryBuilderFields.FIRST_OCCURRENCE, timeOptions),
+    ];
+  }, []);
+
   useEffect(() => {
-    const updatedFields = AlarmsQueryBuilderStaticFields.map(field => {
+    if (!timeFields) {
+      return;
+    }
+    
+    const updatedFields = [...AlarmsQueryBuilderStaticFields, ...timeFields].map(field => {
       if (field.lookup?.dataSource) {
         return {
           ...field,
@@ -37,11 +67,17 @@ export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, 
         };
       }
       return field;
+    })
+
+    const sortedFields = updatedFields.sort((a, b) => {
+      const labelA = a.label ?? '';
+      const labelB = b.label ?? '';
+      return labelA.localeCompare(labelB);
     });
 
-    setFields(updatedFields);
+    setFields(sortedFields);
 
-    const options = Object.values(updatedFields).reduce((accumulator, fieldConfig) => {
+    const options = sortedFields.reduce((accumulator, fieldConfig) => {
       if (fieldConfig.lookup) {
         accumulator[fieldConfig.dataField!] = fieldConfig.lookup.dataSource;
       }
@@ -58,6 +94,12 @@ export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, 
       QueryBuilderOperations.DOES_NOT_CONTAIN,
       QueryBuilderOperations.IS_BLANK,
       QueryBuilderOperations.IS_NOT_BLANK,
+      QueryBuilderOperations.DATE_TIME_IS_BEFORE,
+      QueryBuilderOperations.DATE_TIME_IS_AFTER,
+      QueryBuilderOperations.LIST_EQUALS,
+      QueryBuilderOperations.LIST_DOES_NOT_EQUAL,
+      QueryBuilderOperations.LIST_CONTAINS,
+      QueryBuilderOperations.LIST_DOES_NOT_CONTAIN,
     ].map(operation => {
       return {
         ...operation,
@@ -65,8 +107,15 @@ export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, 
       };
     });
 
-    setOperations([...customOperations]);
-  }, [globalVariableOptions, callbacks]);
+    const keyValueOperations = [
+      QueryBuilderOperations.KEY_VALUE_MATCH,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_MATCH,
+      QueryBuilderOperations.KEY_VALUE_CONTAINS,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_CONTAINS,
+    ];
+
+    setOperations([...customOperations, ...keyValueOperations]);
+  }, [globalVariableOptions, callbacks, timeFields]);
 
   return (
     <SlQueryBuilder

--- a/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
+++ b/src/datasources/alarms/components/query-builder/AlarmsQueryBuilder.tsx
@@ -1,0 +1,79 @@
+import { SlQueryBuilder } from 'core/components/SlQueryBuilder/SlQueryBuilder';
+import { queryBuilderMessages, QueryBuilderOperations } from 'core/query-builder.constants';
+import { expressionBuilderCallbackWithRef, expressionReaderCallbackWithRef } from 'core/query-builder.utils';
+import { QBField, QueryBuilderOption } from 'core/types';
+import { filterXSSField } from 'core/utils';
+import { AlarmsQueryBuilderStaticFields } from 'datasources/alarms/constants/AlarmsQueryBuilder.constants';
+import React, { useState, useEffect, useMemo } from 'react';
+import { QueryBuilderCustomOperation, QueryBuilderProps } from 'smart-webcomponents-react/querybuilder';
+
+type AlarmsQueryBuilderProps = QueryBuilderProps &
+  React.HTMLAttributes<Element> & {
+    filter?: string;
+    globalVariableOptions: QueryBuilderOption[];
+  };
+
+export const AlarmsQueryBuilder: React.FC<AlarmsQueryBuilderProps> = ({ filter, onChange, globalVariableOptions }) => {
+  const [fields, setFields] = useState<QBField[]>([]);
+  const [operations, setOperations] = useState<QueryBuilderCustomOperation[]>([]);
+  const optionsRef = React.useRef<Record<string, QueryBuilderOption[]>>({});
+
+  const callbacks = useMemo(
+    () => ({
+      expressionBuilderCallback: expressionBuilderCallbackWithRef(optionsRef),
+      expressionReaderCallback: expressionReaderCallbackWithRef(optionsRef),
+    }),
+    [optionsRef]
+  );
+
+  useEffect(() => {
+    const updatedFields = AlarmsQueryBuilderStaticFields.map(field => {
+      if (field.lookup?.dataSource) {
+        return {
+          ...field,
+          lookup: {
+            dataSource: [...globalVariableOptions, ...field.lookup?.dataSource].map(filterXSSField),
+          },
+        };
+      }
+      return field;
+    });
+
+    setFields(updatedFields);
+
+    const options = Object.values(updatedFields).reduce((accumulator, fieldConfig) => {
+      if (fieldConfig.lookup) {
+        accumulator[fieldConfig.dataField!] = fieldConfig.lookup.dataSource;
+      }
+
+      return accumulator;
+    }, {} as Record<string, QueryBuilderOption[]>);
+    optionsRef.current = options;
+
+    const customOperations = [
+      QueryBuilderOperations.EQUALS,
+      QueryBuilderOperations.DOES_NOT_EQUAL,
+      QueryBuilderOperations.CONTAINS,
+      QueryBuilderOperations.DOES_NOT_CONTAIN,
+      QueryBuilderOperations.IS_BLANK,
+      QueryBuilderOperations.IS_NOT_BLANK,
+    ].map(operation => {
+      return {
+        ...operation,
+        ...callbacks,
+      };
+    });
+
+    setOperations([...customOperations]);
+  }, [globalVariableOptions, callbacks]);
+
+  return (
+    <SlQueryBuilder
+      customOperations={operations}
+      fields={fields}
+      messages={queryBuilderMessages}
+      onChange={onChange}
+      value={filter}
+    />
+  );
+};

--- a/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
+++ b/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
@@ -1,0 +1,159 @@
+import { QueryBuilderOperations } from 'core/query-builder.constants';
+import { QBField } from 'core/types';
+
+export enum AlarmsQueryBuilderFieldNames {
+  Acknowledged = 'acknowledged',
+  Active = 'active',
+  AlarmID = 'alarmId',
+  AlarmName = 'displayName',
+  Channel = 'channel',
+  Clear = 'clear',
+  CreatedBy = 'createdBy',
+  CurrentSeverity = 'currentSeverityLevel',
+  Description = 'description',
+  HighestSeverity = 'highestSeverityLevel',
+  ResourceType = 'resourceType',
+}
+
+export const AlarmsQueryBuilderFields: Record<string, QBField> = {
+  ACKNOWLEDGED: {
+    label: 'Acknowledged',
+    dataField: AlarmsQueryBuilderFieldNames.Acknowledged,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'True', value: 'true' },
+        { label: 'False', value: 'false' },
+      ],
+    },
+  },
+  ACTIVE: {
+    label: 'Active',
+    dataField: AlarmsQueryBuilderFieldNames.Active,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'True', value: 'true' },
+        { label: 'False', value: 'false' },
+      ],
+    },
+  },
+  ALARM_ID: {
+    label: 'Alarm ID',
+    dataField: AlarmsQueryBuilderFieldNames.AlarmID,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+    ],
+  },
+  ALARM_NAME: {
+    label: 'Alarm name',
+    dataField: AlarmsQueryBuilderFieldNames.AlarmName,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  CHANNEL: {
+    label: 'Channel',
+    dataField: AlarmsQueryBuilderFieldNames.Channel,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  CLEAR: {
+    label: 'Clear',
+    dataField: AlarmsQueryBuilderFieldNames.Clear,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'True', value: 'true' },
+        { label: 'False', value: 'false' },
+      ],
+    },
+  },
+  CREATED_BY: {
+    label: 'Created by',
+    dataField: AlarmsQueryBuilderFieldNames.CreatedBy,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  CURRENT_SEVERITY: {
+    label: 'Current Severity',
+    dataField: AlarmsQueryBuilderFieldNames.CurrentSeverity,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'Clear', value: '-1' },
+        { label: 'Low (1)', value: '1' },
+        { label: 'Moderate (2)', value: '2' },
+        { label: 'High (3)', value: '3' },
+        { label: 'Critical (4)', value: '4' },
+      ],
+    },
+  },
+  DESCRIPTION: {
+    label: 'Description',
+    dataField: AlarmsQueryBuilderFieldNames.Description,
+    filterOperations: [
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
+    ],
+  },
+  HIGHEST_SEVERITY: {
+    label: 'Highest Severity',
+    dataField: AlarmsQueryBuilderFieldNames.HighestSeverity,
+    filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
+    lookup: {
+      dataSource: [
+        { label: 'Clear', value: '-1' },
+        { label: 'Low (1)', value: '1' },
+        { label: 'Moderate (2)', value: '2' },
+        { label: 'High (3)', value: '3' },
+        { label: 'Critical (4)', value: '4' },
+      ],
+    },
+  },
+  RESOURCE_TYPE: {
+    label: 'Resource type',
+    dataField: AlarmsQueryBuilderFieldNames.ResourceType,
+    filterOperations: [
+      QueryBuilderOperations.EQUALS.name,
+      QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+    ],
+  },
+};
+
+export const AlarmsQueryBuilderStaticFields = [
+  AlarmsQueryBuilderFields.ACKNOWLEDGED,
+  AlarmsQueryBuilderFields.ACTIVE,
+  AlarmsQueryBuilderFields.ALARM_ID,
+  AlarmsQueryBuilderFields.ALARM_NAME,
+  AlarmsQueryBuilderFields.CHANNEL,
+  AlarmsQueryBuilderFields.CLEAR,
+  AlarmsQueryBuilderFields.CURRENT_SEVERITY,
+  AlarmsQueryBuilderFields.DESCRIPTION,
+  AlarmsQueryBuilderFields.HIGHEST_SEVERITY,
+  AlarmsQueryBuilderFields.RESOURCE_TYPE,
+];

--- a/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
+++ b/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
@@ -15,6 +15,14 @@ export enum AlarmsQueryBuilderFieldNames {
   ResourceType = 'resourceType',
 }
 
+const SEVERITY_LEVELS = [
+  { label: 'Low', value: '1' },
+  { label: 'Moderate', value: '2' },
+  { label: 'High', value: '3' },
+  { label: 'Critical', value: '4' },
+  { label: 'Clear', value: '-1' },
+];
+
 export const AlarmsQueryBuilderFields: Record<string, QBField> = {
   ACKNOWLEDGED: {
     label: 'Acknowledged',
@@ -91,20 +99,16 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
       QueryBuilderOperations.DOES_NOT_EQUAL.name,
       QueryBuilderOperations.IS_BLANK.name,
       QueryBuilderOperations.IS_NOT_BLANK.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
     ],
   },
   CURRENT_SEVERITY: {
-    label: 'Current Severity',
+    label: 'Current severity',
     dataField: AlarmsQueryBuilderFieldNames.CurrentSeverity,
     filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
     lookup: {
-      dataSource: [
-        { label: 'Clear', value: '-1' },
-        { label: 'Low (1)', value: '1' },
-        { label: 'Moderate (2)', value: '2' },
-        { label: 'High (3)', value: '3' },
-        { label: 'Critical (4)', value: '4' },
-      ],
+        dataSource: SEVERITY_LEVELS,
     },
   },
   DESCRIPTION: {
@@ -120,17 +124,11 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
     ],
   },
   HIGHEST_SEVERITY: {
-    label: 'Highest Severity',
+    label: 'Highest severity',
     dataField: AlarmsQueryBuilderFieldNames.HighestSeverity,
     filterOperations: [QueryBuilderOperations.EQUALS.name, QueryBuilderOperations.DOES_NOT_EQUAL.name],
     lookup: {
-      dataSource: [
-        { label: 'Clear', value: '-1' },
-        { label: 'Low (1)', value: '1' },
-        { label: 'Moderate (2)', value: '2' },
-        { label: 'High (3)', value: '3' },
-        { label: 'Critical (4)', value: '4' },
-      ],
+      dataSource: SEVERITY_LEVELS,
     },
   },
   RESOURCE_TYPE: {
@@ -145,13 +143,14 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
   },
 };
 
-export const AlarmsQueryBuilderStaticFields = [
+export const AlarmsQueryBuilderStaticFields: QBField[] = [
   AlarmsQueryBuilderFields.ACKNOWLEDGED,
   AlarmsQueryBuilderFields.ACTIVE,
   AlarmsQueryBuilderFields.ALARM_ID,
   AlarmsQueryBuilderFields.ALARM_NAME,
   AlarmsQueryBuilderFields.CHANNEL,
   AlarmsQueryBuilderFields.CLEAR,
+  AlarmsQueryBuilderFields.CREATED_BY,
   AlarmsQueryBuilderFields.CURRENT_SEVERITY,
   AlarmsQueryBuilderFields.DESCRIPTION,
   AlarmsQueryBuilderFields.HIGHEST_SEVERITY,

--- a/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
+++ b/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
@@ -3,6 +3,7 @@ import { QBField } from 'core/types';
 
 export enum AlarmsQueryBuilderFieldNames {
   Acknowledged = 'acknowledged',
+  AcknowledgedOn = 'acknowledgedAt',
   Active = 'active',
   AlarmID = 'alarmId',
   AlarmName = 'displayName',
@@ -11,7 +12,10 @@ export enum AlarmsQueryBuilderFieldNames {
   CreatedBy = 'createdBy',
   CurrentSeverity = 'currentSeverityLevel',
   Description = 'description',
+  FirstOccurrence = 'occurredAt',
   HighestSeverity = 'highestSeverityLevel',
+  Keyword = 'keywords',
+  Properties = 'properties',
   ResourceType = 'resourceType',
 }
 
@@ -34,6 +38,14 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
         { label: 'False', value: 'false' },
       ],
     },
+  },
+  ACKNOWLEDGED_ON: {
+    label: 'Acknowledged on',
+    dataField: AlarmsQueryBuilderFieldNames.AcknowledgedOn,
+    filterOperations: [
+      QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
+      QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+    ],
   },
   ACTIVE: {
     label: 'Active',
@@ -123,6 +135,14 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
       QueryBuilderOperations.IS_NOT_BLANK.name,
     ],
   },
+  FIRST_OCCURRENCE: {
+    label: 'First occurrence',
+    dataField: AlarmsQueryBuilderFieldNames.FirstOccurrence,
+    filterOperations: [
+      QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
+      QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+    ],
+  },
   HIGHEST_SEVERITY: {
     label: 'Highest severity',
     dataField: AlarmsQueryBuilderFieldNames.HighestSeverity,
@@ -130,6 +150,27 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
     lookup: {
       dataSource: SEVERITY_LEVELS,
     },
+  },
+  KEYWORD: {
+    label: 'Keyword',
+    dataField: AlarmsQueryBuilderFieldNames.Keyword,
+    filterOperations: [
+      QueryBuilderOperations.LIST_EQUALS.name,
+      QueryBuilderOperations.LIST_DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.LIST_CONTAINS.name,
+      QueryBuilderOperations.LIST_DOES_NOT_CONTAIN.name,
+    ],
+  },
+  PROPERTIES: {
+    label: 'Properties',
+    dataField: AlarmsQueryBuilderFieldNames.Properties,
+    dataType: 'object',
+    filterOperations: [
+      QueryBuilderOperations.KEY_VALUE_MATCH.name,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_MATCH.name,
+      QueryBuilderOperations.KEY_VALUE_CONTAINS.name,
+      QueryBuilderOperations.KEY_VALUE_DOES_NOT_CONTAINS.name,
+    ],
   },
   RESOURCE_TYPE: {
     label: 'Resource type',
@@ -145,6 +186,7 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
 
 export const AlarmsQueryBuilderStaticFields: QBField[] = [
   AlarmsQueryBuilderFields.ACKNOWLEDGED,
+  AlarmsQueryBuilderFields.ACKNOWLEDGED_ON,
   AlarmsQueryBuilderFields.ACTIVE,
   AlarmsQueryBuilderFields.ALARM_ID,
   AlarmsQueryBuilderFields.ALARM_NAME,
@@ -153,6 +195,9 @@ export const AlarmsQueryBuilderStaticFields: QBField[] = [
   AlarmsQueryBuilderFields.CREATED_BY,
   AlarmsQueryBuilderFields.CURRENT_SEVERITY,
   AlarmsQueryBuilderFields.DESCRIPTION,
+  AlarmsQueryBuilderFields.FIRST_OCCURRENCE,
   AlarmsQueryBuilderFields.HIGHEST_SEVERITY,
+  AlarmsQueryBuilderFields.KEYWORD,
+  AlarmsQueryBuilderFields.PROPERTIES,
   AlarmsQueryBuilderFields.RESOURCE_TYPE,
 ];

--- a/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
+++ b/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
@@ -97,10 +97,10 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
     filterOperations: [
       QueryBuilderOperations.EQUALS.name,
       QueryBuilderOperations.DOES_NOT_EQUAL.name,
-      QueryBuilderOperations.IS_BLANK.name,
-      QueryBuilderOperations.IS_NOT_BLANK.name,
       QueryBuilderOperations.CONTAINS.name,
       QueryBuilderOperations.DOES_NOT_CONTAIN.name,
+      QueryBuilderOperations.IS_BLANK.name,
+      QueryBuilderOperations.IS_NOT_BLANK.name,
     ],
   },
   CURRENT_SEVERITY: {
@@ -115,10 +115,10 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
     label: 'Description',
     dataField: AlarmsQueryBuilderFieldNames.Description,
     filterOperations: [
-      QueryBuilderOperations.CONTAINS.name,
-      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
       QueryBuilderOperations.EQUALS.name,
       QueryBuilderOperations.DOES_NOT_EQUAL.name,
+      QueryBuilderOperations.CONTAINS.name,
+      QueryBuilderOperations.DOES_NOT_CONTAIN.name,
       QueryBuilderOperations.IS_BLANK.name,
       QueryBuilderOperations.IS_NOT_BLANK.name,
     ],

--- a/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
+++ b/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
@@ -19,6 +19,11 @@ const EXTENDED_STRING_FILTER_OPERATIONS = [
   QueryBuilderOperations.IS_NOT_BLANK.name,
 ];
 
+const DATE_TIME_FILTER_OPERATIONS = [
+  QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
+  QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
+];
+
 export const SEVERITY_LEVELS = [
   { label: 'Low', value: '1' },
   { label: 'Moderate', value: '2' },
@@ -30,6 +35,12 @@ export const SEVERITY_LEVELS = [
 export const BOOLEAN_OPTIONS = [
   { label: 'True', value: 'true' },
   { label: 'False', value: 'false' },
+];
+
+export const TIME_OPTIONS = [
+  { label: 'From', value: '${__from:date}' },
+  { label: 'To', value: '${__to:date}' },
+  { label: 'Now', value: '${__now:date}' },
 ];
 
 export const AlarmsQueryBuilderFields: Record<string, QBField> = {
@@ -44,10 +55,7 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
   ACKNOWLEDGED_ON: {
     label: 'Acknowledged on',
     dataField: 'acknowledgedAt',
-    filterOperations: [
-      QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
-      QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
-    ],
+    filterOperations: DATE_TIME_FILTER_OPERATIONS,
   },
   ACTIVE: {
     label: 'Active',
@@ -101,10 +109,7 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
   FIRST_OCCURRENCE: {
     label: 'First occurrence',
     dataField: 'occurredAt',
-    filterOperations: [
-      QueryBuilderOperations.DATE_TIME_IS_BEFORE.name,
-      QueryBuilderOperations.DATE_TIME_IS_AFTER.name,
-    ],
+    filterOperations: DATE_TIME_FILTER_OPERATIONS,
   },
   HIGHEST_SEVERITY: {
     label: 'Highest severity',
@@ -144,6 +149,7 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
 
 export const AlarmsQueryBuilderStaticFields: QBField[] = [
   AlarmsQueryBuilderFields.ACKNOWLEDGED,
+  AlarmsQueryBuilderFields.ACKNOWLEDGED_ON,
   AlarmsQueryBuilderFields.ACTIVE,
   AlarmsQueryBuilderFields.ALARM_ID,
   AlarmsQueryBuilderFields.ALARM_NAME,
@@ -152,6 +158,9 @@ export const AlarmsQueryBuilderStaticFields: QBField[] = [
   AlarmsQueryBuilderFields.CREATED_BY,
   AlarmsQueryBuilderFields.CURRENT_SEVERITY,
   AlarmsQueryBuilderFields.DESCRIPTION,
+  AlarmsQueryBuilderFields.FIRST_OCCURRENCE,
   AlarmsQueryBuilderFields.HIGHEST_SEVERITY,
+  AlarmsQueryBuilderFields.KEYWORD,
+  AlarmsQueryBuilderFields.PROPERTIES,
   AlarmsQueryBuilderFields.RESOURCE_TYPE,
 ];

--- a/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
+++ b/src/datasources/alarms/constants/AlarmsQueryBuilder.constants.ts
@@ -149,7 +149,6 @@ export const AlarmsQueryBuilderFields: Record<string, QBField> = {
 
 export const AlarmsQueryBuilderStaticFields: QBField[] = [
   AlarmsQueryBuilderFields.ACKNOWLEDGED,
-  AlarmsQueryBuilderFields.ACKNOWLEDGED_ON,
   AlarmsQueryBuilderFields.ACTIVE,
   AlarmsQueryBuilderFields.ALARM_ID,
   AlarmsQueryBuilderFields.ALARM_NAME,
@@ -158,7 +157,6 @@ export const AlarmsQueryBuilderStaticFields: QBField[] = [
   AlarmsQueryBuilderFields.CREATED_BY,
   AlarmsQueryBuilderFields.CURRENT_SEVERITY,
   AlarmsQueryBuilderFields.DESCRIPTION,
-  AlarmsQueryBuilderFields.FIRST_OCCURRENCE,
   AlarmsQueryBuilderFields.HIGHEST_SEVERITY,
   AlarmsQueryBuilderFields.KEYWORD,
   AlarmsQueryBuilderFields.PROPERTIES,


### PR DESCRIPTION
## 🤨 Rationale

Add support for filtering by acknowledged on, first occurrence, properties and keywords in alarms query builder

## 👩‍💻 Implementation

- Added new fields to the query builder: `Acknowledged on`, `First occurrence`, `Keyword`, and `Properties`, each with appropriate filter operations and configuration in `AlarmsQueryBuilderFields` and included in `AlarmsQueryBuilderStaticFields`. 
- Introduced time-based options (`From`, `To`, `Now`) for the `Acknowledged on` and `First occurrence` fields, allowing users to select these as filter values.
- Added additional filter operations for date/time, list, and key/value matching to support the new fields and use cases.

## 🧪 Testing

Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).