### PR TITLE
fix(core): sort fields in query builder by label

### DIFF
--- a/src/core/components/SlQueryBuilder/SlQueryBuilder.test.tsx
+++ b/src/core/components/SlQueryBuilder/SlQueryBuilder.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { SlQueryBuilder } from './SlQueryBuilder';
 import { QueryBuilderCustomOperation, QueryBuilderField } from 'smart-webcomponents-react';
+import * as QueryBuilderModule from 'smart-webcomponents-react/querybuilder';
+
 
 describe('SlQueryBuilder', () => {
   const containerClass = 'smart-filter-group-condition-container';
@@ -10,7 +12,12 @@ describe('SlQueryBuilder', () => {
     label: 'Custom operation',
     expressionTemplate: '{0} = "{1}"'
   }];
-  const fields = [ { label: 'Field1', dataField: 'field1', filterOperations: ['='] } ];
+  const fields = [
+    { label: 'Field2', dataField: 'field2', filterOperations: ['='] },
+    { label: 'Field1', dataField: 'field1', filterOperations: ['='] },
+    { label: 'Field4', dataField: 'field4', filterOperations: ['='] },
+    { label: 'Field3', dataField: 'field3', filterOperations: ['='] }
+  ];
 
   function renderElement(
     customOperations: QueryBuilderCustomOperation[] = [],
@@ -40,5 +47,16 @@ describe('SlQueryBuilder', () => {
 
     expect(conditionsContainer?.length).toBe(1);
     expect(conditionsContainer.item(0)?.innerHTML).not.toContain('alert(\'Test\')');
+  });
+
+  it('should sort fields in query builder', () => {
+    const queryBuilderSpy = jest.spyOn(QueryBuilderModule, "default").mockImplementation(jest.fn());
+    const expectedFieldLabels = ['Field1', 'Field2', 'Field3', 'Field4'];
+
+    renderElement(customOperations, fields);
+    const queryBuilderFields = queryBuilderSpy.mock.lastCall?.at(0).fields;
+    const queryBuilderFieldLabels = queryBuilderFields?.map((field: QueryBuilderField) => field.label);
+
+    expect(queryBuilderFieldLabels).toEqual(expectedFieldLabels);
   });
 });

--- a/src/core/components/SlQueryBuilder/SlQueryBuilder.tsx
+++ b/src/core/components/SlQueryBuilder/SlQueryBuilder.tsx
@@ -47,6 +47,21 @@ export const SlQueryBuilder: React.FC<SlQueryBuilderProps> = ({
     return filterXSSLINQExpression(value);
   }, [value]);
 
+  const sortFieldsByLabel = (fields: QueryBuilderField[]) => {
+    return fields.sort((a, b) => {
+      if (!a.label && !b.label) {
+        return 0;
+      }
+      if (!a.label) {
+        return 1;
+      }
+      if (!b.label) {
+        return -1;
+      }
+      return a.label.localeCompare(b.label);
+    });
+  }
+
   const sortedFields = useMemo(() => {
     if (!fields) {
       return fields;
@@ -68,18 +83,3 @@ export const SlQueryBuilder: React.FC<SlQueryBuilderProps> = ({
     />
   );
 };
-
-function sortFieldsByLabel(fields: QueryBuilderField[]) {
-  return fields.sort((a, b) => {
-    if (!a.label && !b.label) {
-      return 0;
-    }
-    if (!a.label) {
-      return 1;
-    }
-    if (!b.label) {
-      return -1;
-    }
-    return a.label.localeCompare(b.label);
-  });
-}

--- a/src/core/components/SlQueryBuilder/SlQueryBuilder.tsx
+++ b/src/core/components/SlQueryBuilder/SlQueryBuilder.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { useTheme2 } from '@grafana/ui';
-import QueryBuilder, { QueryBuilderProps } from 'smart-webcomponents-react/querybuilder';
+import QueryBuilder, { QueryBuilderField, QueryBuilderProps } from 'smart-webcomponents-react/querybuilder';
 import './SlQueryBuilder.css';
 import { filterXSSLINQExpression } from 'core/utils';
 
@@ -48,14 +48,11 @@ export const SlQueryBuilder: React.FC<SlQueryBuilderProps> = ({
   }, [value]);
 
   const sortedFields = useMemo(() => {
-    if (!fields) return [];
+    if (!fields) {
+      return fields;
+    }
 
-    return [...fields].sort((a, b) => {
-      if (!a.label && !b.label) return 0;
-      if (!a.label) return 1;
-      if (!b.label) return -1;
-      return a.label.localeCompare(b.label);
-    });
+    return sortFieldsByLabel([...fields]);
   }, [fields]);
 
   return (
@@ -71,3 +68,18 @@ export const SlQueryBuilder: React.FC<SlQueryBuilderProps> = ({
     />
   );
 };
+
+function sortFieldsByLabel(fields: QueryBuilderField[]) {
+  return fields.sort((a, b) => {
+    if (!a.label && !b.label) {
+      return 0;
+    }
+    if (!a.label) {
+      return 1;
+    }
+    if (!b.label) {
+      return -1;
+    }
+    return a.label.localeCompare(b.label);
+  });
+}

--- a/src/core/components/SlQueryBuilder/SlQueryBuilder.tsx
+++ b/src/core/components/SlQueryBuilder/SlQueryBuilder.tsx
@@ -47,10 +47,21 @@ export const SlQueryBuilder: React.FC<SlQueryBuilderProps> = ({
     return filterXSSLINQExpression(value);
   }, [value]);
 
+  const sortedFields = useMemo(() => {
+    if (!fields) return [];
+
+    return [...fields].sort((a, b) => {
+      if (!a.label && !b.label) return 0;
+      if (!a.label) return 1;
+      if (!b.label) return -1;
+      return a.label.localeCompare(b.label);
+    });
+  }, [fields]);
+
   return (
     <QueryBuilder
       customOperations={customOperations}
-      fields={fields}
+      fields={sortedFields}
       messages={messages}
       onChange={onChange}
       value={sanitizedFilter}

--- a/src/core/components/SlQueryBuilder/SlQueryBuilder.tsx
+++ b/src/core/components/SlQueryBuilder/SlQueryBuilder.tsx
@@ -49,16 +49,7 @@ export const SlQueryBuilder: React.FC<SlQueryBuilderProps> = ({
 
   const sortFieldsByLabel = (fields: QueryBuilderField[]) => {
     return fields.sort((a, b) => {
-      if (!a.label && !b.label) {
-        return 0;
-      }
-      if (!a.label) {
-        return 1;
-      }
-      if (!b.label) {
-        return -1;
-      }
-      return a.label.localeCompare(b.label);
+      return (a.label ?? '').localeCompare(b.label ?? '');
     });
   }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

[Bug 3239554](https://dev.azure.com/ni/DevCentral/_workitems/edit/3239554): Grafana | Properties not sorted
Currently the properties in the querybuilder dropdown are not shown in sorted order. Other SLE apps shows the properties in sorted order in the querybuilder. This PR contains changes to sort the fields in the querybuilder.

## 👩‍💻 Implementation

- Added logic to sort the fields by label.

## 🧪 Testing
- Added unit tests for the introduced functionality

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).