### PR TITLE
fix(systems): Fix flaky query builder value selection and improve variable dropdown assertions

### DIFF
--- a/acceptance-tests/page-objects/dashboard/components/query-builder/query-builder-base.component.ts
+++ b/acceptance-tests/page-objects/dashboard/components/query-builder/query-builder-base.component.ts
@@ -1,5 +1,6 @@
 import { Page, Locator } from '@playwright/test';
 import { pressEnter } from '../../../../utils/keyboard-utilities';
+import { time } from 'console';
 
 export class QueryBuilderBaseComponent {
     protected readonly page: Page;
@@ -51,11 +52,11 @@ export class QueryBuilderBaseComponent {
     }
 
     public async addFilterGroup(operator: string): Promise<void> {
-        await this.addGroupFilterButton.scrollIntoViewIfNeeded();
+        await this.addGroupFilterButton.evaluate(el => el.scrollIntoView({ block: 'center' }));
         await this.addGroupFilterButton.dispatchEvent('pointerdown', { bubbles: true, isPrimary: true });
         const menuButton = operator.toLowerCase() === 'and' ? this.andFilterGroupButton : this.orFilterGroupButton;
         await menuButton.waitFor({ state: 'visible' });
-        await menuButton.scrollIntoViewIfNeeded();
+        await menuButton.evaluate(el => el.scrollIntoView({ block: 'center' }));
         await menuButton.click({ force: true });
         await this.queryBuilderPropertyField.last().waitFor({ state: 'visible' });
     }

--- a/acceptance-tests/page-objects/dashboard/components/query-builder/system-query-builder.component.ts
+++ b/acceptance-tests/page-objects/dashboard/components/query-builder/system-query-builder.component.ts
@@ -15,9 +15,10 @@ export class SystemsQueryBuilderComponent extends QueryBuilderBaseComponent {
             await this.page.keyboard.type(value);
             const option = this.page.locator(`[data-label="${value}"]`);
             await option.waitFor({ state: 'visible' });
-            await option.click({ force: true });
+            await option.evaluate(el => (el as HTMLElement).click());
         } else {
             await this.queryBuilderValueField.last().click();
+            await this.page.locator('input:focus').waitFor({ state: 'visible' });
             await this.page.keyboard.type(value);
         }
     }

--- a/acceptance-tests/page-objects/dashboard/components/table.component.ts
+++ b/acceptance-tests/page-objects/dashboard/components/table.component.ts
@@ -11,16 +11,16 @@ export class Table {
         return this.page.locator('.smart-filter-group-condition[role="group"]').nth(index);
     }
 
-    public get getTable(): Locator {
+    public get getTableBody(): Locator {
         return this.page.getByTestId('data-testid table body');
     }
 
     public get tableRow(): Locator {
-        return this.getTable.getByRole('row');
+        return this.getTableBody.getByRole('row');
     }
 
     public cellValue(value: string): Locator {
-        return this.getTable.getByRole('cell', { name: value });
+        return this.getTableBody.getByRole('cell', { name: value });
     }
 
     public async getTableRowCount(): Promise<number> {

--- a/acceptance-tests/page-objects/dashboard/dashboard.pageobject.ts
+++ b/acceptance-tests/page-objects/dashboard/dashboard.pageobject.ts
@@ -28,6 +28,10 @@ export class DashboardPage {
         return this.page.getByTestId(`data-testid Dashboard template variables Variable Value DropDown value link text ${variableName}`);
     }
 
+    public allVariableDropdownOptions(variableName: string): Locator {
+        return this.page.locator(`#options-${variableName} li`);
+    }
+
     public variableDropdownOption(optionName: string): Locator {
         return this.page.getByRole('checkbox', { name: optionName, exact: true });
     }

--- a/acceptance-tests/tests/datasources/asset/asset-summary/asset-summary.spec.ts
+++ b/acceptance-tests/tests/datasources/asset/asset-summary/asset-summary.spec.ts
@@ -40,7 +40,7 @@ test.describe('Asset Summary Table', () => {
                 dashboard.panel.assetQueryEditor.selectQueryType('Asset Summary')
             ]);
 
-            await dashboard.panel.table.getTable.waitFor({ timeout: timeOutPeriod });
+            await dashboard.panel.table.getTableBody.waitFor({ timeout: timeOutPeriod });
 
             expect(assetSummaryResponse).toBeDefined();
             expect(await dashboard.panel.table.getTableRowCount()).toBe(1);

--- a/acceptance-tests/tests/datasources/asset/calibration-forecast/calibration-forecast.spec.ts
+++ b/acceptance-tests/tests/datasources/asset/calibration-forecast/calibration-forecast.spec.ts
@@ -49,7 +49,7 @@ test.describe('Calibration Forecast', () => {
             ]);
 
             await dashboard.panel.toolbar.switchToTableView();
-            await dashboard.panel.table.getTable.waitFor({ timeout: timeOutPeriod });
+            await dashboard.panel.table.getTableBody.waitFor({ timeout: timeOutPeriod });
 
             expect(forecastResponse).toBeDefined();
             expect(forecastResponse.calibrationForecast.columns).toBeDefined();

--- a/acceptance-tests/tests/datasources/asset/global-variable-integration/asset-ds.minion-id-return-type.spec.ts
+++ b/acceptance-tests/tests/datasources/asset/global-variable-integration/asset-ds.minion-id-return-type.spec.ts
@@ -58,7 +58,7 @@ test.describe('Asset data source with minion id return type', () => {
         });
 
         test('should verify that table data changes as the variable value changes', async () => {
-            await dashboard.panel.table.getTable.first().waitFor({ state: 'visible', timeout: timeOutPeriod });
+            await dashboard.panel.table.getTableBody.first().waitFor({ state: 'visible', timeout: timeOutPeriod });
 
             let rowCount = await dashboard.panel.table.getTableRowCount();
 

--- a/acceptance-tests/tests/datasources/asset/global-variable-integration/asset-ds.scan-code-return-type.spec.ts
+++ b/acceptance-tests/tests/datasources/asset/global-variable-integration/asset-ds.scan-code-return-type.spec.ts
@@ -65,7 +65,7 @@ test.describe('Asset data source with scan code return type', () => {
         });
 
         test('should verify that table data changes as the variable value changes', async () => {
-            await dashboard.panel.table.getTable.first().waitFor({ state: 'visible', timeout: timeOutPeriod });
+            await dashboard.panel.table.getTableBody.first().waitFor({ state: 'visible', timeout: timeOutPeriod });
 
             let rowCount = await dashboard.panel.table.getTableRowCount();
 

--- a/acceptance-tests/tests/datasources/system/global-variable-integration/system-ds.minion-id-return-type.spec.ts
+++ b/acceptance-tests/tests/datasources/system/global-variable-integration/system-ds.minion-id-return-type.spec.ts
@@ -60,7 +60,7 @@ test.describe('Systems data source with minion id return type', () => {
         });
 
         test('should verify that table data changes as the variable value changes', async () => {
-            await dashboard.panel.table.getTable.first().waitFor({ state: 'visible', timeout: timeOutPeriod });
+            await dashboard.panel.table.getTableBody.first().waitFor({ state: 'visible', timeout: timeOutPeriod });
 
             let rowCount = await dashboard.panel.table.getTableRowCount();
 

--- a/acceptance-tests/tests/datasources/system/global-variable-integration/system-ds.scan-code-return-type.spec.ts
+++ b/acceptance-tests/tests/datasources/system/global-variable-integration/system-ds.scan-code-return-type.spec.ts
@@ -81,7 +81,7 @@ test.describe('Systems data source with scan code return type', () => {
         });
 
         test('should verify that table data changes as the variable value changes', async () => {
-            await dashboard.panel.table.getTable.first().waitFor({ state: 'visible', timeout: timeOutPeriod });
+            await dashboard.panel.table.getTableBody.first().waitFor({ state: 'visible', timeout: timeOutPeriod });
 
             let rowCount = await dashboard.panel.table.getTableRowCount();
 

--- a/acceptance-tests/tests/datasources/system/global-variable-integration/system-ds.scan-code-return-type.spec.ts
+++ b/acceptance-tests/tests/datasources/system/global-variable-integration/system-ds.scan-code-return-type.spec.ts
@@ -53,6 +53,7 @@ test.describe('Systems data source with scan code return type', () => {
             await dashboard.settings.goBackToDashboardPage();
 
             await dashboard.variableDropdown('System-1').click();
+            await expect(dashboard.allVariableDropdownOptions('scanCode')).toHaveCount(3);
             await expect(dashboard.variableDropdownOption('System-1')).toBeVisible();
             await expect(dashboard.variableDropdownOption('System-6')).toBeVisible();
             await expect(dashboard.variableDropdownOption('System-8')).toBeVisible();

--- a/acceptance-tests/tests/datasources/system/system-summary/system-summary.spec.ts
+++ b/acceptance-tests/tests/datasources/system/system-summary/system-summary.spec.ts
@@ -40,7 +40,7 @@ test.describe('System Summary Table', () => {
                 dashboard.panel.toolbar.refreshButton.click()
             ]);
 
-            await dashboard.panel.table.getTable.waitFor({ timeout: timeOutPeriod });
+            await dashboard.panel.table.getTableBody.waitFor({ timeout: timeOutPeriod });
 
             expect(systemSummaryResponse).toBeDefined();
             expect(await dashboard.panel.table.getTableRowCount()).toBe(1);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
Fix flaky query builder value selection and improve variable dropdown assertions:
- click({ force: true }) uses coordinates that can land on a wrong option when the dropdown is clipped. evaluate(el => el.click()) is coordinate-free
- the missing input:focus wait caused dropped characters. 
- toHaveCount catches cases where the filter returns all results instead of the expected subset.

[Task 3813278](https://dev.azure.com/ni/DevCentral/_workitems/edit/3813278): update selectQueryBuilderValueOption to be more reliable

## 👩‍💻 Implementation
Replace click({ force: true }) with evaluate(el => el.click()) for dropdown option selection, add input:focuswait before typing in plain text fields, and add a toHaveCount assertion for the variable dropdown.

## 🧪 Testing

Verified all acceptance tests pass locally by running the affected test files.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).