### PR TITLE
fix(query-builder): use nullish coalescing in transformBasedOnContainsOperations

### DIFF
--- a/src/core/query-builder.utils.test.ts
+++ b/src/core/query-builder.utils.test.ts
@@ -79,6 +79,24 @@ describe('QueryBuilderUtils', () => {
       expect(result).toBe(query);
     });
 
+    it('should handle Contains operations with empty string value', () => {
+      const query = 'Object1.Contains("")';
+      const result = transformComputedFieldsQuery(query, computedDataFields);
+      expect(result).toBe('obj.prop1.Contains()');
+    });
+
+    it('should handle negated Contains operations with empty string value', () => {
+      const query = '!(Object1.Contains(""))';
+      const result = transformComputedFieldsQuery(query, computedDataFields);
+      expect(result).toBe('!(obj.prop1.Contains())');
+    });
+
+    it('should handle mixed Contains operations with empty and non-empty values', () => {
+      const query = 'Object1.Contains("") AND !(Object2.Contains("value"))';
+      const result = transformComputedFieldsQuery(query, computedDataFields);
+      expect(result).toBe('obj.prop1.Contains() AND !(obj.prop1.Contains(value))');
+    });
+
     it('should handle Any.Contains operations correctly with computed fields', () => {
       const query = 'Object1.Any(it.Contains("value1"))';
       const result = transformComputedFieldsQuery(query, computedDataFields);

--- a/src/core/query-builder.utils.test.ts
+++ b/src/core/query-builder.utils.test.ts
@@ -109,6 +109,24 @@ describe('QueryBuilderUtils', () => {
       expect(result).toBe(query);
     });
 
+    it('should handle Any.Contains operations with empty string value', () => {
+      const query = 'Object1.Any(it.Contains(""))';
+      const result = transformComputedFieldsQuery(query, computedDataFields);
+      expect(result).toBe('Object1.Any(obj.prop1.Contains())');
+    });
+
+    it('should handle negated Any.Contains operations with empty string value', () => {
+      const query = 'Object1.Any(!it.Contains(""))';
+      const result = transformComputedFieldsQuery(query, computedDataFields);
+      expect(result).toBe('!Object1.Any(obj.prop1.Contains())');
+    });
+
+    it('should handle mixed Any.Contains operations with empty and non-empty values', () => {
+      const query = 'Object1.Any(it.Contains("") AND it.Contains("value1"))';
+      const result = transformComputedFieldsQuery(query, computedDataFields);
+      expect(result).toBe('Object1.Any(obj.prop1.Contains() AND obj.prop1.Contains(value1))');
+    });
+
     it('should handle StartsWith operations correctly with computed fields', () => {
       const query = 'Object1.StartsWith("value1") AND Object2.EndsWith("value2")';
       const result = transformComputedFieldsQuery(query, computedDataFields);

--- a/src/core/query-builder.utils.ts
+++ b/src/core/query-builder.utils.ts
@@ -66,7 +66,7 @@ function transformBasedOnContainsOperations(query: string, field: string, transf
 
   return query.replace(containsRegex, (_match, _negatedMatch, negatedValue, _positiveMatch, positiveValue) => {
     const isNegated = negatedValue !== undefined;
-    const extractedValue = negatedValue || positiveValue;
+    const extractedValue = negatedValue ?? positiveValue;
 
     const operation = isNegated
       ? QueryBuilderOperations.DOES_NOT_CONTAIN.name

--- a/src/core/query-builder.utils.ts
+++ b/src/core/query-builder.utils.ts
@@ -104,7 +104,7 @@ function transformListContainsOperations(
     const containsRegex = /(?:!(it\.Contains\("([^"]*)"\))|(it\.Contains\("([^"]*)"\)))/g;
 
     const transformedPredicate = innerPredicate.replace(containsRegex, (_match, _negatedMatch, negatedValue, _positiveMatch, positiveValue) => {
-      const extractedValue = negatedValue || positiveValue;
+      const extractedValue = negatedValue ?? positiveValue;
       return transformation(extractedValue, QueryBuilderOperations.LIST_CONTAINS.name, options?.get(field));
     });
 


### PR DESCRIPTION
# Pull Request

##  🤨 Rationale

When user selects the `does not contain` operator in the query builder in any of the data source and leaves the value empty, the datasource ends up in a run time error : 

<img alt="20260507-1106-50 5265650" src="https://github.com/user-attachments/assets/f2a5cc84-0de7-458a-97e2-5251755d1e06" />

In `transformBasedOnContainsOperations`, the logical OR (`||`) operator was used to select between `negatedValue` and `positiveValue`:

```typescript
const extractedValue = negatedValue || positiveValue;
```

This caused the bug when the query contained an **empty string value** in a negated Contains operation, e.g. `!(source.Contains(""))`. Since `""` is falsy in JavaScript, `"" || undefined` evaluates to `undefined`, so the transformation function received `undefined` instead of the intended empty string.

## 👩‍💻 Implementation

Replaced `||` with `??` (nullish coalescing operator):

```typescript
const extractedValue = negatedValue ?? positiveValue;
```

The `??` operator only falls through to the right-hand side when the left-hand side is `null` or `undefined` - not when it is an empty string. This correctly preserves `""` as a valid extracted value.

## 🧪 Testing

- Verified that `!(field.Contains(""))` now passes `""` to the transformation (previously passed `undefined`).
- Verified that `field.Contains("")` still correctly passes `""`.
- Verified that non-empty values continue to work as before for both negated and positive Contains operations.

## Work Item
[Bug 3864088](https://dev.azure.com/ni/DevCentral/_workitems/edit/3864088): Dataframes Datasource | Property with `does not contain` operator errors out

##  ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).