### PR TITLE
test(tags): Update tags data source acceptance tests to use getTotalColumnCount

### DIFF
--- a/acceptance-tests/page-objects/dashboard/components/table.component.ts
+++ b/acceptance-tests/page-objects/dashboard/components/table.component.ts
@@ -136,6 +136,6 @@ export class Table {
         }
 
         const ariaColCount = await this.page.locator('[role="grid"]').first().getAttribute('aria-colcount');
-        return ariaColCount ? parseInt(ariaColCount) : 0;
+        return ariaColCount ? parseInt(ariaColCount, 10) : 0;
     }
 }

--- a/acceptance-tests/page-objects/dashboard/components/table.component.ts
+++ b/acceptance-tests/page-objects/dashboard/components/table.component.ts
@@ -129,4 +129,13 @@ export class Table {
         const cellValue = await this.getCellInRowByIndex(rowIndex, columnIndex);
         return cellValue === expectedValue;
     }
+
+    public async getTotalColumnCount(): Promise<number> {
+        if (!this.isV12) {
+            return await this.tableColumns.count();
+        }
+
+        const ariaColCount = await this.page.locator('[role="grid"]').first().getAttribute('aria-colcount');
+        return ariaColCount ? parseInt(ariaColCount) : 0;
+    }
 }

--- a/acceptance-tests/tests/datasources/tag/global-variable-integration/tag-ds.asset-variable.spec.ts
+++ b/acceptance-tests/tests/datasources/tag/global-variable-integration/tag-ds.asset-variable.spec.ts
@@ -56,7 +56,7 @@ test.describe('Tag DataSource with Asset Variable', () => {
         await dashboard.panel.tagQueryEditor.selectTagPath('$path.*');
         await dashboard.panel.toolbar.switchToTableView();
 
-        await expect(dashboard.panel.table.tableColumns).toHaveCount(3, { timeout: timeOutPeriod });
+        await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(3);
         expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.name, 'Voltage', 0)).toBeTruthy();
         expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.value, '12.1', 0)).toBeTruthy();
         expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.updated, 'a day ago', 0)).toBeTruthy();
@@ -66,7 +66,7 @@ test.describe('Tag DataSource with Asset Variable', () => {
 
         await dashboard.panel.tagQueryEditor.toggleShowProperties();
 
-        await expect(dashboard.panel.table.tableColumns).toHaveCount(5, { timeout: timeOutPeriod });
+        await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(5);
         expect(await dashboard.panel.table.checkColumnValue('displayName', 'Voltage', 0)).toBeTruthy();
         expect(await dashboard.panel.table.checkColumnValue('units', 'volt', 0)).toBeTruthy();
         expect(await dashboard.panel.table.checkColumnValue('displayName', 'Current', 1)).toBeTruthy();
@@ -74,20 +74,16 @@ test.describe('Tag DataSource with Asset Variable', () => {
 
         await dashboard.panel.tagQueryEditor.toggleShowTagPath();
 
+        await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(6);
         expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.tag_path, 'Assets.vendor1.model1.serial1.Voltage', 0)).toBeTruthy();
         expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.tag_path, 'Assets.vendor1.model1.serial1.Current', 1)).toBeTruthy();
-        // In Grafana v12, only viewport-fitting columns are rendered. The tag path column is initially
-        // outside the viewport, so toHaveCount(6) must come after checkColumnValue, which scrolls
-        // the grid to reach the cell and brings the column into view.
-        //to do: research other approach if needed
-        await expect(dashboard.panel.table.tableColumns).toHaveCount(6, { timeout: timeOutPeriod });
     });
 
     test('should update "current" query type tags when asset variable changes', async () => {
         await dashboard.panel.toolbar.openVariableDropdown('name1 (serial1)', 'name2 (serial2)');
         await dashboard.panel.toolbar.refreshData();
 
-        await expect(dashboard.panel.table.tableColumns).toHaveCount(5, { timeout: timeOutPeriod });
+        await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(5);
         expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.name, 'Assets.vendor2.model2.serial2.Volume', 0)).toBeTruthy();
         expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.value, '4.10', 0)).toBeTruthy();
         expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.updated, '2 days ago', 0)).toBeTruthy();
@@ -98,7 +94,7 @@ test.describe('Tag DataSource with Asset Variable', () => {
     test('should load "historical" query type tags based on asset variable', async () => {
         await dashboard.panel.tagQueryEditor.selectHistoryQueryType();
         await dashboard.panel.toolbar.openDateTimePicker();
-        await expect(dashboard.panel.table.tableColumns).toHaveCount(2, { timeout: timeOutPeriod });
+        await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(2);
 
         await dashboard.panel.toolbar.setTimeRange('2026-01-01 00:00:00', '2026-12-31 23:59:59', 'Coordinated Universal Time');
 
@@ -114,7 +110,7 @@ test.describe('Tag DataSource with Asset Variable', () => {
         await dashboard.panel.toolbar.openVariableDropdown('name2 (serial2)', 'name1 (serial1)');
         await dashboard.panel.toolbar.refreshData();
 
-        await expect(dashboard.panel.table.tableColumns).toHaveCount(3, { timeout: timeOutPeriod });
+        await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(3);
         expect(await dashboard.panel.table.checkColumnValue('time', '2026-04-24 08:15:00', 0)).toBeTruthy();
         expect(await dashboard.panel.table.checkColumnValue('time', '2026-04-24 08:30:00', 1)).toBeTruthy();
         expect(await dashboard.panel.table.checkColumnValue('time', '2026-04-24 08:45:00', 2)).toBeTruthy();

--- a/acceptance-tests/tests/datasources/tag/tag.spec.ts
+++ b/acceptance-tests/tests/datasources/tag/tag.spec.ts
@@ -37,31 +37,27 @@ test.describe('Tag DataSource with Asset Variable', () => {
             await dashboard.panel.tagQueryEditor.selectTagPath('Assets.vendor1.model1.serial1.Current');
             await dashboard.panel.toolbar.switchToTableView();
 
-            await expect(dashboard.panel.table.tableColumns).toHaveCount(3, { timeout: timeOutPeriod });
+            await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(3);
             expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.name, 'Current', 0)).toBeTruthy();
             expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.value, '3.50', 0)).toBeTruthy();
             expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.updated, '3 days ago', 0)).toBeTruthy();
 
             await dashboard.panel.tagQueryEditor.toggleShowProperties();
 
-            await expect(dashboard.panel.table.tableColumns).toHaveCount(5, { timeout: timeOutPeriod });
+            await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(5);
             expect(await dashboard.panel.table.checkColumnValue('displayName', 'Current', 0)).toBeTruthy();
             expect(await dashboard.panel.table.checkColumnValue('units', 'ampere', 0)).toBeTruthy();
 
             await dashboard.panel.tagQueryEditor.toggleShowTagPath();
 
+            await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(6);
             expect(await dashboard.panel.table.checkColumnValue(currentTagColumns.tag_path, 'Assets.vendor1.model1.serial1.Current', 0)).toBeTruthy();
-            // In Grafana v12, only viewport-fitting columns are rendered. The tag path column is initially
-            // outside the viewport, so toHaveCount(6) must come after checkColumnValue, which scrolls
-            // the grid to reach the cell and brings the column into view.
-            //to do: research other approach if needed
-            await expect(dashboard.panel.table.tableColumns).toHaveCount(6, { timeout: timeOutPeriod });
         });
 
         test('should load "historical" query type tag', async () => {
             await dashboard.panel.tagQueryEditor.selectHistoryQueryType();
             await dashboard.panel.toolbar.openDateTimePicker();
-            await expect(dashboard.panel.table.tableColumns).toHaveCount(2, { timeout: timeOutPeriod });
+            await expect.poll(() => dashboard.panel.table.getTotalColumnCount(), { timeout: timeOutPeriod }).toBe(2);
 
             await dashboard.panel.toolbar.setTimeRange('2026-01-01 00:00:00', '2026-12-31 23:59:59', 'Coordinated Universal Time');
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

[Task 3886838](https://dev.azure.com/ni/DevCentral/_workitems/edit/3886838): Tags table columns not picked up by test

This PR, updates existing acceptance tests for the tags data source, to pass with Grafana's upgrade to v12 using the new "getTotalColumnCount" function.

## 👩‍💻 Implementation

Updated acceptance tests in tag.spec.ts and tag-ds.asset-variable.spec.
Added "getTotalColumnCount" function to table.component.ts.

## 🧪 Testing

Ran tests locally

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).