### PR TITLE
chore(work-items): add code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,3 +30,5 @@
 
 /src/panels/qr-code @CiprianAnton @kkerezsi @saradei-ni @BlankaOnodi @OliverCosma
 /acceptance-tests/tests/panels/qr-code @CiprianAnton @kkerezsi @saradei-ni @BlankaOnodi @OliverCosma
+/src/datasources/work-items @kartheeswaran-ni @richie-ni
+/acceptance-tests/tests/datasources/work-items @kartheeswaran-ni @richie-ni

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,5 +30,5 @@
 
 /src/panels/qr-code @CiprianAnton @kkerezsi @saradei-ni @BlankaOnodi @OliverCosma
 /acceptance-tests/tests/panels/qr-code @CiprianAnton @kkerezsi @saradei-ni @BlankaOnodi @OliverCosma
-/src/datasources/work-items @kartheeswaran-ni @richie-ni
-/acceptance-tests/tests/datasources/work-items @kartheeswaran-ni @richie-ni
+/src/datasources/work-items @kartheeswaran-ni @richie-ni @Ahalya-ni
+/acceptance-tests/tests/datasources/work-items @kartheeswaran-ni @richie-ni @Ahalya-ni


### PR DESCRIPTION
## 🤨 Rationale

Adds code owners for the `work-items` datasource plugin so the right team members are automatically requested for review on future changes.

Boilerplate for this work-items datasource is introduced in this PR [#WorkItems](https://github.com/ni/systemlink-grafana-plugins/pull/734).

Related task: [Task 4013191](https://dev.azure.com/ni/DevCentral/_backlogs/backlog/ASW%20SystemLink%20Sharingan/Epics%20and%20Deliverables?showParents=true&workitem=4013191)

## 👩‍💻 Implementation

Added two entries to `.github/CODEOWNERS`:

- `/src/datasources/work-items` → `@kartheeswaran-ni @richie-ni`
- `/acceptance-tests/tests/datasources/work-items` → `@kartheeswaran-ni @richie-ni`

## 🧪 Testing

No functional code changes. Verified the CODEOWNERS entries follow the existing format used by other datasource plugins in the file.

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).