### PR TITLE
chore: enable SCA security scanning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 * @ni/grafana-codeowners-team
 
 /.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
+/.wiz @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
 
 /src/datasources/notebook @CiprianAnton @kkerezsi @saradei-ni
 /src/datasources/tag @CiprianAnton @kkerezsi @saradei-ni

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @ni/grafana-codeowners-team
 
-/.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
-/.wiz @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
+/.snyk @ni/security-scanning-owners
+/.wiz @ni/security-scanning-owners
 
 /src/datasources/notebook @CiprianAnton @kkerezsi @saradei-ni
 /src/datasources/tag @CiprianAnton @kkerezsi @saradei-ni

--- a/.wiz
+++ b/.wiz
@@ -1,2 +1,9 @@
+# Wiz Code global path exclusions for this repository.
+#
+# NOTE: Both /* and /**/* patterns are required per directory due to a known
+# Wiz glob bug (WZ-81029) where /**/* does not match direct children of a
+# directory. The /* pattern catches direct children while /**/* catches nested
+# files. This duplication can be removed once the bug is fixed.
+
 ignore:
   global_paths: {}

--- a/.wiz
+++ b/.wiz
@@ -1,0 +1,2 @@
+ignore:
+  global_paths: {}

--- a/README.md
+++ b/README.md
@@ -183,17 +183,11 @@ follow the instructions.
 - Update the `@grafana` scoped npm package dependency versions to align with the [`ni/grafana`](https://github.com/ni/grafana) upgrade version.
 - Follow the validation instructions in the [`Skyline/Grafana README.md`](https://dev.azure.com/ni/DevCentral/_git/Skyline?path=/Grafana/README.MD&_a=preview).
 
-### Security scanning with Snyk
+### Security scanning
 
-This repository uses [Snyk](https://snyk.io/) for security scanning to identify and fix vulnerabilities in code before they reach production. Snyk provides Static Application Security Testing (SAST) that scans your code for security issues as you develop.
+See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
 
-- **IDE integration**: Install the Snyk extension for [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=snyk-security.snyk-vulnerability-scanner) or [Visual Studio](https://marketplace.visualstudio.com/items?itemName=snyk-security.snyk-vulnerability-scanner-vs-2022) to get real-time security feedback while writing code. To suggest the Snyk extension to contributors, add `.vscode/extensions.json` or `.vsconfig` files to your project root. The VSCode Snyk extension has a richer feature set and is the preferred IDE for working with Snyk.
-- **Pull request scanning**: Snyk automatically scans PRs and posts comments for high/critical vulnerabilities.
-- **Post-merge monitoring**: Automated bugs are created for unresolved issues after code is merged.
-
-**Contributors within NI/Emerson**: For detailed guidance on working with Snyk, including how to address security issues and create ignore records, see the [Snyk reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/146862/Snyk-reference).
-
-**Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability Snyk identifies on your PR, consult with a code owner to understand your options for resolution.
+**Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability identified on your PR, consult with a code owner to understand your options for resolution.
 
 ### Helpful links
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ follow the instructions.
 
 ### Security scanning
 
-See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
+**Contributors within NI/Emerson**: See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
 
 **Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability identified on your PR, consult with a code owner to understand your options for resolution.
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Enable SCA security scanning.

## 👩‍💻 Implementation

- Add .wiz config file
- Created a team for the security scanning files
- Replaced security scanning section in the readme with a link to the handbook document, which already has the wiz content. The readme content was duplicated across multiple repos, we will have more updates, and the handbook provides a central location for those updates.

## 🧪 Testing

PR
## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).