### PR TITLE
fix(tags): Add "tag path" field to the result table

### DIFF
--- a/src/datasources/tag/CurrentQueryHandler.ts
+++ b/src/datasources/tag/CurrentQueryHandler.ts
@@ -5,15 +5,19 @@ import { Workspace } from "core/types";
 import { Observable, of } from "rxjs";
 
 export class CurrentQueryHandler extends QueryHandler {
-    handleQuery$(tagsWithValues: TagWithValue[], result: DataFrameDTO, _workspaces: Workspace[], _range: TimeRange, _maxDataPoints: number | undefined, queryProperties: boolean): Observable<DataFrameDTO> {
-        return of(this.handleCurrentQuery(queryProperties, tagsWithValues, result));
+    handleQuery$(tagsWithValues: TagWithValue[], result: DataFrameDTO, _workspaces: Workspace[], _range: TimeRange, _maxDataPoints: number | undefined, queryProperties: boolean, queryShowTagPath: boolean): Observable<DataFrameDTO> {
+        return of(this.handleCurrentQuery(queryProperties, queryShowTagPath, tagsWithValues, result));
     }
 
-    private handleCurrentQuery(queryProperties: boolean, tagsWithValues: TagWithValue[], result: DataFrameDTO): DataFrameDTO {
+    private handleCurrentQuery(queryProperties: boolean, queryShowTagPath: boolean, tagsWithValues: TagWithValue[], result: DataFrameDTO): DataFrameDTO {
         this.addDefaultFieldsToResult(result, tagsWithValues);
 
         if (queryProperties) {
             this.addPropertiesFieldsToResult(result, tagsWithValues);
+        }
+
+        if (queryShowTagPath) {
+            this.addTagPathFieldToResult(result, tagsWithValues);
         }
 
         return result;
@@ -63,6 +67,13 @@ export class CurrentQueryHandler extends QueryHandler {
         });
 
         return props;
+    }
+
+    private addTagPathFieldToResult(result: DataFrameDTO, tagsWithValues: TagWithValue[]): void {
+        result.fields.push({
+            name: 'tag path',
+            values: tagsWithValues.map(({ tag }: TagWithValue) => tag.path)
+        });
     }
 }
 

--- a/src/datasources/tag/HistoricalQueryHandler.ts
+++ b/src/datasources/tag/HistoricalQueryHandler.ts
@@ -13,7 +13,7 @@ export class HistoricalQueryHandler extends QueryHandler {
         super();
     }
 
-    handleQuery$(tagsWithValues: TagWithValue[], result: DataFrameDTO, workspaces: Workspace[], range: TimeRange, maxDataPoints: number | undefined, _queryProperties: boolean): Observable<DataFrameDTO> {
+    handleQuery$(tagsWithValues: TagWithValue[], result: DataFrameDTO, workspaces: Workspace[], range: TimeRange, maxDataPoints: number | undefined, _queryProperties: boolean, _queryShowTagPath: boolean): Observable<DataFrameDTO> {
         return this.handleHistoricalQuery$(tagsWithValues, workspaces, range, maxDataPoints, result.refId || '');
     }
 
@@ -105,7 +105,7 @@ export class HistoricalQueryHandler extends QueryHandler {
         return forkJoin(observables).pipe(
             map(responses => {
                 const tagsDecimatedHistory: Record<string, TypeAndValues> = {};
-                
+
                 for (const { workspace, results } of responses) {
                     for (const path in results) {
                         const prefixedPath =
@@ -116,7 +116,7 @@ export class HistoricalQueryHandler extends QueryHandler {
                         tagsDecimatedHistory[prefixedPath] = results[path];
                     }
                 }
-                
+
                 return tagsDecimatedHistory;
             })
         );

--- a/src/datasources/tag/TagDataSource.test.ts
+++ b/src/datasources/tag/TagDataSource.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
   [ds, backendSrv, templateSrv] = setupDataSource(TagDataSource, () => tagOptions);
 });
 
-const buildQuery = getQueryBuilder<TagQuery>()({ type: TagQueryType.Current, workspace: '', properties: false });
+const buildQuery = getQueryBuilder<TagQuery>()({ type: TagQueryType.Current, workspace: '', properties: false, showTagPath: false });
 mockTimers();
 
 
@@ -140,7 +140,7 @@ describe('queries', () => {
       .calledWith(requestMatching({ data: { paths: ['my.tag1'], workspaces: ["*"] } }))
       .mockReturnValue(createQueryTagsResponse([{ tag: { path: 'my.tag1' } }]));
     backendSrv.fetch
-      .calledWith(requestMatching({ data: { paths: ['my.tag2'], workspaces: ["*"] }}))
+      .calledWith(requestMatching({ data: { paths: ['my.tag2'], workspaces: ["*"] } }))
       .mockReturnValue(createQueryTagsResponse([{ tag: { path: 'my.tag2' }, current: { value: { value: '41.3' } } }]));
 
     const result = await firstValueFrom(ds.query(buildQuery({ path: 'my.tag1' }, { path: '' }, { path: 'my.tag2' })));
@@ -497,6 +497,17 @@ describe('queries', () => {
     expect(result.data).toMatchSnapshot();
   });
 
+  test('appends tag path to query result when showTagPath is enabled', async () => {
+    backendSrv.fetch.mockReturnValue(createQueryTagsResponse([
+      { tag: { path: 'my.1.tag', properties: { displayName: 'Tag One' } } },
+      { tag: { path: 'my.2.tag' }, current: { value: { value: '41.3' } } }
+    ]));
+
+    const result = await firstValueFrom(ds.query(buildQuery({ path: 'my.*.tag', showTagPath: true })));
+
+    expect(result.data).toMatchSnapshot();
+  });
+
   test('supports legacy tag service property "workspace_id"', async () => {
     backendSrv.fetch
       .mockReturnValueOnce(
@@ -550,10 +561,10 @@ describe('parseMultiSelectValues', () => {
 
   test('multiple targets - skips invalid queries', async () => {
     backendSrv.fetch
-      .calledWith(requestMatching({  data: { paths: ['my.tag1'], workspaces: ["*"] } }))
+      .calledWith(requestMatching({ data: { paths: ['my.tag1'], workspaces: ["*"] } }))
       .mockReturnValue(createQueryTagsResponse([{ tag: { path: 'my.tag1' } }]));
     backendSrv.fetch
-      .calledWith(requestMatching({  data: { paths: ['my.tag2'], workspaces: ["*"] } }))
+      .calledWith(requestMatching({ data: { paths: ['my.tag2'], workspaces: ["*"] } }))
       .mockReturnValue(createQueryTagsResponse([{ tag: { path: 'my.tag2' }, current: { value: { value: '41.3' } } }]));
 
     const result = await firstValueFrom(ds.query(buildQuery({ path: 'my.tag1' }, { path: '' }, { path: 'my.tag2' })));

--- a/src/datasources/tag/TagDataSource.ts
+++ b/src/datasources/tag/TagDataSource.ts
@@ -24,6 +24,7 @@ export class TagDataSource extends DataSourceBase<TagQuery, TagDataSourceOptions
     path: '',
     workspace: '',
     properties: false,
+    showTagPath: false,
   };
 
   private readonly tagUrl = this.instanceSettings.url + '/nitag/v2';
@@ -51,7 +52,7 @@ export class TagDataSource extends DataSourceBase<TagQuery, TagDataSourceOptions
       switchMap(([tagsWithValues, workspaces]) => {
         const result: DataFrameDTO = { refId: query.refId, fields: [] };
 
-        return this.queryHandlerFactory.createQueryHandler(query.type).handleQuery$(tagsWithValues, result, workspaces, range, maxDataPoints, query.properties);
+        return this.queryHandlerFactory.createQueryHandler(query.type).handleQuery$(tagsWithValues, result, workspaces, range, maxDataPoints, query.properties, query.showTagPath);
       }
       ))
   }

--- a/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
+++ b/src/datasources/tag/__snapshots__/TagDataSource.test.ts.snap
@@ -493,6 +493,48 @@ exports[`queries add workspace prefix only when a tag with the same path exists 
 ]
 `;
 
+exports[`queries appends tag path to query result when showTagPath is enabled 1`] = `
+[
+  {
+    "fields": [
+      {
+        "name": "name",
+        "values": [
+          "Tag One",
+          "my.2.tag",
+        ],
+      },
+      {
+        "name": "value",
+        "values": [
+          3.14,
+          41.3,
+        ],
+      },
+      {
+        "config": {
+          "unit": "dateTimeFromNow",
+        },
+        "name": "updated",
+        "type": "time",
+        "values": [
+          "2023-10-04T00:00:00.000000Z",
+          "2023-10-04T00:00:00.000000Z",
+        ],
+      },
+      {
+        "name": "tag path",
+        "values": [
+          "my.1.tag",
+          "my.2.tag",
+        ],
+      },
+    ],
+    "refId": "A",
+  },
+]
+`;
+
 exports[`queries appends tag properties to query result 1`] = `
 [
   {

--- a/src/datasources/tag/components/TagQueryEditor.test.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.test.tsx
@@ -16,7 +16,7 @@ it('renders with query defaults', async () => {
   expect(screen.getByRole('radio', { name: 'Current' })).toBeChecked();
   expect(screen.getByLabelText('Tag path')).not.toHaveValue();
   expect(screen.getByRole('combobox')).toHaveAccessibleDescription('Any workspace');
-  expect(screen.getByLabelText('Properties')).not.toBeChecked();
+  expect(screen.getByLabelText('Show properties')).not.toBeChecked();
   expect(screen.getByLabelText('Show tag path')).not.toBeChecked();
 });
 
@@ -33,7 +33,7 @@ it('renders with initial query and updates when user makes changes', async () =>
 
   // Users changes query type
   await userEvent.click(screen.getByRole('radio', { name: 'Current' }));
-  expect(screen.queryByLabelText('Properties')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Show properties')).toBeInTheDocument();
   expect(screen.queryByLabelText('Show tag path')).toBeInTheDocument();
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ type: TagQueryType.Current }));
 
@@ -46,7 +46,7 @@ it('renders with initial query and updates when user makes changes', async () =>
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ workspace: '2' }));
 
   // User toggles properties
-  await userEvent.click(screen.getByLabelText('Properties'));
+  await userEvent.click(screen.getByLabelText('Show properties'));
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ properties: false }));
 
   // User toggles show tag path

--- a/src/datasources/tag/components/TagQueryEditor.test.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.test.tsx
@@ -16,22 +16,25 @@ it('renders with query defaults', async () => {
   expect(screen.getByRole('radio', { name: 'Current' })).toBeChecked();
   expect(screen.getByLabelText('Tag path')).not.toHaveValue();
   expect(screen.getByRole('combobox')).toHaveAccessibleDescription('Any workspace');
-  expect(screen.getByRole('switch')).not.toBeChecked();
+  expect(screen.getByLabelText('Properties')).not.toBeChecked();
+  expect(screen.getByLabelText('Show tag path')).not.toBeChecked();
 });
 
 it('renders with initial query and updates when user makes changes', async () => {
-  const [onChange] = render({ type: TagQueryType.History, path: 'my.tag', workspace: '1', properties: true });
+  const [onChange] = render({ type: TagQueryType.History, path: 'my.tag', workspace: '1', properties: true, showTagPath: true });
   await workspacesLoaded();
 
   // Renders saved query
   expect(screen.getByRole('radio', { name: 'History' })).toBeChecked();
   expect(screen.getByLabelText('Tag path')).toHaveValue('my.tag');
   expect(screen.getByText('Default workspace')).toBeInTheDocument();
-  expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Properties')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Show tag path')).not.toBeInTheDocument();
 
   // Users changes query type
   await userEvent.click(screen.getByRole('radio', { name: 'Current' }));
-  expect(screen.queryByRole('switch')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Properties')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Show tag path')).toBeInTheDocument();
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ type: TagQueryType.Current }));
 
   // User types in new tag path
@@ -43,6 +46,10 @@ it('renders with initial query and updates when user makes changes', async () =>
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ workspace: '2' }));
 
   // User toggles properties
-  await userEvent.click(screen.getByRole('switch'));
+  await userEvent.click(screen.getByLabelText('Properties'));
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ properties: false }));
+
+  // User toggles show tag path
+  await userEvent.click(screen.getByLabelText('Show tag path'));
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ showTagPath: false }));
 });

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -32,13 +32,18 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
     onRunQuery();
   };
 
+  const onShowTagPathChange = () => {
+    onChange({ ...query, showTagPath: !query.showTagPath });
+    onRunQuery();
+  };
+
   return (
     <>
       <InlineField label="Query type" labelWidth={14} tooltip={tooltips.queryType}>
-        <RadioButtonGroup options={enumToOptions(TagQueryType)} value={query.type} onChange={onTypeChange}/>
+        <RadioButtonGroup options={enumToOptions(TagQueryType)} value={query.type} onChange={onTypeChange} />
       </InlineField>
       <InlineField label="Tag path" labelWidth={14} tooltip={tooltips.tagPath}>
-        <AutoSizeInput minWidth={20} maxWidth={80} defaultValue={query.path} onCommitChange={onPathChange}/>
+        <AutoSizeInput minWidth={20} maxWidth={80} defaultValue={query.path} onCommitChange={onPathChange} />
       </InlineField>
       <InlineField label="Workspace" labelWidth={14} tooltip={tooltips.workspace}>
         <Select
@@ -51,9 +56,14 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
         />
       </InlineField>
       {query.type === TagQueryType.Current && (
-        <InlineField label="Properties" labelWidth={14} tooltip={tooltips.properties}>
-          <InlineSwitch onChange={onPropertiesChange} value={query.properties}/>
-        </InlineField>
+        <>
+          <InlineField label="Properties" labelWidth={14} tooltip={tooltips.properties}>
+            <InlineSwitch onChange={onPropertiesChange} value={query.properties} />
+          </InlineField>
+          <InlineField label="Show tag path" labelWidth={14} tooltip={tooltips.showTagPath}>
+            <InlineSwitch onChange={onShowTagPathChange} value={query.showTagPath} />
+          </InlineField>
+        </>
       )}
     </>
   );
@@ -70,4 +80,5 @@ const tooltips = {
               finds the most recently updated tag in any workspace.`,
 
   properties: `If enabled, include the tag properties in the query result.`,
+  showTagPath: `If enabled, display the tag path in the query result.`,
 };

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -39,13 +39,13 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
 
   return (
     <>
-      <InlineField label="Query type" labelWidth={16} tooltip={tooltips.queryType}>
+      <InlineField label="Query type" labelWidth={18} tooltip={tooltips.queryType}>
         <RadioButtonGroup options={enumToOptions(TagQueryType)} value={query.type} onChange={onTypeChange} />
       </InlineField>
-      <InlineField label="Tag path" labelWidth={16} tooltip={tooltips.tagPath}>
+      <InlineField label="Tag path" labelWidth={18} tooltip={tooltips.tagPath}>
         <AutoSizeInput minWidth={20} maxWidth={80} defaultValue={query.path} onCommitChange={onPathChange} />
       </InlineField>
-      <InlineField label="Workspace" labelWidth={16} tooltip={tooltips.workspace}>
+      <InlineField label="Workspace" labelWidth={18} tooltip={tooltips.workspace}>
         <Select
           isClearable
           isLoading={workspaces.loading}
@@ -57,10 +57,10 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
       </InlineField>
       {query.type === TagQueryType.Current && (
         <>
-          <InlineField label="Show properties" labelWidth={16} tooltip={tooltips.properties}>
+          <InlineField label="Show properties" labelWidth={18} tooltip={tooltips.properties}>
             <InlineSwitch onChange={onPropertiesChange} value={query.properties} />
           </InlineField>
-          <InlineField label="Show tag path" labelWidth={16} tooltip={tooltips.showTagPath}>
+          <InlineField label="Show tag path" labelWidth={18} tooltip={tooltips.showTagPath}>
             <InlineSwitch onChange={onShowTagPathChange} value={query.showTagPath} />
           </InlineField>
         </>

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -39,13 +39,13 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
 
   return (
     <>
-      <InlineField label="Query type" labelWidth={14} tooltip={tooltips.queryType}>
+      <InlineField label="Query type" labelWidth={16} tooltip={tooltips.queryType}>
         <RadioButtonGroup options={enumToOptions(TagQueryType)} value={query.type} onChange={onTypeChange} />
       </InlineField>
-      <InlineField label="Tag path" labelWidth={14} tooltip={tooltips.tagPath}>
+      <InlineField label="Tag path" labelWidth={16} tooltip={tooltips.tagPath}>
         <AutoSizeInput minWidth={20} maxWidth={80} defaultValue={query.path} onCommitChange={onPathChange} />
       </InlineField>
-      <InlineField label="Workspace" labelWidth={14} tooltip={tooltips.workspace}>
+      <InlineField label="Workspace" labelWidth={16} tooltip={tooltips.workspace}>
         <Select
           isClearable
           isLoading={workspaces.loading}
@@ -57,10 +57,10 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
       </InlineField>
       {query.type === TagQueryType.Current && (
         <>
-          <InlineField label="Properties" labelWidth={14} tooltip={tooltips.properties}>
+          <InlineField label="Properties" labelWidth={16} tooltip={tooltips.properties}>
             <InlineSwitch onChange={onPropertiesChange} value={query.properties} />
           </InlineField>
-          <InlineField label="Show tag path" labelWidth={14} tooltip={tooltips.showTagPath}>
+          <InlineField label="Show tag path" labelWidth={16} tooltip={tooltips.showTagPath}>
             <InlineSwitch onChange={onShowTagPathChange} value={query.showTagPath} />
           </InlineField>
         </>
@@ -80,5 +80,5 @@ const tooltips = {
               finds the most recently updated tag in any workspace.`,
 
   properties: `If enabled, include the tag properties in the query result.`,
-  showTagPath: `If enabled, display the tag path in the query result.`,
+  showTagPath: `If enabled, include the tag path in the query result.`,
 };

--- a/src/datasources/tag/components/TagQueryEditor.tsx
+++ b/src/datasources/tag/components/TagQueryEditor.tsx
@@ -57,7 +57,7 @@ export function TagQueryEditor({ query, onChange, onRunQuery, datasource }: Prop
       </InlineField>
       {query.type === TagQueryType.Current && (
         <>
-          <InlineField label="Properties" labelWidth={16} tooltip={tooltips.properties}>
+          <InlineField label="Show properties" labelWidth={16} tooltip={tooltips.properties}>
             <InlineSwitch onChange={onPropertiesChange} value={query.properties} />
           </InlineField>
           <InlineField label="Show tag path" labelWidth={16} tooltip={tooltips.showTagPath}>

--- a/src/datasources/tag/types.ts
+++ b/src/datasources/tag/types.ts
@@ -13,6 +13,7 @@ export interface TagQuery extends DataQuery {
   path: string;
   workspace: string;
   properties: boolean;
+  showTagPath: boolean;
 }
 
 interface TagWithValueBase {
@@ -93,5 +94,5 @@ export const TagFeatureTogglesDefaults: TagFeatureToggles = {
 export type PostFn = <T>(url: string, body: Record<string, any>) => Observable<T>;
 
 export abstract class QueryHandler {
-  abstract handleQuery$(tagsWithValues: TagWithValue[], result: DataFrameDTO, workspaces: Workspace[], range: TimeRange, maxDataPoints: number | undefined, queryProperties: boolean): Observable<DataFrameDTO>;
+  abstract handleQuery$(tagsWithValues: TagWithValue[], result: DataFrameDTO, workspaces: Workspace[], range: TimeRange, maxDataPoints: number | undefined, queryProperties: boolean, queryShowTagPath: boolean): Observable<DataFrameDTO>;
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add a "Show tag path" toggle to the Tag datasource (Current query type) so users can include the tag path as a separate column in query results, similar to the existing Properties switch.

## 👩‍💻 Implementation

Added a showTagPath: boolean field to TagQuery. When enabled, CurrentQueryHandler appends a path field to the result data frame with each tag's raw path. The switch is hidden for History queries (same as Properties). Backwards compatible as old dashboards default to false via prepareQuery.

## 🧪 Testing

Unit tests:
-  check that the path field appears in results when enabled
- verifies the "Show path" switch renders/hides with query type changes and fires onChange with the correct value.
- Snapshots updated to reflect the new field.

<img width="1909" height="934" alt="tagsBug" src="https://github.com/user-attachments/assets/8c3bfcf2-d18c-477d-a0d7-aea2b16c4297" />


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).