### PR TITLE
feat(work-items): add work-items datasource boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Tools](https://grafana.github.io/plugin-tools/).
 - [Results](src/datasources/results/)
 - [Work orders](src/datasources/work-orders/)
 - [Test plans](src/datasources/test-plans/)
+- [Work items](src/datasources/work-items/)
 - [Alarms](src/datasources/alarms/)
 - [Workspaces](src/datasources/workspace/)
 

--- a/provisioning/example.yaml
+++ b/provisioning/example.yaml
@@ -72,3 +72,4 @@ datasources:
   - name: SystemLink Work Items
     type: ni-slworkitems-datasource
     uid: ni-slworkitems-datasource
+    <<: *config

--- a/provisioning/example.yaml
+++ b/provisioning/example.yaml
@@ -69,3 +69,6 @@ datasources:
     type: ni-slalarms-datasource
     uid: ni-slalarms-datasource
     <<: *config
+  - name: SystemLink Work Items
+    type: ni-slworkitems-datasource
+    uid: ni-slworkitems-datasource

--- a/src/datasources/work-items/WorkItemsConfigEditor.tsx
+++ b/src/datasources/work-items/WorkItemsConfigEditor.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { DataSourceHttpSettings } from '@grafana/ui';
+import { WorkItemsDataSourceOptions } from './types';
+
+interface Props extends DataSourcePluginOptionsEditorProps<WorkItemsDataSourceOptions> {}
+
+export const WorkItemsConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
+  return (
+    <>
+      <DataSourceHttpSettings
+        defaultUrl=""
+        dataSourceConfig={options}
+        showAccessOptions={false}
+        onChange={onOptionsChange}
+      />
+    </>
+  );
+};

--- a/src/datasources/work-items/WorkItemsDataSource.test.ts
+++ b/src/datasources/work-items/WorkItemsDataSource.test.ts
@@ -1,0 +1,23 @@
+import { WorkItemsDataSource } from './WorkItemsDataSource';
+import { setupDataSource } from 'test/fixtures';
+
+describe('WorkItemsDataSource', () => {
+  it('returns a placeholder frame', async () => {
+    const [ds] = setupDataSource(WorkItemsDataSource);
+
+    const result = await ds.runQuery({ refId: 'A' }, { scopedVars: {} } as any);
+    expect(result.fields[0].name).toBe('message');
+  });
+
+  it('tests datasource connection against authenticated endpoint', async () => {
+    const [ds] = setupDataSource(WorkItemsDataSource, () => ({
+      url: 'https://example.com',
+    }));
+    const getSpy = jest.spyOn(ds, 'get').mockResolvedValue({} as any);
+
+    const result = await ds.testDatasource();
+
+    expect(getSpy).toHaveBeenCalledWith('/niauth/v1/user');
+    expect(result.status).toBe('success');
+  });
+});

--- a/src/datasources/work-items/WorkItemsDataSource.ts
+++ b/src/datasources/work-items/WorkItemsDataSource.ts
@@ -40,7 +40,7 @@ export class WorkItemsDataSource extends DataSourceBase<WorkItemsQuery, WorkItem
   }
 
   async testDatasource(): Promise<TestDataSourceResponse> {
-    await this.get(this.instanceSettings.url + '/niauth/v1/user');
+    await this.get('/niauth/v1/user');
     return { status: 'success', message: 'Data source connected and authentication successful!' };
   }
 

--- a/src/datasources/work-items/WorkItemsDataSource.ts
+++ b/src/datasources/work-items/WorkItemsDataSource.ts
@@ -1,0 +1,50 @@
+import {
+  DataFrameDTO,
+  DataQueryRequest,
+  DataSourceInstanceSettings,
+  FieldType,
+  MetricFindValue,
+  TestDataSourceResponse,
+} from '@grafana/data';
+import { BackendSrv, TemplateSrv, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
+import { DataSourceBase } from 'core/DataSourceBase';
+import { WorkItemsDataSourceOptions, WorkItemsQuery } from './types';
+
+export class WorkItemsDataSource extends DataSourceBase<WorkItemsQuery, WorkItemsDataSourceOptions> {
+  constructor(
+    readonly instanceSettings: DataSourceInstanceSettings<WorkItemsDataSourceOptions>,
+    readonly backendSrv: BackendSrv = getBackendSrv(),
+    readonly templateSrv: TemplateSrv = getTemplateSrv()
+  ) {
+    super(instanceSettings, backendSrv, templateSrv);
+  }
+
+  defaultQuery = {};
+
+  async runQuery(query: WorkItemsQuery, _options: DataQueryRequest<WorkItemsQuery>): Promise<DataFrameDTO> {
+    return {
+      refId: query.refId,
+      name: query.refId,
+      fields: [
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: ['Work Items datasource query implementation will be added in follow-up stories.'],
+        },
+      ],
+    };
+  }
+
+  shouldRunQuery(query: WorkItemsQuery): boolean {
+    return !query.hide;
+  }
+
+  async testDatasource(): Promise<TestDataSourceResponse> {
+    await this.get(this.instanceSettings.url + '/niauth/v1/user');
+    return { status: 'success', message: 'Data source connected and authentication successful!' };
+  }
+
+  async metricFindQuery(): Promise<MetricFindValue[]> {
+    return [];
+  }
+}

--- a/src/datasources/work-items/components/WorkItemsQueryEditor.test.tsx
+++ b/src/datasources/work-items/components/WorkItemsQueryEditor.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from '@testing-library/react';
+import { setupRenderer } from 'test/fixtures';
+import { WorkItemsDataSource } from '../WorkItemsDataSource';
+import { WorkItemsQueryEditor } from './WorkItemsQueryEditor';
+
+describe('WorkItemsQueryEditor', () => {
+  it('shows placeholder message and initializes query', () => {
+    const render = setupRenderer(WorkItemsQueryEditor, WorkItemsDataSource);
+
+    const [onChange, onRunQuery] = render({});
+
+    expect(screen.getByText('Work Items datasource query controls will be added in follow-up stories.')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ init: true }));
+    expect(onRunQuery).toHaveBeenCalled();
+  });
+});

--- a/src/datasources/work-items/components/WorkItemsQueryEditor.tsx
+++ b/src/datasources/work-items/components/WorkItemsQueryEditor.tsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+import { QueryEditorProps } from '@grafana/data';
+import { WorkItemsDataSource } from '../WorkItemsDataSource';
+import { WorkItemsQuery } from '../types';
+
+type Props = QueryEditorProps<WorkItemsDataSource, WorkItemsQuery>;
+
+export function WorkItemsQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+  useEffect(() => {
+    onChange(Object.assign({ init: true }, query));
+    onRunQuery();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <span>Work Items datasource query controls will be added in follow-up stories.</span>;
+}

--- a/src/datasources/work-items/img/logo-ni.svg
+++ b/src/datasources/work-items/img/logo-ni.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="43px" height="29px" viewBox="0 0 43 29" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>9B441361-9BF9-4E57-A772-8A5F7846467E</title>
+    <g id="Login" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Logging-In-Loader" transform="translate(-864.000000, -139.000000)" fill="#00B383">
+            <g id="NI-logo" transform="translate(864.000000, 139.000000)">
+                <path d="M9.98214286,9.92105263 L9.98214286,29 L0,29 L0,9.92105263 L9.98214286,9.92105263 Z M43,0 L43,29 C37.4870147,29 33.0178571,24.5308424 33.0178571,19.0178571 L33.0178571,0 L43,0 Z M18.4107143,0 C23.9335618,-1.01453063e-15 28.4107143,4.4771525 28.4107143,10 L28.4107143,29 L18.4293773,29 L18.4293773,10.9210526 C18.4293439,10.3687809 17.981649,9.92107107 17.4293773,9.92101925 L9.98214286,9.92077061 L9.98214286,0 L18.4107143,0 Z"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/datasources/work-items/module.ts
+++ b/src/datasources/work-items/module.ts
@@ -1,0 +1,9 @@
+import { DataSourcePlugin } from '@grafana/data';
+import { WorkItemsDataSource } from './WorkItemsDataSource';
+import { WorkItemsQueryEditor } from './components/WorkItemsQueryEditor';
+import { WorkItemsConfigEditor } from './WorkItemsConfigEditor';
+
+export const plugin = new DataSourcePlugin(WorkItemsDataSource)
+  .setConfigEditor(WorkItemsConfigEditor)
+  .setQueryEditor(WorkItemsQueryEditor)
+  .setVariableQueryEditor(() => null);

--- a/src/datasources/work-items/plugin.json
+++ b/src/datasources/work-items/plugin.json
@@ -1,0 +1,15 @@
+{
+  "type": "datasource",
+  "name": "SystemLink Work Items",
+  "id": "ni-slworkitems-datasource",
+  "metrics": true,
+  "info": {
+    "author": {
+      "name": "NI"
+    },
+    "logos": {
+      "small": "img/logo-ni.svg",
+      "large": "img/logo-ni.svg"
+    }
+  }
+}

--- a/src/datasources/work-items/types.ts
+++ b/src/datasources/work-items/types.ts
@@ -1,0 +1,9 @@
+import { DataSourceJsonData } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
+
+export interface WorkItemsDataSourceOptions extends DataSourceJsonData {
+}
+
+export interface WorkItemsQuery extends DataQuery {
+  init?: boolean;
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Introduces the initial scaffolding for the `SystemLink Work Items` data source plugin as a foundation for follow-up implementation stories.

## 👩‍💻 Implementation

- Generated the `SystemLink Work Items` datasource skeleton via `npm run generate`.
- Removed unnecessary generated code and added a placeholder for future query logic.
<img width="771" height="269" alt="image" src="https://github.com/user-attachments/assets/ead1b4c8-56fd-482a-b78b-c0ada0443ebf" />

## 🧪 Testing

Added unit tests covering the initial boilerplate.

## ✅ Checklist

- [x] This PR has a title that follows the [commit message format](https://github.com/ni/systemlink-grafana-plugins#commit-message-format).