### PR TITLE
fix(data-frame): strip CSV apostrophe escape prefix from string column values

### DIFF
--- a/src/datasources/data-frame/datasources/v2/DataFrameDataSourceV2.test.ts
+++ b/src/datasources/data-frame/datasources/v2/DataFrameDataSourceV2.test.ts
@@ -11835,4 +11835,61 @@ describe('DataFrameDataSourceV2', () => {
             });
         });
     });
+
+    describe('stripCsvEscapePrefix', () => {
+        it('should strip apostrophe prefix when followed by equals sign', () => {
+            const result = (ds as any).stripCsvEscapePrefix("'=SUM(A1)");
+            expect(result).toBe('=SUM(A1)');
+        });
+
+        it('should strip apostrophe prefix when followed by at sign', () => {
+            const result = (ds as any).stripCsvEscapePrefix("'@value");
+            expect(result).toBe('@value');
+        });
+
+        it('should strip apostrophe prefix when followed by plus sign', () => {
+            const result = (ds as any).stripCsvEscapePrefix("'+5");
+            expect(result).toBe('+5');
+        });
+
+        it('should strip apostrophe prefix when followed by minus sign', () => {
+            const result = (ds as any).stripCsvEscapePrefix("'-5");
+            expect(result).toBe('-5');
+        });
+
+        it('should strip apostrophe prefix when followed by tab character', () => {
+            const result = (ds as any).stripCsvEscapePrefix("'\tvalue");
+            expect(result).toBe('\tvalue');
+        });
+
+        it('should strip apostrophe prefix when followed by carriage return', () => {
+            const result = (ds as any).stripCsvEscapePrefix("'\rvalue");
+            expect(result).toBe('\rvalue');
+        });
+
+        it('should not strip apostrophe when followed by a regular character', () => {
+            const result = (ds as any).stripCsvEscapePrefix("'hello");
+            expect(result).toBe("'hello");
+        });
+
+        it('should not strip apostrophe when it is the only character', () => {
+            const result = (ds as any).stripCsvEscapePrefix("'");
+            expect(result).toBe("'");
+        });
+
+        it('should return null when value is null', () => {
+            const result = (ds as any).stripCsvEscapePrefix(null);
+            expect(result).toBeNull();
+        });
+
+        it('should return empty string when value is empty', () => {
+            const result = (ds as any).stripCsvEscapePrefix('');
+            expect(result).toBe('');
+        });
+
+        it('should return value unchanged when it does not start with apostrophe', () => {
+            const result = (ds as any).stripCsvEscapePrefix('normal value');
+            expect(result).toBe('normal value');
+        });
+    });
 });

--- a/src/datasources/data-frame/datasources/v2/DataFrameDataSourceV2.ts
+++ b/src/datasources/data-frame/datasources/v2/DataFrameDataSourceV2.ts
@@ -1486,11 +1486,17 @@ export class DataFrameDataSourceV2 extends DataFrameDataSourceBase {
     }
 
     private stripCsvEscapePrefix(value: string | null): string | null {
-        if (!value || value.length < 2 || value[0] !== "'") {
+        const csvInjectionTriggers = ['=', '@', '+', '-', '\t', '\r'];
+        if (
+            !value
+            || value.length < 2
+            || value[0] !== "'"
+            || !csvInjectionTriggers.includes(value[1])
+        ) {
             return value;
         }
-        const csvInjectionTriggers = ['=', '@', '+', '-', '\t', '\r'];
-        return csvInjectionTriggers.includes(value[1]) ? value.substring(1) : value;
+
+        return value.substring(1);
     }
 
     private getFieldTypeForDataType(dataType: ColumnDataType): FieldType {

--- a/src/datasources/data-frame/datasources/v2/DataFrameDataSourceV2.ts
+++ b/src/datasources/data-frame/datasources/v2/DataFrameDataSourceV2.ts
@@ -1481,8 +1481,16 @@ export class DataFrameDataSourceV2 extends DataFrameDataSourceBase {
             case 'TIMESTAMP':
                 return dateTime(value).valueOf();
             default:
-                return value;
+                return this.stripCsvEscapePrefix(value);
         }
+    }
+
+    private stripCsvEscapePrefix(value: string | null): string | null {
+        if (!value || value.length < 2 || value[0] !== "'") {
+            return value;
+        }
+        const csvInjectionTriggers = ['=', '@', '+', '-', '\t', '\r'];
+        return csvInjectionTriggers.includes(value[1]) ? value.substring(1) : value;
     }
 
     private getFieldTypeForDataType(dataType: ColumnDataType): FieldType {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The undecimated data table query feature fetches raw data via the Data Frame Service's CSV export route (`POST /tables/{tableId}/export-data` with `responseFormat: 'CSV'`). The DFS backend has a CSV injection mitigation that prefixes string column values with an apostrophe (`'`) when they start with certain characters (`=`, `@`, `+`, `-`, tab, or carriage return) to prevent attacks when the CSV is opened in Excel.

The Grafana plugin was displaying these escaped values as-is (e.g., `'-5` instead of `-5`), which breaks data transforms in dashboards that expect numeric-like values and shows incorrect data to users.

Related work item: [Bug 3832031](https://dev.azure.com/ni/DevCentral/_workitems/edit/3832031)

## 👩‍💻 Implementation

Added a `stripCsvEscapePrefix` method to `DataFrameDataSourceV2` that strips the leading apostrophe **only when it is followed by one of the known DFS CSV injection trigger characters** (`=`, `@`, `+`, `-`, `\t`, `\r`). This ensures:

- Escaped values are correctly unescaped (e.g., `'-5` → `-5`)
- Strings that legitimately start with an apostrophe followed by a non-trigger character are preserved unchanged (e.g., `'hello` stays `'hello`)

The `transformValue` method now calls `stripCsvEscapePrefix` for STRING columns instead of returning the raw value directly.

**Files changed:**
- `src/datasources/data-frame/datasources/v2/DataFrameDataSourceV2.ts` — added `stripCsvEscapePrefix` and updated `transformValue`
- `src/datasources/data-frame/datasources/v2/DataFrameDataSourceV2.test.ts` — added 11 unit tests

## 🧪 Testing

- Added 11 unit tests covering:
  - All 6 CSV injection trigger characters are correctly stripped
  - Apostrophe followed by a regular character is preserved
  - Single apostrophe string is preserved
  - Null and empty string inputs are handled safely
  - Strings not starting with an apostrophe pass through unchanged
- All existing tests continue to pass

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).