### PR TITLE
feat(dataframe): Add lookup options for properties and workspace

### DIFF
--- a/src/datasources/data-frame/types.ts
+++ b/src/datasources/data-frame/types.ts
@@ -30,6 +30,108 @@ export const DataFrameFeatureTogglesDefaults: DataFrameFeatureToggles = {
   queryByDataTableProperties: false,
 };
 
+export enum DataTableProperties {
+  Name = 'Name',
+  Id = 'Id',
+  RowCount = 'RowCount',
+  ColumnCount = 'ColumnCount',
+  CreatedAt = 'CreatedAt',
+  Workspace = 'Workspace',
+  MetadataModifiedAt = 'MetadataModifiedAt',
+  MetadataRevision = 'MetadataRevision',
+  RowsModifiedAt = 'RowsModifiedAt',
+  ColumnName = 'ColumnName',
+  ColumnDataType = 'ColumnDataType',
+  ColumnType = 'ColumnType',
+  ColumnProperties = 'ColumnProperties',
+  SupportsAppend = 'SupportsAppend',
+  Properties = 'Properties'
+}
+
+export enum DataTableProjections {
+  Name = 'NAME',
+  Id = 'ID',
+  RowCount = 'ROW_COUNT',
+  columnCount = 'COLUMN_COUNT',
+  CreatedAt = 'CREATED_AT',
+  Workspace = 'WORKSPACE',
+  MetadataModifiedAt = 'METADATA_MODIFIED_AT',
+  MetadataRevision = 'METADATA_REVISION',
+  RowsModifiedAt = 'ROWS_MODIFIED_AT',
+  ColumnName = 'COLUMN_NAME',
+  ColumnDataType = 'COLUMN_DATA_TYPE',
+  ColumnType = 'COLUMN_COLUMN_TYPE',
+  ColumnProperties = 'COLUMN_PROPERTIES',
+  SupportsAppend = 'SUPPORTS_APPEND',
+  Properties = 'PROPERTIES'
+}
+
+export const DataTableProjectionLabelLookup: Record<DataTableProperties, {
+  label: string,
+  projection: readonly DataTableProjections[]
+}> = {
+  [DataTableProperties.Name]: {
+    label: 'Data table name',
+    projection: [DataTableProjections.Name],
+  },
+  [DataTableProperties.Id]: {
+    label: 'Data table ID',
+    projection: [DataTableProjections.Id],
+  },
+  [DataTableProperties.RowCount]: {
+    label: 'Number of rows',
+    projection: [DataTableProjections.RowCount],
+  },
+  [DataTableProperties.ColumnCount]: {
+    label: 'Number of columns',
+    projection: [DataTableProjections.columnCount],
+  },
+  [DataTableProperties.CreatedAt]: {
+    label: 'Created at',
+    projection: [DataTableProjections.CreatedAt],
+  },
+  [DataTableProperties.Workspace]: {
+    label: 'Workspace',
+    projection: [DataTableProjections.Workspace],
+  },
+  [DataTableProperties.MetadataModifiedAt]: {
+    label: 'Metadata modified at',
+    projection: [DataTableProjections.MetadataModifiedAt],
+  },
+  [DataTableProperties.MetadataRevision]: {
+    label: 'Metadata revision',
+    projection: [DataTableProjections.MetadataRevision],
+  },
+  [DataTableProperties.RowsModifiedAt]: {
+    label: 'Rows modified at',
+    projection: [DataTableProjections.RowsModifiedAt],
+  },
+  [DataTableProperties.ColumnName]: {
+    label: 'Column name',
+    projection: [DataTableProjections.ColumnName],
+  },
+  [DataTableProperties.ColumnDataType]: {
+    label: 'Column data type',
+    projection: [DataTableProjections.ColumnDataType],
+  },
+  [DataTableProperties.ColumnType]: {
+    label: 'Column type',
+    projection: [DataTableProjections.ColumnType],
+  },
+  [DataTableProperties.ColumnProperties]: {
+    label: 'Column properties',
+    projection: [DataTableProjections.ColumnProperties],
+  },
+  [DataTableProperties.SupportsAppend]: {
+    label: 'Supports append',
+    projection: [DataTableProjections.SupportsAppend],
+  },
+  [DataTableProperties.Properties]: {
+    label: 'Properties',
+    projection: [DataTableProjections.Properties],
+  },
+}
+
 export type ValidDataFrameQuery = DataFrameQuery & Required<Omit<DataFrameQuery, keyof DataQuery>>;
 
 export type ColumnDataType = 'BOOL' | 'INT32' | 'INT64' | 'FLOAT32' | 'FLOAT64' | 'STRING' | 'TIMESTAMP';


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR holds the changes to add lookup options for workspace and properties fields
[Task 3407289](https://dev.azure.com/ni/DevCentral/_workitems/edit/3407289): Populate properties and workspace options in query builder

## 👩‍💻 Implementation

- Added constants for projection
- Added methods in the datasource for loading workspaces.
- Updated the component to query workspace when the datsource changes

## 🧪 Testing

Added unit tests for the added funtionalities.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).