### PR TITLE
Draft | Innovation | Implement feature toggle

### DIFF
--- a/provisioning/example.yaml
+++ b/provisioning/example.yaml
@@ -6,6 +6,7 @@ apiVersion: 1
 
 config: &config
   access: proxy
+  editable: true
   url: MY_SYSTEMLINK_API_URL
   jsonData:
     httpHeaderName1: 'x-ni-api-key'

--- a/src/core/feature-toggle.ts
+++ b/src/core/feature-toggle.ts
@@ -1,0 +1,62 @@
+import { DataSourceJsonData } from "@grafana/data";
+
+interface FeatureToggle {
+  name: string;
+  enabledByDefault: boolean;
+  description?: string;
+}
+
+export interface FeatureToggleDataSourceOptions extends DataSourceJsonData {
+  featureToggles: { [key: string]: boolean };
+}
+
+export enum FeatureToggleNames {
+  assetList = 'assetList',
+  calibrationForecast = 'calibrationForecast',
+  assetSummary = 'assetSummary',
+  locations = 'locations'
+}
+
+export const FeatureTogglesDefaults: Record<FeatureToggleNames, FeatureToggle> = {
+  [FeatureToggleNames.assetList]: {
+    name: 'assetList',
+    enabledByDefault: true,
+    description: 'Enables the Asset List query type.'
+  },
+  [FeatureToggleNames.calibrationForecast]: {
+    name: 'calibrationForecast',
+    enabledByDefault: true,
+    description: 'Enables the Calibration Forecast query type.'
+  },
+  [FeatureToggleNames.assetSummary]: {
+    name: 'assetSummary',
+    enabledByDefault: true,
+    description: 'Enables the Asset Summary query type.'
+  },
+  [FeatureToggleNames.locations]: {
+    name: 'locations',
+    enabledByDefault: false,
+    description: 'Enables location support in Asset queries.'
+  }
+};
+
+export function getFeatureFlagValue(options:  FeatureToggleDataSourceOptions, flagName: FeatureToggleNames): boolean {
+  // Check if the feature flag is set in the datasource options.
+  const optionValue = options?.featureToggles && options?.featureToggles[flagName];
+  if (optionValue !== undefined && optionValue) {
+    return optionValue;
+  }
+
+  // Check if the feature flag is set in local storage.
+  const localValue = localStorage.getItem(`${flagName}`);
+  if (localValue !== null) {
+    return localValue === 'true';
+  }
+
+  // If not set in options or local storage, use the default value and set it to local storage.
+  localStorage.setItem(
+      FeatureTogglesDefaults[flagName].name,
+      FeatureTogglesDefaults[flagName].enabledByDefault.toString()
+  );
+  return FeatureTogglesDefaults[flagName].enabledByDefault;
+}

--- a/src/datasources/asset/AssetConfigEditor.tsx
+++ b/src/datasources/asset/AssetConfigEditor.tsx
@@ -5,9 +5,9 @@
 import React, { ChangeEvent, useCallback } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { DataSourceHttpSettings, InlineField, InlineSegmentGroup, InlineSwitch, Tag, Text } from '@grafana/ui';
-import { AssetDataSourceOptions, AssetFeatureTogglesDefaults } from './types/types';
+import { FeatureToggleDataSourceOptions, FeatureTogglesDefaults } from 'core/feature-toggle';
 
-interface Props extends DataSourcePluginOptionsEditorProps<AssetDataSourceOptions> { }
+interface Props extends DataSourcePluginOptionsEditorProps<FeatureToggleDataSourceOptions> { }
 
 export const AssetConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
   const handleFeatureChange =  useCallback((featureKey: string) => (event: ChangeEvent<HTMLInputElement>) => {
@@ -35,7 +35,7 @@ export const AssetConfigEditor: React.FC<Props> = ({ options, onOptionsChange })
         <InlineSegmentGroup>
           <InlineField label="Asset list" labelWidth={25}>
             <InlineSwitch
-              value={options.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList}
+              value={options.jsonData?.featureToggles?.assetList ?? FeatureTogglesDefaults.assetList.enabledByDefault}
               onChange={handleFeatureChange('assetList')} />
           </InlineField>
           <Tag name='Beta' colorIndex={5} />
@@ -43,7 +43,7 @@ export const AssetConfigEditor: React.FC<Props> = ({ options, onOptionsChange })
         <InlineSegmentGroup>
           <InlineField label="Calibration forecast" labelWidth={25}>
             <InlineSwitch
-              value={options.jsonData?.featureToggles?.calibrationForecast ?? AssetFeatureTogglesDefaults.calibrationForecast}
+              value={options.jsonData?.featureToggles?.calibrationForecast ?? FeatureTogglesDefaults.calibrationForecast.enabledByDefault}
               onChange={handleFeatureChange('calibrationForecast')} />
           </InlineField>
           <Tag name='Beta' colorIndex={5} />
@@ -51,7 +51,7 @@ export const AssetConfigEditor: React.FC<Props> = ({ options, onOptionsChange })
         <InlineSegmentGroup>
           <InlineField label="Asset summary" labelWidth={25}>
             <InlineSwitch
-              value={options.jsonData?.featureToggles?.assetSummary ?? AssetFeatureTogglesDefaults.assetSummary}
+              value={options.jsonData?.featureToggles?.assetSummary ?? FeatureTogglesDefaults.assetSummary.enabledByDefault}
               onChange={handleFeatureChange('assetSummary')} />
           </InlineField>
           <Tag name='Beta' colorIndex={5} />

--- a/src/datasources/asset/AssetDataSource.ts
+++ b/src/datasources/asset/AssetDataSource.ts
@@ -9,7 +9,6 @@ import {
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { DataSourceBase } from 'core/DataSourceBase';
 import {
-  AssetDataSourceOptions,
   AssetQuery,
   AssetQueryType,
   AssetQueryReturnType
@@ -25,15 +24,16 @@ import { transformComputedFieldsQuery } from 'core/query-builder.utils';
 import { AssetVariableQuery } from './types/AssetVariableQuery.types';
 import { defaultListAssetsVariable, defaultProjectionForListAssetsVariable } from './defaults';
 import { TAKE_LIMIT } from './constants/ListAssets.constants';
+import { FeatureToggleDataSourceOptions } from 'core/feature-toggle';
 
-export class AssetDataSource extends DataSourceBase<AssetQuery, AssetDataSourceOptions> {
+export class AssetDataSource extends DataSourceBase<AssetQuery, FeatureToggleDataSourceOptions> {
   private assetSummaryDataSource: AssetSummaryDataSource;
   private calibrationForecastDataSource: CalibrationForecastDataSource;
   private listAssetsDataSource: ListAssetsDataSource;
   private assetQueryReturnType: AssetQueryReturnType = AssetQueryReturnType.AssetTagPath;
 
   constructor(
-    readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,
+    readonly instanceSettings: DataSourceInstanceSettings<FeatureToggleDataSourceOptions>,
     readonly backendSrv: BackendSrv = getBackendSrv(),
     readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {

--- a/src/datasources/asset/components/AssetQueryEditor.test.ts
+++ b/src/datasources/asset/components/AssetQueryEditor.test.ts
@@ -8,10 +8,11 @@ import { ListAssetsQuery } from '../types/ListAssets.types';
 import { CalibrationForecastQuery } from '../types/CalibrationForecastQuery.types';
 import { select } from 'react-select-event';
 import { AssetSummaryQuery } from '../types/AssetSummaryQuery.types';
-import { AssetFeatureTogglesDefaults, AssetQueryType } from '../types/types';
+import { AssetQueryType } from '../types/types';
 import { ListAssetsDataSource } from '../data-sources/list-assets/ListAssetsDataSource';
 import { AssetSummaryDataSource } from '../data-sources/asset-summary/AssetSummaryDataSource';
 import { LocationModel } from '../types/ListLocations.types';
+import { FeatureTogglesDefaults } from 'core/feature-toggle';
 
 const fakeSystems: SystemProperties[] = [
     {
@@ -38,7 +39,7 @@ const fakeLocations: LocationModel[] = [
 ]
 
 let assetDatasourceOptions = {
-    featureToggles: { ...AssetFeatureTogglesDefaults }
+    featureToggles: { ...FeatureTogglesDefaults }
 }
 
 class FakeAssetsSource extends ListAssetsDataSource {
@@ -67,12 +68,12 @@ const render = setupRenderer(AssetQueryEditor, FakeAssetDataSource, () => assetD
 
 beforeEach(() => {
     assetDatasourceOptions = {
-        featureToggles: { ...AssetFeatureTogglesDefaults }
+        featureToggles: { ...FeatureTogglesDefaults }
     };
 });
 
 it('renders Asset list when feature is enabled', async () => {
-    assetDatasourceOptions.featureToggles.assetList = true;
+    localStorage.setItem('assetList', 'true');
     render({ type: AssetQueryType.ListAssets } as ListAssetsQuery);
     const queryType = screen.getAllByRole('combobox')[0];
     await select(queryType, "List Assets", { container: document.body });
@@ -80,7 +81,7 @@ it('renders Asset list when feature is enabled', async () => {
 });
 
 it('renders Asset calibration forecast when feature is enabled', async () => {
-    assetDatasourceOptions.featureToggles.calibrationForecast = true;
+    localStorage.setItem('calibrationForecast', 'true');
     render({ type: AssetQueryType.CalibrationForecast } as CalibrationForecastQuery);
     const queryType = screen.getAllByRole('combobox')[0];
     await select(queryType, "Calibration Forecast", { container: document.body });
@@ -88,7 +89,7 @@ it('renders Asset calibration forecast when feature is enabled', async () => {
 });
 
 it('renders Asset summary when feature is enabled', async () => {
-    assetDatasourceOptions.featureToggles.assetSummary = true;
+    localStorage.setItem('assetSummary', 'true');
     render({ type: AssetQueryType.AssetSummary } as AssetSummaryQuery);
     const queryType = screen.getAllByRole('combobox')[0];
     await select(queryType, "Asset Summary", { container: document.body });

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -10,18 +10,28 @@ import { ListAssetsEditor } from './editors/list-assets/ListAssetsEditor';
 import { defaultAssetSummaryQuery, defaultCalibrationForecastQuery, defaultListAssetsQuery } from '../defaults';
 import { ListAssetsQuery } from '../types/ListAssets.types';
 import { AssetSummaryQuery } from '../types/AssetSummaryQuery.types';
-import { AssetDataSourceOptions, AssetFeatureToggles, AssetFeatureTogglesDefaults, AssetQuery, AssetQueryType } from '../types/types';
+import { AssetQuery, AssetQueryType } from '../types/types';
 import { CalibrationForecastQuery } from '../types/CalibrationForecastQuery.types';
+import { FeatureToggleDataSourceOptions, FeatureToggleNames, getFeatureFlagValue } from 'core/feature-toggle';
 
-type Props = QueryEditorProps<AssetDataSource, AssetQuery, AssetDataSourceOptions>;
+type Props = QueryEditorProps<AssetDataSource, AssetQuery, FeatureToggleDataSourceOptions>;
 
 export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   const [queryType, setQueryType] = useState(query.type);
-  const assetFeatures = useRef<AssetFeatureToggles>({
-    assetList: datasource.instanceSettings.jsonData?.featureToggles?.assetList ?? AssetFeatureTogglesDefaults.assetList,
-    calibrationForecast: datasource.instanceSettings.jsonData?.featureToggles?.calibrationForecast ?? AssetFeatureTogglesDefaults.calibrationForecast,
-    assetSummary: datasource.instanceSettings.jsonData?.featureToggles?.assetSummary ?? AssetFeatureTogglesDefaults.assetSummary,
-    locations: datasource.instanceSettings.jsonData?.featureToggles?.locations ?? AssetFeatureTogglesDefaults.locations
+  const assetFeatures = useRef<{ [key: string]: boolean }>({
+    // assetList: (window as any).DataSourceFeatureFlags['assetList']
+    //   ?? datasource.instanceSettings.jsonData?.featureToggles?.assetList
+    //   ?? FeatureTogglesDefaults.assetList,
+    // calibrationForecast: (window as any).DataSourceFeatureFlags['calibrationForecast']
+    //   ?? datasource.instanceSettings.jsonData?.featureToggles?.calibrationForecast
+    //   ?? FeatureTogglesDefaults.calibrationForecast,
+    // assetSummary: (window as any).DataSourceFeatureFlags['assetSummary']
+    //   ?? datasource.instanceSettings.jsonData?.featureToggles?.assetSummary
+    //   ?? FeatureTogglesDefaults.assetSummary,
+    assetList: getFeatureFlagValue(datasource.instanceSettings.jsonData, FeatureToggleNames.assetList),
+    calibrationForecast: getFeatureFlagValue(datasource.instanceSettings.jsonData, FeatureToggleNames.calibrationForecast),
+    assetSummary: getFeatureFlagValue(datasource.instanceSettings.jsonData, FeatureToggleNames.assetSummary),
+    locations: getFeatureFlagValue(datasource.instanceSettings.jsonData, FeatureToggleNames.locations)
   });
 
   const handleQueryChange = useCallback((value: AssetQuery, runQuery = false): void => {

--- a/src/datasources/asset/components/AssetQueryEditor.tsx
+++ b/src/datasources/asset/components/AssetQueryEditor.tsx
@@ -22,7 +22,6 @@ export function AssetQueryEditor({ query, onChange, onRunQuery, datasource }: Pr
     assetList: getFeatureFlagValue(datasource.instanceSettings.jsonData, FeatureToggleNames.assetList),
     calibrationForecast: getFeatureFlagValue(datasource.instanceSettings.jsonData, FeatureToggleNames.calibrationForecast),
     assetSummary: getFeatureFlagValue(datasource.instanceSettings.jsonData, FeatureToggleNames.assetSummary),
-    locations: getFeatureFlagValue(datasource.instanceSettings.jsonData, FeatureToggleNames.locations)
   });
 
   const handleQueryChange = useCallback((value: AssetQuery, runQuery = false): void => {

--- a/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.test.tsx
+++ b/src/datasources/asset/components/editors/asset-summary/AssetSummaryEditor.test.tsx
@@ -3,13 +3,14 @@ import { BackendSrv, TemplateSrv } from '@grafana/runtime';
 import { mock } from 'jest-mock-extended';
 
 import { AssetSummaryResponse } from 'datasources/asset/types/AssetSummaryQuery.types';
-import { AssetDataSourceOptions, AssetQuery, AssetQueryType } from 'datasources/asset/types/types';
+import { AssetQuery, AssetQueryType } from 'datasources/asset/types/types';
 import { AssetSummaryDataSource } from '../../../data-sources/asset-summary/AssetSummaryDataSource';
 import { assetSummaryFields } from '../../../constants/AssetSummaryQuery.constants';
+import { FeatureToggleDataSourceOptions } from 'core/feature-toggle';
 
 describe('AssetSummaryDataSource', () => {
   let dataSource: AssetSummaryDataSource;
-  const instanceSettings = mock<DataSourceInstanceSettings<AssetDataSourceOptions>>();
+  const instanceSettings = mock<DataSourceInstanceSettings<FeatureToggleDataSourceOptions>>();
   const backendSrv = mock<BackendSrv>();
   const templateSrv = mock<TemplateSrv>();
   const assetSummary: AssetSummaryResponse = {

--- a/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.test.tsx
+++ b/src/datasources/asset/components/editors/list-assets/ListAssetsEditor.test.tsx
@@ -4,11 +4,12 @@ import { AssetDataSource } from '../../../AssetDataSource';
 import { AssetQueryEditor } from '../../AssetQueryEditor';
 import { setupRenderer } from '../../../../../test/fixtures';
 import { AssetFilterProperties, AssetFilterPropertiesOption, ListAssetsQuery, OutputType } from '../../../types/ListAssets.types';
-import { AssetFeatureTogglesDefaults, AssetQueryType } from 'datasources/asset/types/types';
+import { AssetQueryType } from 'datasources/asset/types/types';
 import { ListAssetsDataSource } from '../../../data-sources/list-assets/ListAssetsDataSource';
 import userEvent from '@testing-library/user-event';
 import { select } from 'react-select-event';
 import { LocationModel } from 'datasources/asset/types/ListLocations.types';
+import { FeatureTogglesDefaults } from 'core/feature-toggle';
 
 const fakeSystems: SystemProperties[] = [
   {
@@ -35,7 +36,7 @@ const fakeLocations: LocationModel[] = [
 ];
 
 let assetDatasourceOptions = {
-  featureToggles: { ...AssetFeatureTogglesDefaults }
+  featureToggles: { ...FeatureTogglesDefaults }
 }
 
 class FakeAssetsSource extends ListAssetsDataSource {
@@ -61,18 +62,18 @@ const render = async (query: ListAssetsQuery) => {
 
 beforeEach(() => {
   assetDatasourceOptions = {
-    featureToggles: { ...AssetFeatureTogglesDefaults }
+    featureToggles: { ...FeatureTogglesDefaults }
   };
 })
 
 it('does not render when feature is not enabled', async () => {
-  assetDatasourceOptions.featureToggles.assetList = false;
+  localStorage.setItem('assetList', 'false');
   await render({} as ListAssetsQuery);
   await waitFor(() => expect(screen.getAllByRole('combobox').length).toBe(2));
 });
 
 it('renders the query builder', async () => {
-  assetDatasourceOptions.featureToggles.assetList = true;
+  localStorage.setItem('assetList', 'true');
   await render({} as ListAssetsQuery);
   await waitFor(() => expect(screen.getAllByText('Property').length).toBe(1));
   await waitFor(() => expect(screen.getAllByText('Operator').length).toBe(1));
@@ -223,7 +224,7 @@ it('should not display error message when user changes value to number between 0
 })
 
 it('renders the query builder with properties field', async () => {
-  assetDatasourceOptions.featureToggles.assetList = true;
+  localStorage.setItem('assetList', 'true');
   await render({} as ListAssetsQuery);
 
   await waitFor(() => {

--- a/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.tsx
+++ b/src/datasources/asset/components/variable-editor/AssetVariableQueryEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { QueryEditorProps } from "@grafana/data";
-import { AssetDataSourceOptions, AssetQuery, AssetQueryReturnType } from '../../../asset/types/types';
+import { AssetQuery, AssetQueryReturnType } from '../../../asset/types/types';
 import { AssetDataSource } from '../../AssetDataSource'
 import { FloatingError } from '../../../../core/errors';
 import { AssetQueryBuilder } from '../editors/list-assets/query-builder/AssetQueryBuilder';
@@ -12,8 +12,9 @@ import { takeErrorMessages } from 'datasources/asset/constants/constants';
 import { TAKE_LIMIT, tooltips } from 'datasources/asset/constants/ListAssets.constants';
 import { validateNumericInput } from 'core/utils';
 import { LocationModel } from 'datasources/asset/types/ListLocations.types';
+import { FeatureToggleDataSourceOptions } from 'core/feature-toggle';
 
-type Props = QueryEditorProps<AssetDataSource, AssetQuery, AssetDataSourceOptions>;
+type Props = QueryEditorProps<AssetDataSource, AssetQuery, FeatureToggleDataSourceOptions>;
 
 export function AssetVariableQueryEditor({ datasource, query, onChange }: Props) {
   query = datasource.patchListAssetQueryVariable(query);

--- a/src/datasources/asset/data-sources/AssetDataSourceBase.ts
+++ b/src/datasources/asset/data-sources/AssetDataSourceBase.ts
@@ -1,5 +1,5 @@
 import { DataFrameDTO, DataQueryRequest, TestDataSourceResponse } from "@grafana/data";
-import { AssetDataSourceOptions, AssetQuery } from "../types/types";
+import { AssetQuery } from "../types/types";
 import { DataSourceBase } from "../../../core/DataSourceBase";
 import { defaultOrderBy, defaultProjection } from "../../system/constants";
 import { SystemProperties } from "../../system/types";
@@ -10,8 +10,9 @@ import { QueryBuilderOperations } from "../../../core/query-builder.constants";
 import { AllFieldNames } from "../constants/constants";
 import { getVariableOptions } from "core/utils";
 import { ListLocationsResponse, LocationModel } from "../types/ListLocations.types";
+import { FeatureToggleDataSourceOptions, FeatureToggleNames, getFeatureFlagValue } from "core/feature-toggle";
 
-export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, AssetDataSourceOptions> {
+export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, FeatureToggleDataSourceOptions> {
   private systemsLoaded!: () => void;
   private locationsLoaded!: () => void;
   private workspacesLeaded!: () => void;
@@ -97,7 +98,7 @@ export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, Ass
   }
 
   private async loadLocations(): Promise<void> {
-    if (!this.instanceSettings.jsonData?.featureToggles?.locations) {
+    if (!getFeatureFlagValue(this.instanceSettings.jsonData, FeatureToggleNames.locations)) {
       this.locationsLoaded();
       return;
     }

--- a/src/datasources/asset/data-sources/AssetDataSourceBase.ts
+++ b/src/datasources/asset/data-sources/AssetDataSourceBase.ts
@@ -10,7 +10,7 @@ import { QueryBuilderOperations } from "../../../core/query-builder.constants";
 import { AllFieldNames, LocationFieldNames } from "../constants/constants";
 import { getVariableOptions } from "core/utils";
 import { ListLocationsResponse, LocationModel } from "../types/ListLocations.types";
-import { FeatureToggleDataSourceOptions, FeatureToggleNames, getFeatureFlagValue } from "core/feature-toggle";
+import { FeatureToggleDataSourceOptions } from "core/feature-toggle";
 
 export abstract class AssetDataSourceBase extends DataSourceBase<AssetQuery, FeatureToggleDataSourceOptions> {
   private systemsLoaded!: () => void;

--- a/src/datasources/asset/data-sources/asset-summary/AssetSummaryDataSource.ts
+++ b/src/datasources/asset/data-sources/asset-summary/AssetSummaryDataSource.ts
@@ -3,11 +3,13 @@ import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana
 
 import { AssetSummaryResponse } from 'datasources/asset/types/AssetSummaryQuery.types';
 import { AssetDataSourceBase } from '../AssetDataSourceBase';
-import { AssetDataSourceOptions, AssetQuery, AssetQueryType } from '../../types/types';
+import { AssetQuery, AssetQueryType } from '../../types/types';
 import { assetSummaryFields } from '../../constants/AssetSummaryQuery.constants';
+import { FeatureToggleDataSourceOptions } from 'core/feature-toggle';
+
 export class AssetSummaryDataSource extends AssetDataSourceBase {
     constructor(
-        readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,
+        readonly instanceSettings: DataSourceInstanceSettings<FeatureToggleDataSourceOptions>,
         readonly backendSrv: BackendSrv = getBackendSrv(),
         readonly templateSrv: TemplateSrv = getTemplateSrv()
     ) {

--- a/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.ts
+++ b/src/datasources/asset/data-sources/calibration-forecast/CalibrationForecastDataSource.ts
@@ -1,10 +1,11 @@
 import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings, FieldDTO, TestDataSourceResponse, DataLink } from '@grafana/data';
-import { AssetDataSourceOptions, AssetQuery, AssetQueryType, AssetType, AssetTypeOptions, BusType, BusTypeOptions } from '../../types/types';
+import { AssetQuery, AssetQueryType, AssetType, AssetTypeOptions, BusType, BusTypeOptions } from '../../types/types';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv, locationService } from '@grafana/runtime';
 import { AssetDataSourceBase } from '../AssetDataSourceBase';
 import { AssetCalibrationForecastKey, AssetCalibrationTimeBasedGroupByType, CalibrationForecastQuery, CalibrationForecastResponse, ColumnDescriptorType, FieldDTOWithDescriptor } from '../../types/CalibrationForecastQuery.types';
 import { transformComputedFieldsQuery } from '../../../../core/query-builder.utils';
 import { AssetModel, AssetsResponse } from '../../../asset-common/types';
+import { FeatureToggleDataSourceOptions } from 'core/feature-toggle';
 
 export class CalibrationForecastDataSource extends AssetDataSourceBase {
     private dependenciesLoadedPromise: Promise<void>;
@@ -16,7 +17,7 @@ export class CalibrationForecastDataSource extends AssetDataSourceBase {
     ]);
 
     constructor(
-        readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,
+        readonly instanceSettings: DataSourceInstanceSettings<FeatureToggleDataSourceOptions>,
         readonly backendSrv: BackendSrv = getBackendSrv(),
         readonly templateSrv: TemplateSrv = getTemplateSrv()
     ) {

--- a/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
+++ b/src/datasources/asset/data-sources/list-assets/ListAssetsDataSource.ts
@@ -1,19 +1,20 @@
 import { DataQueryRequest, DataFrameDTO, DataSourceInstanceSettings, FieldType } from '@grafana/data';
 import { BackendSrv, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { AssetDataSourceBase } from '../AssetDataSourceBase';
-import { AssetDataSourceOptions, AssetQuery, AssetQueryType } from '../../types/types';
+import { AssetQuery, AssetQueryType } from '../../types/types';
 import { AssetFilterProperties, AssetFilterPropertiesOption, ListAssetsQuery, OutputType, QueryListAssetRequestBody } from '../../types/ListAssets.types';
 import { AssetModel, AssetsResponse } from '../../../asset-common/types';
 import { transformComputedFieldsQuery } from '../../../../core/query-builder.utils';
 import { defaultListAssetsQuery, defaultListAssetsQueryForOldPannels } from 'datasources/asset/defaults';
 import { TAKE_LIMIT } from 'datasources/asset/constants/ListAssets.constants';
 import { getWorkspaceName } from 'core/utils';
+import { FeatureToggleDataSourceOptions, FeatureToggleNames, getFeatureFlagValue } from 'core/feature-toggle';
 
 export class ListAssetsDataSource extends AssetDataSourceBase {
   private dependenciesLoadedPromise: Promise<void>;
 
   constructor(
-    readonly instanceSettings: DataSourceInstanceSettings<AssetDataSourceOptions>,
+    readonly instanceSettings: DataSourceInstanceSettings<FeatureToggleDataSourceOptions>,
     readonly backendSrv: BackendSrv = getBackendSrv(),
     readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
@@ -120,7 +121,7 @@ export class ListAssetsDataSource extends AssetDataSourceBase {
 
   private getLocationFromAsset(asset: AssetModel): string {
     if (asset.location.physicalLocation) {
-      const isLocationsFeatureToggleEnabled = this.instanceSettings.jsonData?.featureToggles?.locations ?? false;
+      const isLocationsFeatureToggleEnabled = getFeatureFlagValue(this.instanceSettings.jsonData, FeatureToggleNames.locations);
 
       return isLocationsFeatureToggleEnabled
         ? this.locationCache.get(asset.location.physicalLocation)?.name || ''

--- a/src/datasources/asset/module.ts
+++ b/src/datasources/asset/module.ts
@@ -1,12 +1,12 @@
 import { DataSourcePlugin } from '@grafana/data';
 import { AssetDataSource } from './AssetDataSource';
 import { AssetQueryEditor } from './components/AssetQueryEditor';
-import { AssetDataSourceOptions, AssetQuery } from './types/types';
+import { AssetQuery } from './types/types';
 import { AssetConfigEditor } from './AssetConfigEditor';
-import { AssetVariableQueryEditor } from './components/variable-editor/AssetVariableQueryEditor'
+import { AssetVariableQueryEditor } from './components/variable-editor/AssetVariableQueryEditor';
+import { FeatureToggleDataSourceOptions } from 'core/feature-toggle';
 
-
-export const plugin = new DataSourcePlugin<AssetDataSource, AssetQuery, AssetDataSourceOptions>(AssetDataSource)
+export const plugin = new DataSourcePlugin<AssetDataSource, AssetQuery, FeatureToggleDataSourceOptions>(AssetDataSource)
   .setConfigEditor(AssetConfigEditor)
   .setQueryEditor(AssetQueryEditor)
   .setVariableQueryEditor(AssetVariableQueryEditor);

--- a/src/datasources/asset/types/types.ts
+++ b/src/datasources/asset/types/types.ts
@@ -1,6 +1,4 @@
-import { DataSourceJsonData } from "@grafana/data";
 import { DataQuery } from "@grafana/schema";
-
 
 export enum AssetQueryType {
   None = "",
@@ -11,24 +9,6 @@ export enum AssetQueryType {
 
 export interface AssetQuery extends DataQuery {
   type: AssetQueryType
-}
-
-export interface AssetFeatureToggles {
-  calibrationForecast: boolean;
-  assetList: boolean;
-  assetSummary: boolean;
-  locations: boolean;
-}
-
-export interface AssetDataSourceOptions extends DataSourceJsonData {
-  featureToggles: AssetFeatureToggles;
-}
-
-export const AssetFeatureTogglesDefaults: AssetFeatureToggles = {
-  assetList: true,
-  calibrationForecast: true,
-  assetSummary: true,
-  locations: false
 }
 
 export enum AssetQueryReturnType {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Innovation idea:
[Idea 3260573](https://dev.azure.com/ni/InnovationCentral/_workitems/edit/3260573): Grafana | Feature flag infra exploration for datasources

**Description**: Explore and come up with a proper feature flag infra implementation for Grafana, similar to that we have in SLE Angular Apps
 
Whenever a developer or tester wants to test a feature under development, the only way to do so is either from local development or they have to update the `featureToggle` from the helm file of [GrafanaAddons](https://dev.azure.com/ni/DevCentral/_git/Skyline?path=/GrafanaAddons/helm/values.yaml&version=GBusers/susan/dataframe-data-source&line=100&lineEnd=104&lineStartColumn=11&lineEndColumn=33&lineStyle=plain&_a=contents). So, this idea is to use `local storage` for the developers to toggle the feature.

This PR introduces a feature flag infrastructure to the SystemLink Grafana plugins, inspired by the SLE Angular Apps implementation.
I also experimented with the infrastructure with the Asset data source.

## 👩‍💻 Implementation

**feature-toggle.ts**
- Feature toggles are defined in the `FeatureToggleNames` enum, and `FeatureTogglesDefaults` are defined
- Created `getFeatureFlagValue` method to get the boolean value for a feature

Utilized the infrastructure in the Assets data source.
Updated README for more details.

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements.

Include automated test additions or modifications, manual testing done on a local build, and additional testing not covered by automatic pull request validation.
-->

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).