### PR TITLE
fix(dataframe): Fix clipped dropdowns in Query configurations collapse

### DIFF
--- a/src/datasources/data-frame/components/v2/DataFrameQueryEditorV2.scss
+++ b/src/datasources/data-frame/components/v2/DataFrameQueryEditorV2.scss
@@ -1,3 +1,9 @@
+.query-configuration-section {
+    [class*='collapse__body'] {
+        overflow: visible;
+    }
+}
+
 .property-selection-section {
     [role='alert'] {
         width: 524px;

--- a/src/datasources/data-frame/components/v2/DataFrameQueryEditorV2.test.tsx
+++ b/src/datasources/data-frame/components/v2/DataFrameQueryEditorV2.test.tsx
@@ -4218,5 +4218,16 @@ describe("DataFrameQueryEditorV2", () => {
         });
     });
 
+    describe("query configuration section", () => {
+        it("should render a collapse element with a class containing 'collapse__body'", () => {
+            renderComponent();
+
+            const queryConfigSection = document.querySelector('.query-configuration-section');
+            expect(queryConfigSection).toBeInTheDocument();
+
+            const collapseBody = queryConfigSection!.querySelector('[class*="collapse__body"]');
+            expect(collapseBody).not.toBeNull();
+        });
+    });
 });
 

--- a/src/datasources/data-frame/components/v2/DataFrameQueryEditorV2.test.tsx
+++ b/src/datasources/data-frame/components/v2/DataFrameQueryEditorV2.test.tsx
@@ -4220,10 +4220,10 @@ describe("DataFrameQueryEditorV2", () => {
 
     describe("query configuration section", () => {
         it("should render a collapse element with a class containing 'collapse__body'", () => {
-            renderComponent();
+            const { renderResult } = renderComponent();
 
-            const queryConfigSection = document.querySelector('.query-configuration-section');
-            expect(queryConfigSection).toBeInTheDocument();
+            const queryConfigSection = renderResult.container.querySelector('.query-configuration-section');
+            expect(queryConfigSection).not.toBeNull();
 
             const collapseBody = queryConfigSection!.querySelector('[class*="collapse__body"]');
             expect(collapseBody).not.toBeNull();

--- a/src/datasources/data-frame/components/v2/DataFrameQueryEditorV2.tsx
+++ b/src/datasources/data-frame/components/v2/DataFrameQueryEditorV2.tsx
@@ -608,6 +608,7 @@ export const DataFrameQueryEditorV2: React.FC<Props> = (
             </InlineField>
 
             <div
+                className="query-configuration-section"
                 style={{ width: getValuesInPixels(SECTION_WIDTH) }}
             >
                 <Collapse


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

**Collapse `overflow` styling**: The `Collapse` component from `@grafana/ui` applies `overflow: hidden` to its body, which clips the `SlQueryBuilder` dropdowns when they open beyond the collapse body boundary.

The three query builders are stacked in order - Results → Data Table → Column. For Results and Data Table, the query builders below them extend the collapse body height enough that their dropdowns open within the visible area. The Column query builder sits at the very bottom with nothing below it, so its dropdowns are immediately clipped when they open.

## 👩‍💻 Implementation

Override `overflow: hidden` to `overflow: visible` on the `Collapse` body, scoped only to the Query configurations section so other `Collapse` sections are unaffected.

## 🧪 Testing

Manually verified and added unit test
<img width="2500" height="800" alt="options_dropdown_grafana" src="https://github.com/user-attachments/assets/d51ddb52-3a0f-4b34-a355-f7184d76cb90" />


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).